### PR TITLE
Handle None elements in lists of TreeChange objects

### DIFF
--- a/dulwich/walk.py
+++ b/dulwich/walk.py
@@ -255,6 +255,9 @@ class Walker(object):
         return False
 
     def _change_matches(self, change):
+        if not change:
+            return False
+
         old_path = change.old.path
         new_path = change.new.path
         if self._path_matches(new_path):


### PR DESCRIPTION
The docstring of diff_tree.tree_changes_for_merge reports that it yields
lists of TreeChange objects, and that "An element may be None...".
