### PR TITLE
Travis: use system site packages in virtualenv.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "2.7"
+virtualenv:
+  system_site_packages: true
 script: PYTHONHASHSEED=random python setup.py test
 install:
   - sudo apt-get update


### PR DESCRIPTION
Otherwise the packages we install with apt-get don't get used.

This might become an issue again if the default python changes from 2.7 on the travis machines, or we start testing other python versions again.
