### PR TITLE
Check for ref names being instance of basestring rather than str

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -88,7 +88,7 @@ def hex_to_sha(hex):
     try:
         return binascii.unhexlify(hex)
     except TypeError as exc:
-        if not isinstance(hex, str):
+        if not isinstance(hex, basestring):
             raise
         raise ValueError(exc.args[0])
 

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -439,8 +439,8 @@ class BaseRepo(object):
         :return: A `ShaFile` object, such as a Commit or Blob
         :raise KeyError: when the specified ref or object does not exist
         """
-        if not isinstance(name, str):
-            raise TypeError("'name' must be bytestring, not %.80s" %
+        if not isinstance(name, basestring):
+            raise TypeError("'name' must be basestring, not %.80s" %
                     type(name).__name__)
         if len(name) in (20, 40):
             try:


### PR DESCRIPTION
Checking for instance of str causes problems when using Dulwich
in a Django application where ref names are given as unicode
strings.
