### PR TITLE
Use stderr.splitlines rather than Popen(universal_newlines=True)

### DIFF
--- a/dulwich/tests/__init__.py
+++ b/dulwich/tests/__init__.py
@@ -101,7 +101,6 @@ class BlackboxTestCase(TestCase):
         return subprocess.Popen(argv,
             stdout=subprocess.PIPE,
             stdin=subprocess.PIPE, stderr=subprocess.PIPE,
-            universal_newlines=True,
             env=env)
 
 

--- a/dulwich/tests/test_blackbox.py
+++ b/dulwich/tests/test_blackbox.py
@@ -46,7 +46,7 @@ class GitReceivePackTests(BlackboxTestCase):
     def test_missing_arg(self):
         process = self.run_command("dul-receive-pack", [])
         (stdout, stderr) = process.communicate()
-        self.assertEqual('usage: dul-receive-pack <git-dir>\n', stderr)
+        self.assertEqual(['usage: dul-receive-pack <git-dir>'], stderr.splitlines())
         self.assertEqual('', stdout)
         self.assertEqual(1, process.returncode)
 
@@ -62,6 +62,6 @@ class GitUploadPackTests(BlackboxTestCase):
     def test_missing_arg(self):
         process = self.run_command("dul-upload-pack", [])
         (stdout, stderr) = process.communicate()
-        self.assertEqual('usage: dul-upload-pack <git-dir>\n', stderr)
+        self.assertEqual(['usage: dul-upload-pack <git-dir>'], stderr.splitlines())
         self.assertEqual('', stdout)
         self.assertEqual(1, process.returncode)


### PR DESCRIPTION
The reason for this is that universal_newlines takes the Popen files out of bytes mode on python3.

This is an alternative fix to this commit: 5f706799a8e820c90a0ddf755765ebf4R47
