### PR TITLE
server._is_satisfied should not travel all the paths.

### DIFF
--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -443,6 +443,7 @@ def _find_shallow(store, heads, depth):
 def _want_satisfied(store, haves, want, earliest):
     o = store[want]
     pending = collections.deque([o])
+    known = set([want])
     while pending:
         commit = pending.popleft()
         if commit.id in haves:
@@ -451,6 +452,9 @@ def _want_satisfied(store, haves, want, earliest):
             # non-commit wants are assumed to be satisfied
             continue
         for parent in commit.parents:
+            if parent in known:
+                continue
+            known.add(parent)
             parent_obj = store[parent]
             # TODO: handle parents with later commit times than children
             if parent_obj.commit_time >= earliest:


### PR DESCRIPTION
We just found out that the way `ProtocolGraphWalker._is_satisfied` is currently implemented is very inefficient, and that would be the understatement of the year.

The implementation travels all the paths in the commit graph that lead from the want to one have.

It is usually not a problem, but we have a relatively small repository (less than 400 commits), with an arguably weird history of cross-merges, that has `2.1e22` paths between its HEAD commit and its root commit.

A really good start is to maintain the set of already known nodes (i.e. nodes that are either pending or already visited).
