### PR TITLE
Fixed formatting for "extension not found" messages

### DIFF
--- a/dulwich/tests/utils.py
+++ b/dulwich/tests/utils.py
@@ -160,7 +160,7 @@ def ext_functest_builder(method, func):
 
     def do_test(self):
         if not isinstance(func, types.BuiltinFunctionType):
-            raise SkipTest("%s extension not found", func.func_name)
+            raise SkipTest("%s extension not found" % func.func_name)
         method(self, func)
 
     return do_test


### PR DESCRIPTION
One character change to turn:

```
... skipped "('%s extension not found', '_count_blocks')
```

into

```
... skipped '_count_blocks extension not found'
```
