### PR TITLE
fixed parsing commits with float times

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -823,7 +823,7 @@ class Tree(ShaFile):
     def add(self, name, mode, hexsha):
         """Add an entry to the tree.
 
-        :param mode: The mode of the entry as an integral type. Not all 
+        :param mode: The mode of the entry as an integral type. Not all
             possible modes are supported by git; see check() for details.
         :param name: The name of the entry, as a string.
         :param hexsha: The hex SHA of the entry as a string.
@@ -996,12 +996,12 @@ class Commit(ShaFile):
                 self._parents.append(value)
             elif field == _AUTHOR_HEADER:
                 self._author, timetext, timezonetext = value.rsplit(" ", 2)
-                self._author_time = int(timetext)
+                self._author_time = int(float(timetext))
                 self._author_timezone, self._author_timezone_neg_utc =\
                     parse_timezone(timezonetext)
             elif field == _COMMITTER_HEADER:
                 self._committer, timetext, timezonetext = value.rsplit(" ", 2)
-                self._commit_time = int(timetext)
+                self._commit_time = int(float(timetext))
                 self._commit_timezone, self._commit_timezone_neg_utc =\
                     parse_timezone(timezonetext)
             elif field == _ENCODING_HEADER:

--- a/dulwich/tests/test_objects.py
+++ b/dulwich/tests/test_objects.py
@@ -389,6 +389,17 @@ class CommitParseTests(ShaFileCheckTests):
             else:
                 self.assertCheckFails(Commit, text)
 
+    def test_float_time(self):
+        lines = self.make_commit_lines(
+            author='James Westby <jw+debian@jameswestby.net> 1174773719.0 +0000')
+        c = Commit.from_string(self.make_commit_text())
+        self.assertEquals('James Westby <jw+debian@jameswestby.net>', c.author)
+        expected_time = datetime.datetime(2007, 3, 24, 22, 1, 59)
+        self.assertEquals(expected_time,
+                          datetime.datetime.utcfromtimestamp(c.author_time))
+        self.assertEquals(0, c.author_timezone)
+
+
 
 _TREE_ITEMS = {
   'a.c': (0100755, 'd80c186a03f423a81b39df39dc87fd269736ca86'),


### PR DESCRIPTION
For some reason on my Mac talking to a remote git repository returned time information that was not parsable with int, which caused dulwich to die in a fiery blaze of errors.

Fixed the issue and added tests for it.
