### PR TITLE
Handle case that client does not send wanted refs.

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -896,7 +896,7 @@ class BaseRepo(object):
         :return: iterator over objects, with __len__ implemented
         """
         wants = determine_wants(self.get_refs())
-        if wants is None:
+        if not wants:
             # TODO(dborowitz): find a way to short-circuit that doesn't change
             # this interface.
             return None


### PR DESCRIPTION
Determine_wants can return empty dict if client
does not send wanted refs. Avoid stack trace.

Fixes #106
