### PR TITLE
Use a block cache in _find_content_rename_candidates().

### DIFF
--- a/dulwich/diff_tree.py
+++ b/dulwich/diff_tree.py
@@ -498,19 +498,20 @@ class RenameDetector(object):
         if not self._should_find_content_renames():
             return
 
+        block_cache = {}
         check_paths = self._rename_threshold is not None
         for delete in self._deletes:
             if S_ISGITLINK(delete.old.mode):
                 continue  # Git links don't exist in this repo.
             old_sha = delete.old.sha
             old_obj = self._store[old_sha]
-            old_blocks = _count_blocks(old_obj)
+            block_cache[old_sha] = _count_blocks(old_obj)
             for add in self._adds:
                 if stat.S_IFMT(delete.old.mode) != stat.S_IFMT(add.new.mode):
                     continue
                 new_obj = self._store[add.new.sha]
                 score = _similarity_score(old_obj, new_obj,
-                                          block_cache={old_sha: old_blocks})
+                                          block_cache=block_cache)
                 if score > self._rename_threshold:
                     new_type = self._rename_type(check_paths, delete, add)
                     rename = TreeChange(new_type, delete.old, add.new)


### PR DESCRIPTION
This will improve the performance of calls to changes_with_renames(), (which calls _find_content_rename_candidates), by avoiding re-hashing in _similarity_score().