### PR TITLE
ConfigDict should act like a dictionary

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -92,14 +92,14 @@ class ConfigDict(Config, DictMixin):
             isinstance(other, self.__class__) and
             other._values == self._values)
 
-   def __getitem__(self, key):
-      return self._values[key]
+    def __getitem__(self, key):
+        return self._values[key]
       
-   def __setitem__(self, key, value):
-      self._values[key] = value
-
-   def keys(self):
-      return self._values.keys()
+    def __setitem__(self, key, value):
+        self._values[key] = value
+        
+    def keys(self):
+        return self._values.keys()
 
     @classmethod
     def _parse_setting(cls, name):

--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -170,6 +170,17 @@ class ConfigDictTests(TestCase):
         cd.set(("core", ), "foo", "invalid")
         self.assertRaises(ValueError, cd.get_boolean, ("core", ), "foo")
 
+    def test_dict(self):
+        cd = ConfigDict()
+        cd.set(("core", ), "foo", "bla")
+        cd.set(("core2", ), "foo", "bloe")
+
+        self.assertEqual([("core2", ), ("core", )], cd.keys())
+        self.assertEqual(cd[("core", )], {'foo': 'bla'})
+
+        cd['a'] = 'b'
+        self.assertEqual(cd['a'], 'b')
+
 
 class StackedConfigTests(TestCase):
 


### PR DESCRIPTION
ConfigDict should have the ability to be accessed like any dictionary. It's confusing otherwise. I'm attempting to use it to find all remotes, which if it's not iterable, means it's difficult to do so.
