### PR TITLE
Fixed parsing of HTTP Git URLs

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -715,8 +715,7 @@ def get_transport_and_path(uri):
         return SSHGitClient(parsed.hostname, port=parsed.port,
                             username=parsed.username), parsed.path
     elif parsed.scheme in ('http', 'https'):
-        return HttpGitClient(urlparse.urlunparse(
-            parsed.scheme, parsed.netloc, path='/'))
+        return HttpGitClient(urlparse.urlunparse(parsed)), parsed.path
 
     if parsed.scheme and not parsed.netloc:
         # SSH with no user@, zero or one leading slash.

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -23,6 +23,7 @@ from dulwich.client import (
     TCPGitClient,
     SubprocessGitClient,
     SSHGitClient,
+    HttpGitClient,
     ReportStatusParser,
     SendPackError,
     UpdateRefsError,
@@ -136,6 +137,12 @@ class GitClientTests(TestCase):
         # expected parsing of the URL on Python versions less than 2.6.5
         self.assertRaises(ValueError, get_transport_and_path,
         'prospero://bar/baz')
+
+    def test_get_transport_and_path_http(self):
+        url = 'https://github.com/jelmer/dulwich'
+        client, path = get_transport_and_path(url)
+        self.assertTrue(isinstance(client, HttpGitClient))
+        self.assertEquals('/jelmer/dulwich', path)
 
 
 class SSHGitClientTests(TestCase):


### PR DESCRIPTION
Hi,

I just fixed get_transport_and_path for HTTP / HTTPS URLs, which wasn't working because of the way it invoked `urlparse.urlunparse`.

Full test suite runs successfully, let me know if there is anything wrong with this change.

Cheers,
Bruno
