### PR TITLE
Preserve the order of configuration files.

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -28,6 +28,7 @@ import errno
 import os
 import re
 
+from collections import OrderedDict
 from UserDict import DictMixin
 
 from dulwich.file import GitFile
@@ -38,7 +39,7 @@ class Config(object):
 
     def get(self, section, name):
         """Retrieve the contents of a configuration setting.
-        
+
         :param section: Tuple with section name and optional subsection namee
         :param subsection: Subsection name
         :return: Contents of the setting
@@ -67,7 +68,7 @@ class Config(object):
 
     def set(self, section, name, value):
         """Set a configuration value.
-        
+
         :param name: Name of the configuration value, including section
             and optional subsection
         :param: Value of the setting
@@ -81,7 +82,7 @@ class ConfigDict(Config, DictMixin):
     def __init__(self, values=None):
         """Create a new ConfigDict."""
         if values is None:
-            values = {}
+            values = OrderedDict()
         self._values = values
 
     def __repr__(self):
@@ -94,10 +95,10 @@ class ConfigDict(Config, DictMixin):
 
     def __getitem__(self, key):
         return self._values[key]
-      
+
     def __setitem__(self, key, value):
         self._values[key] = value
-        
+
     def keys(self):
         return self._values.keys()
 
@@ -122,7 +123,7 @@ class ConfigDict(Config, DictMixin):
     def set(self, section, name, value):
         if isinstance(section, basestring):
             section = (section, )
-        self._values.setdefault(section, {})[name] = value
+        self._values.setdefault(section, OrderedDict())[name] = value
 
 
 def _format_string(value):
@@ -236,7 +237,7 @@ class ConfigFile(ConfigDict):
                             section = (pts[0], pts[1])
                         else:
                             section = (pts[0], )
-                    ret._values[section] = {}
+                    ret._values[section] = OrderedDict()
                 if _strip_comments(line).strip() == "":
                     continue
                 if section is None:


### PR DESCRIPTION
For some work I'm doing, allowing access to the _order_ that the configuration file was defined, as well as its contents, is very useful.  (Specifically, it permits cleaning up the contents with the minimal diff possible by not reordering where we don't have to.)  This breaks no tests, and while I didn't add any new ones to explicitly test order preservation, I'm happy to do so.
