### PR TITLE
Add ConfigFile support to MemoryRepos

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -902,9 +902,11 @@ class MemoryRepo(BaseRepo):
     """
 
     def __init__(self):
+        from dulwich.config import ConfigFile
         BaseRepo.__init__(self, MemoryObjectStore(), DictRefsContainer({}))
         self._named_files = {}
         self.bare = True
+        self._config = ConfigFile()
 
     def _put_named_file(self, path, contents):
         """Write a file to the control dir with the given name and contents.
@@ -941,8 +943,7 @@ class MemoryRepo(BaseRepo):
 
         :return: `ConfigFile` object.
         """
-        from dulwich.config import ConfigFile
-        return ConfigFile()
+        return self._config
 
     def get_description(self):
         """Retrieve the repository description.

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -615,6 +615,21 @@ class BuildRepoTests(TestCase):
             "Jelmer <jelmer@apache.org>",
             r[commit_sha].committer)
 
+    def test_commit_config_identity_in_memoryrepo(self):
+        # commit falls back to the users' identity if it wasn't specified
+        r = MemoryRepo.init_bare([], {})
+        c = r.get_config()
+        c.set(("user", ), "name", "Jelmer")
+        c.set(("user", ), "email", "jelmer@apache.org")
+
+        commit_sha = r.do_commit('message', tree=objects.Tree().id)
+        self.assertEqual(
+            "Jelmer <jelmer@apache.org>",
+            r[commit_sha].author)
+        self.assertEqual(
+            "Jelmer <jelmer@apache.org>",
+            r[commit_sha].committer)
+
     def test_commit_fail_ref(self):
         r = self._repo
 


### PR DESCRIPTION
For MemoryRepo, initialize the ConfigFile to the contents of the config named file in the repo.

To save a config file in a MemoryRepo, use a temporary StringIO with
write_to_file and then write it with repo._put_named_file.
