### PR TITLE
Strip newline from final ACKed SHA while fetching packs.

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -390,7 +390,7 @@ class GitClient(object):
         while pkt:
             parts = pkt.rstrip('\n').split(' ')
             if parts[0] == 'ACK':
-                graph_walker.ack(pkt.split(' ')[1])
+                graph_walker.ack(parts[1])
             if len(parts) < 3 or parts[2] not in (
                     'ready', 'continue', 'common'):
                 break


### PR DESCRIPTION
Without this change, the final ACKed SHA will be (eg) `1122334455667788990011223344556677889900\n` instead of `1122334455667788990011223344556677889900`.
