### PR TITLE
Remove monkeypatch for older versions of urlparse.uses_netloc.

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -69,12 +69,6 @@ from dulwich.refs import (
     )
 
 
-# Python 2.6.6 included these in urlparse.uses_netloc upstream. Do
-# monkeypatching to enable similar behaviour in earlier Pythons:
-for scheme in ('git', 'git+ssh'):
-    if scheme not in urlparse.uses_netloc:
-        urlparse.uses_netloc.append(scheme)
-
 def _fileno_can_read(fileno):
     """Check if a file descriptor is readable."""
     return len(select.select([fileno], [], [], 0)[0]) > 0


### PR DESCRIPTION
Another monkey patch that can be removed now that we don't support python 2.6.
