### PR TITLE
Leaking file handles when pack cache is rebuilt

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -303,7 +303,10 @@ class PackBasedObjectStore(BaseObjectStore):
     @property
     def packs(self):
         """List with pack objects."""
-        if self._pack_cache is None or self._pack_cache_stale():
+        if self._pack_cache is not None and self._pack_cache_stale():
+            self.close()
+
+        if self._pack_cache is None:
             self._pack_cache = self._load_packs()
         return self._pack_cache
 


### PR DESCRIPTION
`PackBasedObjectStore` maintains a cache of the packs of the repository, and automatically refreshes it when it becomes stale (for example, after a push). Unfortunately, it doesn't close the previously opened packs when doing so.

This results in a leak of file handles, ultimately leading to the process hitting its open file handles limit.
