### PR TITLE
Bugfix: cmd_reset could not determine the mode

### DIFF
--- a/bin/dulwich
+++ b/bin/dulwich
@@ -234,6 +234,7 @@ def cmd_tag(args):
 
 def cmd_reset(args):
     opts, args = getopt(args, "", ["hard", "soft", "mixed"])
+    opts = dict(opts)
     mode = ""
     if "--hard" in opts:
         mode = "hard"


### PR DESCRIPTION
`opts = dict(opts)` was missing.
