### PR TITLE
A bit more flexible string check for __getitem__

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -439,7 +439,7 @@ class BaseRepo(object):
         :return: A `ShaFile` object, such as a Commit or Blob
         :raise KeyError: when the specified ref or object does not exist
         """
-        if len(name) in (20, 40) and isinstance(name, str):
+        if len(name) in (20, 40) and isinstance(name, basestring):
             try:
                 return self.object_store[name]
             except (KeyError, ValueError):


### PR DESCRIPTION
The `str` type check for the `name` param was newly added in 0.9.5 and a bit more to restrictive; breaking compatibility with some older code.

I believe switching from `str` to `basestring` has low impact on the code and still drop all the possible invalid values like `list` and other.

It allows unicode strings to be passed over.

ex.

``` python
from dulwich import repo
r = repo.Repo('.')

# Using regular string
r['19417600c7a4db72642717ef4f316b4203913eaf'].tree
# returns 'e621006fc06b1dda838f91e1216c277712ec324e'

# Using unicode string
r[unicode('19417600c7a4db72642717ef4f316b4203913eaf')].tree

Traceback (most recent call last):
  File "", line 1, in 
  File "/Users/juhas/.virtualenvs/git/lib/python2.7/site-packages/dulwich/repo.py", line 448, in getitem
    return self.object_store[self.refs[name]]
  File "/Users/juhas/.virtualenvs/git/lib/python2.7/site-packages/dulwich/refs.py", line 223, in getitem
    raise KeyError(name)
  KeyError: u'19417600c7a4db72642717ef4f316b4203913eaf'
```

(Thanks @juhas !)
