### PR TITLE
fixed typo in tutorial

### DIFF
--- a/docs/tutorial/repo.txt
+++ b/docs/tutorial/repo.txt
@@ -14,7 +14,7 @@ repositories:
   Regular Repositories -- They are the ones you create using ``git init`` and
   you daily use. They contain a ``.git`` folder.
 
-  Bare Repositories -- There is not ".git" folder. The top-level folder
+  Bare Repositories -- There is no ".git" folder. The top-level folder
   contains itself the "branches", "hooks"... folders. These are used for
   published repositories (mirrors). They do not have a working tree.
 


### PR DESCRIPTION
This commit fixes only a typo.  There is still inconsistency between the the following lines:
- line 15: `.git`
- line 17: ".git"
- line 32: "myrepo/.git"
