### PR TITLE
Fixed wrong string formatting call

### DIFF
--- a/dulwich/hooks.py
+++ b/dulwich/hooks.py
@@ -76,8 +76,8 @@ class ShellHook(Hook):
 
         if len(args) != self.numparam:
             raise HookError("Hook %s executed with wrong number of args. \
-                            Expected %d. Saw %d. %s"
-                            % (self.name, self.numparam, len(args)))
+                            Expected %d. Saw %d. args: %s"
+                            % (self.name, self.numparam, len(args), args))
 
         if (self.pre_exec_callback is not None):
             args = self.pre_exec_callback(*args)


### PR DESCRIPTION
The number of arguments were missing last one. As discussed it's debugging error, so we actually want the arguments to be printed in the error. This commit fixes the formatting error, and adds the list of arguments to be printed together with the error.
