### PR TITLE
Fix error in fetching with side-band-64k disabled

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -402,7 +402,7 @@ class GitClient(object):
                 raise Exception('Unexpected response %r' % data)
         else:
             while True:
-                data = self.read(rbufsize)
+                data = proto.read(rbufsize)
                 if data == "":
                     break
                 pack_data(data)


### PR DESCRIPTION
Trying to get the test of a project which uses dulwich to work I removed side-band-64k from the caps, which then crashed the client.

this simple fix made it work.
