### PR TITLE
Allow customization of Paramiko's host-key verification policy.

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -390,7 +390,7 @@ class GitClient(object):
         while pkt:
             parts = pkt.rstrip('\n').split(' ')
             if parts[0] == 'ACK':
-                graph_walker.ack(pkt.split(' ')[1])
+                graph_walker.ack(parts[1])
             if len(parts) < 3 or parts[2] not in (
                     'ready', 'continue', 'common'):
                 break


### PR DESCRIPTION
My organization's security policies require us to whitelist remote SSH keys, so making the policy configurable at all was a required change from stock dulwich.

This pull request also changes the default host-key verification policy from the do-nothing "[MissingHostKeyPolicy](https://github.com/paramiko/paramiko/blob/master/paramiko/client.py#L463)" to "[WarningPolicy](https://github.com/paramiko/paramiko/blob/master/paramiko/client.py#L510)" which _will_ result in a behavior change: a warning will be printed using the standard Python "warnings" module upon connecting to an SSH server whose public key fingerprint is not in `~/.ssh/known_keys`. I personally think this is a good thing - key verification is a fundamental component of the SSH protocol - but I can revert this particular change if you think this will just annoy most dulwich users.
