### PR TITLE
Hardcoding ARCHFLAGS breaks the build against fink's python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ if sys.platform == 'darwin' and os.path.exists('/usr/bin/xcodebuild'):
     # Also parse only first digit, because 3.2.1 can't be parsed nicely
     if (version.startswith('Xcode') and
         int(version.split()[1].split('.')[0]) >= 4):
-        os.environ['ARCHFLAGS'] = '-arch i386 -arch x86_64'
+        os.environ['ARCHFLAGS'] = ''
 
 setup(name='dulwich',
       description='Python Git Library',


### PR DESCRIPTION
Fink's python is either i386 or amd64, but not universal. Setting ARCHFLAGS to the
empty string produces a successful build against both OS X python and fink python.
The modules will no longer be universal -- if that is an issue, we can change the
test to extract ARCHFLAGS from distutils.sysconfig and remove ppc if necessary.
