### PR TITLE
Remove leading '/' from path in FileSystemBackend

### DIFF
--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -169,6 +169,10 @@ class FileSystemBackend(Backend):
         self.root = (os.path.abspath(root) + "/").replace("//", "/")
 
     def open_repository(self, path):
+        # If path starts with a '/' the os.path.join function has no effect, so
+        # we make sure to get rid of that.
+        if path.startswith('/'):
+            path = path[1:]
         logger.debug('opening repository at %s', path)
         abspath = os.path.abspath(os.path.join(self.root, path)) + "/"
         if not abspath.startswith(self.root):


### PR DESCRIPTION
When doing `git clone git://localhost/foo.git` I get an `Invalid path /foo.git` exception even though `self.root = '/home/git/repositories'`. This is because the path given is `/foo.git` and that makes the call to `os.path.join` have no effect.

Don't know if I'm using git clone the wrong way, but this PR fixes this issue when using `dulwich daemon`. 