### PR TITLE
Changed py_parse_tree to return a custom iterator

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -876,11 +876,12 @@ class Tree(ShaFile):
         """Grab the entries in the tree"""
         try:
             parsed_entries = parse_tree("".join(chunks))
+
+            # TODO: list comprehension is for efficiency in the common (small) case;
+            # if memory efficiency in the large case is a concern, use a genexp.
+            self._entries = dict([(n, (m, s)) for n, m, s in parsed_entries])
         except ValueError, e:
             raise ObjectFormatException(e)
-        # TODO: list comprehension is for efficiency in the common (small) case;
-        # if memory efficiency in the large case is a concern, use a genexp.
-        self._entries = dict([(n, (m, s)) for n, m, s in parsed_entries])
 
     def check(self):
         """Check this object for internal consistency.


### PR DESCRIPTION
From _objects.c:69 (in `py_parse_tree`)

``` C
/* TODO: currently this returns a list; if memory usage is a concern,
 * consider rewriting as a custom iterator object */
```

I've gone ahead and implemented this. I've never created a generator function on the C side of things, so I used this as my guide:

http://stackoverflow.com/questions/1815812/how-to-create-a-generator-iterator-with-the-python-c-api/1816961#1816961

The tests all seem to work, and I don't think there are any leaks. I also wrote a py3k version, but the structures have changed enough that I decided to make it its own commit (rather than just merging this one).
