### PR TITLE
repo.clone() fix for a missing 'HEAD' ref.

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1383,8 +1383,9 @@ class Repo(BaseRepo):
 
         # Update target head
         head, head_sha = self.refs._follow('HEAD')
-        target.refs.set_symbolic_ref('HEAD', head)
-        target['HEAD'] = head_sha
+        if head is not None and head_sha is not None:
+            target.refs.set_symbolic_ref('HEAD', head)
+            target['HEAD'] = head_sha
 
         if not bare:
             # Checkout HEAD to target dir


### PR DESCRIPTION
One of my work repos didn't have a HEAD (and used a different name for master branch).

Dulwich clone() raised an exception when failed to set target repo head, though at that point, the target repo was fully cloned, and update to the HEAD ref was not necessary.

It might be useful to either add a conditional check for source head_sha availability and skip this step if there is no head to update or, if that's not desirable for some reason, add a specific exception that cloning headless repos is not supported.
