### PR TITLE
fix: unicode filename causes IOError error

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -412,7 +412,7 @@ def build_index_from_tree(prefix, index_path, object_store, tree_id,
     index = Index(index_path)
 
     for entry in object_store.iter_tree_contents(tree_id):
-        full_path = os.path.join(prefix, entry.path)
+        full_path = unicode(os.path.join(prefix, entry.path), "utf-8")
 
         if not os.path.exists(os.path.dirname(full_path)):
             os.makedirs(os.path.dirname(full_path))


### PR DESCRIPTION
Fix following error when the filenames contains unicode characters.

```
File "c:\Python27\lib\site-packages\dulwich-0.9.1-py2.7.egg\dulwich\index.py", line 433, in build_index_from_tree
f = open(full_path, 'wb')
IOError: [Errno 22] invalid mode ('wb') or filename: ...
```
