### PR TITLE
In Protocol.read_pkt_line, assert the length of the data read matches the length prefix.

### DIFF
--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -108,7 +108,11 @@ class Protocol(object):
                 return None
             if self.report_activity:
                 self.report_activity(size, 'read')
-            return read(size-4)
+            pkt_contents = read(size-4)
+            if len(pkt_contents) + 4 != size:
+                raise AssertionError('Length of pkt read {:04x} does not match length prefix {:04x}.'
+                                     .format(len(pkt_contents) + 4, size))
+            return pkt_contents
         except socket.error as e:
             raise GitProtocolError(e)
 

--- a/dulwich/tests/test_protocol.py
+++ b/dulwich/tests/test_protocol.py
@@ -82,6 +82,11 @@ class BaseProtocolTests(object):
         self.rin.seek(0)
         self.assertEqual(None, self.proto.read_pkt_line())
 
+    def test_read_pkt_line_wrong_size(self):
+        self.rin.write('0100too short')
+        self.rin.seek(0)
+        self.assertRaises(AssertionError, self.proto.read_pkt_line)
+
     def test_write_sideband(self):
         self.proto.write_sideband(3, 'bloe')
         self.assertEqual(self.rout.getvalue(), '0009\x03bloe')


### PR DESCRIPTION
I hope this will narrow down the cause of errors like this: https://lists.launchpad.net/dulwich-users/msg00790.html
