### PR TITLE
Replace 'unlink' with 'rm' in tests.

### DIFF
--- a/dulwich/tests/test_hooks.py
+++ b/dulwich/tests/test_hooks.py
@@ -113,7 +113,7 @@ exit 0
 
         (fd, path) = tempfile.mkstemp()
         post_commit_msg = """#!/bin/sh
-unlink %(file)s
+rm %(file)s
 """ % {'file': path}
 
         post_commit_msg_fail = """#!/bin/sh

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -460,7 +460,7 @@ exit 0
 
         (fd, path) = tempfile.mkstemp(dir=repo_dir)
         post_commit_msg = """#!/bin/sh
-unlink %(file)s
+rm %(file)s
 """ % {'file': path}
 
         root_sha = r.do_commit(


### PR DESCRIPTION
Several Unix-like systems (eg. OpenBSD) don't have 'unlink' utility. 'rm' does
exactly the same job, so using 'rm' instead of 'unlink' makes dulwich tests
more portable.
