### PR TITLE
Fixes a bug in dul-receive-pack

### DIFF
--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -619,8 +619,8 @@ class ReceivePackHandler(Handler):
         status = []
         # TODO: more informative error messages than just the exception string
         try:
-            p = self.repo.object_store.add_thin_pack(self.proto.read,
-                                                     self.proto.recv)
+            recv = getattr(self.proto, "recv", None)
+            p = self.repo.object_store.add_thin_pack(self.proto.read, recv)
             status.append(('unpack', 'ok'))
         except all_exceptions, e:
             status.append(('unpack', str(e).replace('\n', '')))


### PR DESCRIPTION
Protocol does not have a recv attritbue.
This causes dul-receive-pack to throw an error.

Fixes a bug where an AttributeError is thrown when dul-receive-pack is
run. This is caused due to the fact that the default protocol used is
the Protocol class, which does not have recv defined.
