### PR TITLE
getopt longopts weren't specified correctly

### DIFF
--- a/bin/dulwich
+++ b/bin/dulwich
@@ -114,7 +114,7 @@ def cmd_dump_index(args):
 
 
 def cmd_init(args):
-    opts, args = getopt(args, "", ["--bare"])
+    opts, args = getopt(args, "", ["bare"])
     opts = dict(opts)
 
     if args == []:


### PR DESCRIPTION
I found a very small bug in the `dulwich` script. The longopts passed in to `getopt` included `--` which isn't necessary. As a result, calling `dulwich init --bare somerepo.git` didn't work. Removed the `--` and all is well.
