### PR TITLE
fix index.changes_from_tree against a repository with no initial commit.

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -354,22 +354,24 @@ def changes_from_tree(names, lookup_entry, object_store, tree,
     :param names: Iterable of names in the working copy
     :param lookup_entry: Function to lookup an entry in the working copy
     :param object_store: Object store to use for retrieving tree contents
-    :param tree: SHA1 of the root tree
+    :param tree: SHA1 of the root tree, or None for an empty tree
     :param want_unchanged: Whether unchanged files should be reported
     :return: Iterator over tuples with (oldpath, newpath), (oldmode, newmode),
         (oldsha, newsha)
     """
     other_names = set(names)
-    for (name, mode, sha) in object_store.iter_tree_contents(tree):
-        try:
-            (other_sha, other_mode) = lookup_entry(name)
-        except KeyError:
-            # Was removed
-            yield ((name, None), (mode, None), (sha, None))
-        else:
-            other_names.remove(name)
-            if (want_unchanged or other_sha != sha or other_mode != mode):
-                yield ((name, name), (mode, other_mode), (sha, other_sha))
+
+    if tree is not None:
+        for (name, mode, sha) in object_store.iter_tree_contents(tree):
+            try:
+                (other_sha, other_mode) = lookup_entry(name)
+            except KeyError:
+                # Was removed
+                yield ((name, None), (mode, None), (sha, None))
+            else:
+                other_names.remove(name)
+                if (want_unchanged or other_sha != sha or other_mode != mode):
+                    yield ((name, name), (mode, other_mode), (sha, other_sha))
 
     # Mention added files
     for name in other_names:

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -76,6 +76,13 @@ class SimpleIndexTestCase(IndexTestCase):
         self.assertEqual(0, len(i))
         self.assertFalse(os.path.exists(i._filename))
 
+    def test_against_empty_tree(self):
+        i = self.get_simple_index("index")
+        changes = list(i.changes_from_tree(MemoryObjectStore(), None))
+        self.assertEqual(1, len(changes))
+        (oldname, newname), (oldmode, newmode), (oldsha, newsha) = changes[0]
+        self.assertEqual('bla', newname)
+        self.assertEqual('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391', newsha)
 
 class SimpleIndexWriterTestCase(IndexTestCase):
 


### PR DESCRIPTION
index.changes_from_tree(object_store, None) should work. This change modifies BaseObjectStore.iter_tree_contents so that it works with tree_id=None.
