### PR TITLE
Log all error messages from wsgiref server to the logging module. 

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@
   * Support relative paths in alternate paths.
     (milki, Michel Lespinasse, #1175007)
 
+  * Log all error messages from wsgiref server to the logging module. This
+    makes the test suit quiet again. (Gary van der Merwe)
+
  IMPROVEMENTS:
 
   * Add optional honor_filemode flag to build_index_from_tree.

--- a/dulwich/tests/compat/test_web.py
+++ b/dulwich/tests/compat/test_web.py
@@ -36,7 +36,8 @@ from dulwich.tests import (
 from dulwich.web import (
     make_wsgi_chain,
     HTTPGitApplication,
-    HTTPGitRequestHandler,
+    WSGIRequestHandlerLogger,
+    WSGIServerLogger,
     )
 
 from dulwich.tests.compat.server_utils import (
@@ -50,9 +51,9 @@ from dulwich.tests.compat.utils import (
 
 
 if getattr(simple_server.WSGIServer, 'shutdown', None):
-    WSGIServer = simple_server.WSGIServer
+    WSGIServer = WSGIServerLogger
 else:
-    class WSGIServer(ShutdownServerMixIn, simple_server.WSGIServer):
+    class WSGIServer(ShutdownServerMixIn, WSGIServerLogger):
         """Subclass of WSGIServer that can be shut down."""
 
         def __init__(self, *args, **kwargs):
@@ -77,7 +78,7 @@ class WebTests(ServerTests):
         app = self._make_app(backend)
         dul_server = simple_server.make_server(
           'localhost', 0, app, server_class=WSGIServer,
-          handler_class=HTTPGitRequestHandler)
+          handler_class=WSGIRequestHandlerLogger)
         self.addCleanup(dul_server.shutdown)
         threading.Thread(target=dul_server.serve_forever).start()
         self._server = dul_server


### PR DESCRIPTION
This makes the test suit quiet again. :-)
