### PR TITLE
HttpClient crash when cloning a repository that returns 404

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -657,7 +657,6 @@ class HttpGitClient(GitClient):
         :param req: urllib2.Request instance
         :return: matching response
         """
-        #raise NotGitRepository()
         return urllib2.urlopen(req)
 
     def _discover_references(self, service, url):


### PR DESCRIPTION
This patch fixes a bug in `HttpClient` and `GitClient` which occurs when cloning a repo that returns a 404 (or any other http error).

When cloning a repository served over http that returns an error code, `urllib2.HTTPError` would be raised. The exception is not caught until `GitClient.fetch()` where it will attempt to commit without any data. The commit will fail and throw a TypeError crashing dulwich.

I have removed the 'try ... finally' block inside GitClient.fetch() so when exceptions such as NotGitRepository() or GitProtocolError() are raised they are not caught.
