### PR TITLE
Fix redundant parse

### DIFF
--- a/dulwich/contrib/swift.py
+++ b/dulwich/contrib/swift.py
@@ -211,7 +211,7 @@ def pack_info_create(pack_data, pack_index):
             info[obj.id] = None
         # Tag
         elif obj.type_num == Tag.type_num:
-            info[obj.id] = (obj.type_num, obj._object_sha)
+            info[obj.id] = (obj.type_num, obj.object[1])
     return zlib.compress(json_dumps(info))
 
 

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -298,12 +298,11 @@ class ShaFile(object):
     def set_raw_chunks(self, chunks, sha=None):
         """Set the contents of this object from a list of chunks."""
         self._chunked_text = chunks
-        self._deserialize(chunks)
         if sha is None:
             self._sha = None
         else:
             self._sha = FixedSha(sha)
-        self._needs_parsing = False
+        self._needs_parsing = True
         self._needs_serialization = False
 
     @staticmethod
@@ -318,7 +317,7 @@ class ShaFile(object):
         return ret
 
     def _parse_object(self, map):
-        """Parse a new style object, setting self._text."""
+        """Parse a new style object, setting the raw string."""
         # skip type and size; type must have already been determined, and
         # we trust zlib to fail if it's otherwise corrupted
         byte = ord(map[0])


### PR DESCRIPTION
Before this retrieving a loose tree object from a repository would cause it be parsed three times. objects stored in a pack did not show this behaviour.

Setting the raw string no longer implies parsing the data which has the possibly problematic side effect that errors will only occur when you actually try to use the object.