### PR TITLE
Add all test requirements to setup.py. Use setup.py test on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "2.7"
-script: make check
+script: PYTHONHASHSEED=random python setup.py test
 install:
-  - pip install unittest2 fastimport
   - sudo apt-get update
-  - sudo apt-get install -qq git
+  - sudo apt-get install -qq git python-setuptools
+

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,8 @@
 
 try:
     from setuptools import setup, Extension
-    has_setuptools = True
 except ImportError:
     from distutils.core import setup, Extension
-    has_setuptools = False
 from distutils.core import Distribution
 
 dulwich_version_string = '0.9.8'
@@ -49,10 +47,6 @@ if sys.platform == 'darwin' and os.path.exists('/usr/bin/xcodebuild'):
         if l.startswith('Xcode') and int(l.split()[1].split('.')[0]) >= 4:
             os.environ['ARCHFLAGS'] = ''
 
-setup_kwargs = {}
-
-if has_setuptools:
-    setup_kwargs['test_suite'] = 'dulwich.tests.test_suite'
 
 setup(name='dulwich',
       description='Python Git Library',
@@ -82,9 +76,10 @@ setup(name='dulwich',
           Extension('dulwich._diff_tree', ['dulwich/_diff_tree.c'],
               include_dirs=include_dirs),
       ],
+      test_suite='dulwich.tests.test_suite',
+      tests_require=['fastimport', 'mock', 'gevent', 'geventhttpclient'],
       distclass=DulwichDistribution,
       include_package_data=True,
       use_2to3=True,
       convert_2to3_doctests=['../docs/*', '../docs/tutorial/*', ],
-      **setup_kwargs
       )


### PR DESCRIPTION
This reduces the number of skipped tests on travis from 60 to 11.
