### PR TITLE
add large table support to reading PackIndex2 files

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -629,8 +629,8 @@ class PackIndex2(FilePackIndex):
     def _unpack_offset(self, i):
         offset = self._pack_offset_table_offset + i * 4
         offset = unpack_from('>L', self._contents, offset)[0]
-        if (offset&0x80000000):
-            offset = self._pack_offset_largetable_offset + (offset&0x7fffffff) * 8
+        if (offset&(2**31)):
+            offset = self._pack_offset_largetable_offset + (offset&(2**31-1)) * 8L
             offset = unpack_from('>Q', self._contents, offset)[0]
         return offset
 
@@ -1723,10 +1723,10 @@ def write_pack_index_v2(f, entries, pack_checksum):
     for (name, offset, entry_checksum) in entries:
         f.write(struct.pack('>L', entry_checksum))
     for (name, offset, entry_checksum) in entries:
-        if offset < 0x80000000:
+        if offset < 2**31:
             f.write(struct.pack('>L', offset))
         else:
-            f.write(struct.pack('>L', 0x80000000 + len(largetable)))
+            f.write(struct.pack('>L', 2**31 + len(largetable)))
             largetable.append(offset)
     for offset in largetable:
         f.write(struct.pack('>Q', offset))

--- a/dulwich/tests/test_pack.py
+++ b/dulwich/tests/test_pack.py
@@ -479,9 +479,14 @@ class BaseTestPackIndexWriting(object):
     def test_single(self):
         entry_sha = hex_to_sha('6f670c0fb53f9463760b7295fbb814e965fb20c8')
         my_entries = [(entry_sha, 178, 42)]
+        if self._has_crc32_checksum:
+            entry_sha = hex_to_sha('4e6388232ec39792661e2e75db8fb117fc869ce6')
+            my_entries.append([entry_sha, 0xf2972d0830529b87, 24])
+            entry_sha = hex_to_sha('e98f071751bd77f59967bfa671cd2caebdccc9a2')
+            my_entries.append([entry_sha, (~0xf2972d0830529b87)&(2**64-1), 92])
         idx = self.index('single.idx', my_entries, pack_checksum)
         self.assertEqual(idx.get_pack_checksum(), pack_checksum)
-        self.assertEqual(1, len(idx))
+        self.assertEqual(len(my_entries), len(idx))
         actual_entries = list(idx.iterentries())
         self.assertEqual(len(my_entries), len(actual_entries))
         for mine, actual in zip(my_entries, actual_entries):


### PR DESCRIPTION
Git pack files larger than 2GB have an extended offset table. This patches up reading those files.

http://repo.or.cz/w/git.git?a=blob;f=Documentation/technical/pack-format.txt;h=1803e64e465fa4f8f0fe520fc0fd95d0c9def5bd;hb=HEAD
