### PR TITLE
Allow unicode strings for ShaFiles.from_string()

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -256,7 +256,7 @@ class ShaFile(object):
             self._needs_parsing = False
 
     def set_raw_string(self, text):
-        if type(text) != str:
+        if type(text) != str and type(text) != unicode:
             raise TypeError(text)
         self.set_raw_chunks([text])
 


### PR DESCRIPTION
There's no reason files can't be unicode.
