### PR TITLE
Fix a hang of SSH pull on Windows.

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -616,7 +616,8 @@ class SubprocessWrapper(object):
             from msvcrt import get_osfhandle
             from win32pipe import PeekNamedPipe
             handle = get_osfhandle(self.proc.stdout.fileno())
-            return PeekNamedPipe(handle, 0)[2] != 0
+            data, total_bytes_avail, msg_bytes_left = PeekNamedPipe(handle, 0)
+            return total_bytes_avail != 0
         else:
             return _fileno_can_read(self.proc.stdout.fileno())
 


### PR DESCRIPTION
Last week I stopped being able to pull from a specific Git repository over SSH using Mercurial on two Windows machines I am using. I could see the pull starting to transfer data, but quickly just stall. I couldn't kill Mercurial with control-c, I had to kill the `ssh.exe` manually or wait long enough for the server to kill the idle connection.

I hadn't made any updates to either of the machines recently and they both had some Mercurial version from last year. I searched the Internet for similar problems, but couldn't find anything matching. I updated to the latest Mercurial version, but it didn't help either, so I started to debug the problem myself.

After I had added the following instrumentation I could see the problematic behavior:

```
diff -r 1f2e6a62f59a -r 8c076d0cfdba dulwich/client.py
--- a/dulwich/client.py	Wed Jan 21 22:37:48 2015 +0100
+++ b/dulwich/client.py	Fri Jan 23 17:15:02 2015 +0200
@@ -357,6 +357,7 @@
         :param can_read: function that returns a boolean that indicates
             whether there is extra graph data to read on proto
         """
+        print ">> _handle_upload_pack_head()"
         assert isinstance(wants, list) and isinstance(wants[0], str)
         proto.write_pkt_line('want %s %s\n' % (
             wants[0], ' '.join(capabilities)))
@@ -616,7 +617,9 @@
             from msvcrt import get_osfhandle
             from win32pipe import PeekNamedPipe
             handle = get_osfhandle(self.proc.stdout.fileno())
-            return PeekNamedPipe(handle, 0)[2] != 0
+            data = PeekNamedPipe(handle, 0)
+            print "CAN READ %s" % (data,)
+            return data[2] != 0
         else:
             return _fileno_can_read(self.proc.stdout.fileno())
 
diff -r 1f2e6a62f59a -r 8c076d0cfdba dulwich/protocol.py
--- a/dulwich/protocol.py	Wed Jan 21 22:37:48 2015 +0100
+++ b/dulwich/protocol.py	Fri Jan 23 17:15:02 2015 +0200
@@ -95,6 +95,10 @@
         self.close()
 
     def read_pkt_line(self):
+        ret = self._read_pkt_line()
+        print "<< read_pkt_line %r" % ret
+        return ret
+    def _read_pkt_line(self):
         """Reads a pkt-line from the remote git process.
 
         This method may read from the readahead buffer; see unread_pkt_line.
@@ -170,6 +174,7 @@
         :param line: A string containing the data to send, without the length
             prefix.
         """
+        print ">> write_pkt_line %r" % line
         try:
             line = pkt_line(line)
             self.write(line)
```

Here is an actual log of what happens before the communication hang (redacted for privacy):

```
pulling from git+ssh://git@*****.********.***/***/******.git
[lines elided for brevity]
<< read_pkt_line None
>> _handle_upload_pack_head()
>> write_pkt_line 'want ec7cafe3f3b47e73606c71a51a76a72873c3bf20 thin-pack multi_ack side-band-64k multi_ack_detailed ofs-delta\n'
>> write_pkt_line None
>> write_pkt_line 'have 272be3338dd352671b723f1e9a1bc35068d85414\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 5f05dc71d774117085af5ef0c110763734404c84\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have d76c845c57e44edb6def0b7363707603ad185cd9\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 82f2cdf0ed46c80cb9128c08924658eb8365daed\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4d659bafd5be4f66b4cb91df6448eb865b0eda94\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have e25824c67f46bf43332c4aa1af2567de4b633179\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have c19508137ea9523dfe35af9735ae6ded8238e9ae\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have bfa6391616afa429fb552e91a4e678bd6aed6199\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2ebef8d32fa0dc9e7758c7ee54c43f2e528944c8\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have a1503a35aee66fde9edba688f9899fb579b1f17f\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2d9ef4d641485933be0548801205cdb521fa04a0\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have e3f132a2facc3a949aabeed083b57d40de11a463\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 86e17579cfb9170e0cec617099eb586064a102d3\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have fe26f42c13b499a4e3eaa27685e2f27eed843c9b\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 40b1e453e64d3da4b9bcaad82b5fc39e41435029\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have b6303aee1cb7489c7dd8a64dd9a4f1ed481434ab\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2c6f825f48f8972c188509501215373340aeda2a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 728817f9c6cd1514d670c0e9222d92fa24ee4d72\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 8dac6ab587c9e3bb6bdc9dd8f7af41c969f61770\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ffb8a0cc70ae68e10a19cabab98fc7eb8b56e65a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ce409e7d09bf47d248b50bbf9a323138e29dd752\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4f35bb277c1bc6a80ceec21eac7686b090633b5d\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4c8f10a83dd7d0e1da36411eb667a1c3d5c05fe4\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 5f741c5b16aaa263230127df557c91e039a7bc80\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 58ff5f2f6731f4db1a30e6d2305f4b6cccfd4615\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4032af28006b983a6ddf84ac68083d6f6c1b1851\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 16fc5f686658a245ca7823abbbf6ce671ae21f80\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ac42f43398d95db16c2782c0d60758071a758fc8\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ecc3de3f7c1c74c37464a65d6f891b3b61a4da0e\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 9f2e145c167db152bacb746927e4f5d42fc741d5\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 8cf4caa94dfd8c8e5e15d9e1da995b7f74715b2e\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4c09ac33436266375de6685feeaa9f1d599138f3\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 44e8089520f155408d4c30fd96813c97555db838\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 842146770cf4e036ccfb3a516b8976074ae9d044\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2974db58d64b2c4bbfa4df3b4b130fe4ba450a9a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have e06ad27159c79a14a76254690b6c17d3a85debfb\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2be20f60a4a73ea55627f63c9d842893d0e2783a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 7350501ef1426757a4e97e480d09ca31f607b035\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 79f88c3b01a289873bc0341b70461fb4929408bb\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2a2ae9b1c0c3c72946ed774768647787160d060d\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have a0df4071dac0334206e3b17659e91a61e3428f96\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have fa789b8d6f706eac55e0e9b6004e2d85aa0fef41\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4d51a93e9341049309d779de9fea0995e2c39098\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ae2f5e19795ba0088b1fd777c2cf7c08cdf24762\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 7bb0c8b1e00643e3519edb7ee1f6319058dd854c\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 192d2cbd85d8f8fed5f54a8a158ee6b686403b24\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have fdba85a4fa401cb8d6cfc21179668131a1bb7ef3\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have b281ccbfa78e7823e6df11bba643e3fc35252e95\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 726dadd4b876bd3705596c400bac409003d0d1f2\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 12afad09e451ebd382b3afc5d49c6d4376b361fe\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 538d486b486fdeb14bb2b75546702dc7502763e2\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 1cf40fde2a6446f438b23941d00f97b82fc8dc68\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 8c658b8b4cb713050f1f3dc3ff61bb1670963a53\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have b108c84f980b6a2cb57d5293e22b789fd48aad13\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 29aa40a125dd44308a02c765796667e28ae714ca\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 7f3ebe1d435d532d0ec738915342d6486550b179\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have b5ccee345d6ded86a0e48b9cbcfbef711a80863f\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 82c59ddf9729a888ebf0b6afda72a9382eed83a2\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 014de85be61177ec1eb9478b90fffd2836d2115b\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2ceb39c85b0660af83cd4870973d534edec0df39\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 064351c98e44ac3cb1137d4cab81c4b4488a0044\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 0e74a8e0d02530454b06d25aec2265b73c7e31cb\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ce0bf7ab44ffff4ff939edb787be1cbb55e97c16\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have eae48767c26706730dd93c372ebca91bc8ebb190\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 41df72eb7ce70315584c8286acc7b228409f1ef9\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have d50effa7bbd37e51e1e317be8a3218965095f033\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 6b607bf68b7873227d47abb40b0a21151e3dd76e\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 8b70ff960470edd7e83e350db34bbe599b93c32b\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have c9b37fe9555ff3c8d482e98a240ba630804e39ce\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have c55b85c430df598b11515b6ee1fda8bf4cfc130e\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2059f1600621076e359ef24f3b99c67f8428edc4\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 22c36437b7eaa32ee1e5aabb26d66d78a06d8b6c\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have da499dffb053479b372876282a594e4e9e3af5c9\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have e198bff18c1e8b88626822160cd57c84bf7a27a8\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 33932af30bcff6340151d304cae8e956c5181a37\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have d5c2762c63169931205511a51f61000110fcf6b4\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 1824ed08ea5025411340abdd1ebc2c5b8eddeb52\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have a8fbb0f33af18299fff6d5e21a05b66bedaa7484\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 026f4ba001458ec8aa3ebf5115edf416882db3c4\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 0e569a9483efc73a46b67132f727f8a52214e69a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 9834b221f5ba236c3d9a04cd52bfd0b4d716e5e2\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have d6227349278d03c59556044f7025e23791daa72d\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 7cbe7a05ac3467c00f64033a76191f278155eda4\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2c3a5b8463373596b4050125597716068ce6bacf\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 76dbc337de2d38c5f627e03a16d11603b36ff46a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 1793a4f77fa40b3949e1c942f8dc0c13557f1669\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4499b4bf1d8ddda482b21206a352993ce0fe4617\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have dedaa8eedfebc44520711cb08c9a76887afe4f0e\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 17014eee1c9328e4b5592501f5ac2d8e4cb339ed\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 0f2fe98cb991c351ee1b1251e422b5eb1b9ae3ca\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2dd4cc84e039cf5ea6cfe7f6770275b2255c2637\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 497eba6785a8e0a90a16a6cd3c1daae8076e5974\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 60dffd6d6f2bd9750d0f032dc667b1bd8cf72a57\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 5e7cb2dc5601d7d7d0cddd8740c3dbdff38b3ef1\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 8ad3d3fc5921a1b7ebaab9dc2f10c34ecb30538a\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 4a5433ce2e377b2bd3314d9dbb72c997f9c9b7d0\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have e221df06c3c0c65c5229733748aaa5aa35f93b96\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have dfcaae681001e9fb947a281de67fa08204fd905e\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 25a849b3dd8c270025a70ee713d69f55c8301435\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 2acfa0b41217b3a2ad27a8c42180107eb45adaac\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 28cbc75fc2d2c185da84deb0093dba6181272cf2\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 8a590ce4e1d74f8b5e704594664fcd1725c17df8\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 361786312e586cac837f57dbbb7ca60ea5a2ec66\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have 9eab04ef0a3b16ab4e57acda69d90abd673498aa\n'
CAN READ ('', 0, 0)
>> write_pkt_line 'have ab87a0d383c5f27053220db59ff07502e78a1f8f\n'
CAN READ ('', 784, 0)
>> write_pkt_line 'have 287ff400bf7905edd00d2b8084fcabb0248d51ab\n'
CAN READ ('', 784, 0)
>> write_pkt_line 'have 79926919920b5d3bea6fea4265161bc6f03390a9\n'
CAN READ ('', 784, 0)
>> write_pkt_line 'have 36b74e2c84660aa8a99eef59cb5eba68dfcdaef6\n'
CAN READ ('', 784, 0)
>> write_pkt_line 'have 4a00e98df698643561127952c95f1e76f47db262\n'
CAN READ ('', 784, 0)
>> write_pkt_line 'have d430a3c7206e339ace8accf297a01b2cc367e4c3\n'
CAN READ ('', 3415, 0)
>> write_pkt_line 'have 3568038894adae250950897659d09cf5246942e1\n'
CAN READ ('', 3415, 0)
>> write_pkt_line 'have 67d20a282fe516d7b18f4d6add9f5485b6a9b158\n'
CAN READ ('', 3415, 0)
>> write_pkt_line 'have 3088adff081cd2ead33d7d2c7d62c4f50ac478f0\n'
CAN READ ('', 3415, 0)
>> write_pkt_line 'have 493e99851de3cfa40ee8a9616fedf50bd5cde1bc\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 1fc496e96f1200448d56f72604f49de9e6ab60cb\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 5f1030395dfd57c63af7fc640da62dddb30e241c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 659967e00e2695bcb4e715a5f53c7ee77be68498\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 1576e617f239ee9d7dd15231cdc906bd6867a75e\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 4dcb553c7f69fe72a386afc17ad024325b27839a\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 3273fe60cd40f25eda05883e353d4495947ef6d6\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 52e457cd3ba7b0cd618eec58d14a21f6f03e0887\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have f4d37ba2c39ebf1dedf4a09ea13a072762a6b30a\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 1baf9994946b6ee2db0efaabad9019faa52eb5be\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 5f853b3ca56593b02da219a623c7757b60198bac\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have eb1c3293b1d9aa9063581f9040aca5dd03fe6cd3\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 32dd80b860e4490ad2933246b296da1c5d7ea5d0\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 2c8af105a3f7a6882bd71b4b7f13a8af0577edb5\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 0a5bf88806e681249d0da4181333fd3c30fc9eef\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a44b206056ea3aab2cea2edc5ad978fa14e58865\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 0c392fff8ec1bbc1576e5383a37d9d6b71ce5dc5\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a53d6499b0e2c87db28d6940e729cd4fcb10f9dd\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have b4aea2ace943f95f4cefbd3916decb98fc67e575\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 20892a1d29d248a3d21ea4cb727f717eb208e4e8\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 5048373165dcd8ef3d09c954e46be0ad33814a7d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have d4a7f484685f73d4ab705446d8dc20498d014bae\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 46d198ea7cea0685e8aa1ba2081f702243fd670d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have def493c99211c4158b681b03c55847d773ef1ffb\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 1c64f108be7f307983bdfa8fc7da7dd80f10638d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 86fdf052a2436ca761180912197f40a214e75428\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 6e2e0edd88d88b867caac308754d7e4395f3c899\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 0224aacdd8c1683f231dd98fa81fafc1dcd683f9\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 4e39cc6de9b557ccffe426a34b0db9bf0b6eedff\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 1b2ffbebf00b1992e4281fa2b087edeeb65b1d61\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 7f869e7b57d308973181ea7bd4ab041df208ff50\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have f0ee4c8b99c830bdfd034c68b42e0c0c81d14f16\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 2c60e998cb4187d1a4fc328cccf9ac1384be8460\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 5ac14f8ddec8cae1b17248fe669c8afe1a2a49d9\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 37d9824ae34d3f2c8630501982d992c9307abffd\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 0e8db9089d35b5c386e948caa6f62b613aadddaa\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 13ae6424ffeecad6e5758703b290fad9682cb54e\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 78734f85eac36dc6710dff62343432b3d77c910c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 93007baadebe9409291f51af54d7fff964b48d7f\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 668432f85fac17095eec577034d5ddfd0def49dc\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have d31cfea83eb020105588ce2ba526af5d0ed73c2d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have b2eefeee237147a97be42431bb244a30de1e8649\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have f3ee5333f526bc1289af031c7af3972bec70993a\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 7d3e468798a01bea426b9a920d65d17ab213451d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 55a8167b2bfda00fdfe06c1e8db889b2e5c61265\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a633963b340cbb2b1ab90c4d1639ce0f926d3e96\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 0fb4e4e5bd048ab29273db12cb5a5dcd11290a1c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 2d83d73bd114d09acf72caf60b531fb82e9db176\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have d29170b8c36a6f758490ea21a4b4a8515ce896cd\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 0263723cea0dedc95172ae4b267e27e72a1af55f\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 73e918f1b49f1abfcbdd343cad40f1a476e1a4cd\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 86ab322915ddf51a1d35c931cf47361547c997f5\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 52e1913c64ef94472d6dd99e5688abfc8a69cf94\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have c5e92b1883114c212abdd1e293ac1a7cd9e1bc37\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 2bc91cdb7e5c77d0a582ff9f87dafe94c14b3863\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a046a0c259b72f2d288da5623f232756fed20f2a\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 7426df51e0d8041d97491c8fdbf8e627e43f6a12\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have b40e273812d12115b092cdf7def55b7d83551d1c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 1e38237901d5a50ce42ad41afdad36bb19f4726e\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a03634268f80a3752fdfd0c26222d18e86bec935\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have cc56941aa6ff434e27569c00be1aba2243cd3db7\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 5a253bc1271d676f8eac1936967aa57c86c7256c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a7fb9d8868bfbf07f36af1e9ccdc50fa6e1cdebc\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 47fff43377f07d2a723f3976269a3f77eb4ff1ec\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 5bdefb47690d8d74a3cd2c49d39541975742309c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have f7a3ea5b616720785043a4daf1384abf89a1597c\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 889bf6269aa90a1f8c757dde1bc4b67e1e492b90\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 313d3983e1e280d92c7d272ea9ea95a4157b6202\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 8046fbfba17af748797c906738198fc1ceb83c16\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have d1584f36f844becec7f1cb6ffb2387c77d9fbcbd\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 02b94cb366f0e14aa468ef9af8fb593cf80087e8\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have d2e19536a9c199559608749ff15acf4dc785cdb6\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have f577661362d274eb8057e81ef3348e97b2d03fb9\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have c4f81fe3491165e5a4311053ad4e85640d6d9843\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have e29e42ab0ad98a47c23487600bc6d9b5fa0856ca\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have e12db0736f2d03aa297e263940492db1ff7bddb0\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 928a3b324c6be927833f835193e043befa3732ee\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have cf3bedd1b712a6727ef5ec76772f98a56bdda31d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 3f82ee9248bb548f9e652bb9628fecad4bba711d\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have a3d83c69c748574436da171bb68a4adf4a9180bd\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have 95a5d0323ea39394389caac424a9524a285e0b7e\n'
CAN READ ('', 5543, 0)
>> write_pkt_line 'have e34a98b5d0510e50dcfc6c2f7002e70c2c0696d1\n'
CAN READ ('', 3415, 0)
>> write_pkt_line 'have 0bf5a376f186cb238689b4822d5c1f761bd799ff\n'
```

At this point everything would just hang until the server times out and closes the connection which makes Mercurial fail.

What is happening is that `SubprocessWrapper.can_read()` returns `False` when the 3rd item returned by `PeekNamedPipe()` is zero and therefore the loop in `GitClient._handle_upload_pack_head()` never reads what the server is sending but keeps itself sending more data to the server. At some point the buffers between the client and server fill up and they start waiting each other.

Looking at `win32pipe.PeekNamedPipe()` [documentation](http://docs.activestate.com/activepython/3.2/pywin32/win32pipe__PeekNamedPipe_meth.html) gives only this uninformative data:

    (string, int, int) = PeekNamedPipe(hPipe, size )

Looking at the [implementation](http://pywin32.hg.sourceforge.net/hgweb/pywin32/pywin32/file/b81227a0b147/win32/src/win32pipe.i#l481) we can see what the returned values actually are:

```
   481 	if (PeekNamedPipe(hNamedPipe, buf, size, &bytesRead, &totalAvail, &bytesLeft)) {
   482 		rc = Py_BuildValue("Nii", 
   483 			PyString_FromStringAndSize((char *)buf, bytesRead),
   484 			totalAvail, bytesLeft);```
```

Looking at [MSDN documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365779(v=vs.85).aspx) we can confirm that the code is comparing the `lpBytesLeftThisMessage` argument against zero:

```
BOOL WINAPI PeekNamedPipe(
  _In_       HANDLE hNamedPipe,
  _Out_opt_  LPVOID lpBuffer,
  _In_       DWORD nBufferSize,
  _Out_opt_  LPDWORD lpBytesRead,
  _Out_opt_  LPDWORD lpTotalBytesAvail,
  _Out_opt_  LPDWORD lpBytesLeftThisMessage
);

lpTotalBytesAvail [out, optional]
    A pointer to a variable that receives the total number of bytes available to be read from the pipe.
    This parameter can be NULL if no data is to be read.
lpBytesLeftThisMessage [out, optional]
    A pointer to a variable that receives the number of bytes remaining in this message. This parameter
    will be zero for byte-type named pipes or for anonymous pipes. This parameter can be NULL if
    no data is to be read.
```
And like the documentation points out, for anonymous pipes this is *guaranteed to be always zero* like also indicated by the log above!

The fix is simple, use `lpTotalBytesAvail` instead.

The most astounding thing is that the current, totally non-functional code was introduced 3 years ago! I think the reason it started biting me now is that the amount of heads crossed a critical limit which increased the number of bytes communicated over the size of the buffer in the server.