### PR TITLE
Complete fix for issue #88

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -262,6 +262,9 @@ class BaseRepo(object):
 
             return []
 
+        # If the graph walker is set up with an implementation that can
+        # ACK/NAK to the wire, it will write data to the client through
+        # this call as a side-effect.
         haves = self.object_store.find_common_revisions(graph_walker)
 
         # Deal with shallow requests separately because the haves do

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -660,6 +660,8 @@ class BaseGraphWalkerImpl(object):
             # Okay we are not actually done then since the walker picked
             # up no haves.  This is usually triggered when client attempts
             # to pull from a source that has no common base_commit.
+            # See: test_server.MultiAckDetailedGraphWalkerImplTestCase.\
+            #          test_multi_ack_stateless_nodone
             return False
 
         self.post_nodone_check()

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -242,7 +242,6 @@ class UploadPackHandler(Handler):
         # data (such as side-band, see the progress method here).
         self._processing_have_lines = False
 
-    @property
     def _done_required(self):
         return not self.has_capability("no-done")
 
@@ -317,7 +316,7 @@ class UploadPackHandler(Handler):
         self._processing_have_lines = False
 
         if not graph_walker.handle_done(
-                self._done_required, self._done_received):
+                self._done_required(), self._done_received):
             return
 
         self.progress("dul-daemon says what\n")

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -316,18 +316,9 @@ class UploadPackHandler(Handler):
         # band data now.
         self._processing_have_lines = False
 
-        if self._done_required and not self._done_received:
-            # we are not done, especially when done is required; skip
-            # the pack for this request and especially do not handle
-            # the done.
+        if not graph_walker.handle_done(
+                self._done_required, self._done_received):
             return
-
-        if not self._done_received and not graph_walker._haves:
-            # Okay we are not actually done then since the walker picked
-            # up no haves.
-            return
-
-        graph_walker.handle_done()
 
         self.progress("dul-daemon says what\n")
         self.progress("counting objects: %d, done.\n" % len(objects_iter))
@@ -474,7 +465,6 @@ class ProtocolGraphWalker(object):
         self.http_req = handler.http_req
         self.advertise_refs = handler.advertise_refs
         self._wants = []
-        self._haves = []
         self.shallow = set()
         self.client_shallow = set()
         self.unshallow = set()
@@ -618,9 +608,9 @@ class ProtocolGraphWalker(object):
     def send_nak(self):
         self.proto.write_pkt_line('NAK\n')
 
-    def handle_done(self):
-        # Now continue the process as if done was sent.
-        return self._impl.handle_done()
+    def handle_done(self, done_required, done_received):
+        # Delegate this to the implementation.
+        return self._impl.handle_done(done_required, done_received)
 
     def set_wants(self, wants):
         self._wants = wants
@@ -632,7 +622,6 @@ class ProtocolGraphWalker(object):
         :note: Wants are specified with set_wants rather than passed in since
             in the current interface they are determined outside this class.
         """
-        self._haves = haves
         return _all_wants_satisfied(self.store, haves, self._wants)
 
     def set_ack_type(self, ack_type):
@@ -647,17 +636,43 @@ class ProtocolGraphWalker(object):
 _GRAPH_WALKER_COMMANDS = ('have', 'done', None)
 
 
-class SingleAckGraphWalkerImpl(object):
-    """Graph walker implementation that speaks the single-ack protocol."""
+class BaseGraphWalkerImpl(object):
 
     def __init__(self, walker):
         self.walker = walker
-        self._sent_ack = False
+        self._common = []
+
+    def pre_nodone_check(self):
+        pass
+
+    def post_nodone_check(self):
+        pass
+
+    def handle_done(self, done_required, done_received):
+        self.pre_nodone_check()
+
+        if done_required and not done_received:
+            # we are not done, especially when done is required; skip
+            # the pack for this request and especially do not handle
+            # the done.
+            return False
+
+        if not done_received and not self._common:
+            # Okay we are not actually done then since the walker picked
+            # up no haves.
+            return False
+
+        self.post_nodone_check()
+        return True
+
+
+class SingleAckGraphWalkerImpl(BaseGraphWalkerImpl):
+    """Graph walker implementation that speaks the single-ack protocol."""
 
     def ack(self, have_ref):
-        if not self._sent_ack:
+        if not self._common:
             self.walker.send_ack(have_ref)
-            self._sent_ack = True
+            self._common.append(have_ref)
 
     def next(self):
         command, sha = self.walker.read_proto_line(_GRAPH_WALKER_COMMANDS)
@@ -670,18 +685,17 @@ class SingleAckGraphWalkerImpl(object):
 
     __next__ = next
 
-    def handle_done(self):
-        if not self._sent_ack:
+    def pre_nodone_check(self):
+        if not self._common:
             self.walker.send_nak()
 
 
-class MultiAckGraphWalkerImpl(object):
+class MultiAckGraphWalkerImpl(BaseGraphWalkerImpl):
     """Graph walker implementation that speaks the multi-ack protocol."""
 
     def __init__(self, walker):
-        self.walker = walker
+        super(MultiAckGraphWalkerImpl, self).__init__(walker)
         self._found_base = False
-        self._common = []
 
     def ack(self, have_ref):
         self._common.append(have_ref)
@@ -710,7 +724,7 @@ class MultiAckGraphWalkerImpl(object):
 
     __next__ = next
 
-    def handle_done(self):
+    def post_nodone_check(self):
         # don't nak unless no common commits were found, even if not
         # everything is satisfied
         if self._common:
@@ -719,12 +733,8 @@ class MultiAckGraphWalkerImpl(object):
             self.walker.send_nak()
 
 
-class MultiAckDetailedGraphWalkerImpl(object):
+class MultiAckDetailedGraphWalkerImpl(BaseGraphWalkerImpl):
     """Graph walker implementation speaking the multi-ack-detailed protocol."""
-
-    def __init__(self, walker):
-        self.walker = walker
-        self._common = []
 
     def ack(self, have_ref):
         # Should only be called iff have_ref is common
@@ -758,7 +768,10 @@ class MultiAckDetailedGraphWalkerImpl(object):
 
     __next__ = next
 
-    def handle_done(self):
+    def pre_nodone_check(self):
+        pass
+
+    def post_nodone_check(self):
         # don't nak unless no common commits were found, even if not
         # everything is satisfied
         if self._common:

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -658,7 +658,8 @@ class BaseGraphWalkerImpl(object):
 
         if not done_received and not self._common:
             # Okay we are not actually done then since the walker picked
-            # up no haves.
+            # up no haves.  This is usually triggered when client attempts
+            # to pull from a source that has no common base_commit.
             return False
 
         self.post_nodone_check()

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -184,9 +184,7 @@ class Handler(object):
         self.proto = proto
         self.http_req = http_req
         self._client_capabilities = None
-        # used for UploadPackHandler, leaving this here until it is 
-        # determined that it is the only user of this.
-        self._done_required = True
+        # Flags needed for the no-done capability
         self._done_received = False
 
     @classmethod
@@ -226,6 +224,9 @@ class Handler(object):
                                    'before asking client' % cap)
         return cap in self._client_capabilities
 
+    def notify_done(self):
+        self._done_received = True
+
 
 class UploadPackHandler(Handler):
     """Protocol handler for uploading a pack to the server."""
@@ -241,10 +242,14 @@ class UploadPackHandler(Handler):
         # side-band data.
         self._processing_have_lines = False
 
+    @property
+    def _done_required(self):
+        return not self.has_capability("no-done")
+
     @classmethod
     def capabilities(cls):
         return ("multi_ack_detailed", "multi_ack", "side-band-64k", "thin-pack",
-                "ofs-delta", "no-progress", "include-tag", "shallow")
+                "ofs-delta", "no-progress", "include-tag", "shallow", "no-done")
 
     @classmethod
     def required_capabilities(cls):
@@ -313,8 +318,16 @@ class UploadPackHandler(Handler):
 
         if self._done_required and not self._done_received:
             # we are not done, especially when done is required; skip
-            # the pack for this request.
+            # the pack for this request and especially do not handle
+            # the done.
             return
+
+        if not self._done_received and not graph_walker._haves:
+            # Okay we are not actually done then since the walker picked
+            # up no haves.
+            return
+
+        graph_walker.handle_done()
 
         self.progress("dul-daemon says what\n")
         self.progress("counting objects: %d, done.\n" % len(objects_iter))
@@ -461,6 +474,7 @@ class ProtocolGraphWalker(object):
         self.http_req = handler.http_req
         self.advertise_refs = handler.advertise_refs
         self._wants = []
+        self._haves = []
         self.shallow = set()
         self.client_shallow = set()
         self.unshallow = set()
@@ -592,6 +606,10 @@ class ProtocolGraphWalker(object):
 
         self.proto.write_pkt_line(None)
 
+    def notify_done(self):
+        # relay the message down to the handler.
+        self.handler.notify_done()
+
     def send_ack(self, sha, ack_type=''):
         if ack_type:
             ack_type = ' %s' % ack_type
@@ -599,6 +617,10 @@ class ProtocolGraphWalker(object):
 
     def send_nak(self):
         self.proto.write_pkt_line('NAK\n')
+
+    def handle_done(self):
+        # Now continue the process as if done was sent.
+        return self._impl.handle_done()
 
     def set_wants(self, wants):
         self._wants = wants
@@ -610,6 +632,7 @@ class ProtocolGraphWalker(object):
         :note: Wants are specified with set_wants rather than passed in since
             in the current interface they are determined outside this class.
         """
+        self._haves = haves
         return _all_wants_satisfied(self.store, haves, self._wants)
 
     def set_ack_type(self, ack_type):
@@ -639,13 +662,17 @@ class SingleAckGraphWalkerImpl(object):
     def next(self):
         command, sha = self.walker.read_proto_line(_GRAPH_WALKER_COMMANDS)
         if command in (None, 'done'):
-            if not self._sent_ack:
-                self.walker.send_nak()
+            # defer the handling of done
+            self.walker.notify_done()
             return None
         elif command == 'have':
             return sha
 
     __next__ = next
+
+    def handle_done(self):
+        if not self._sent_ack:
+            self.walker.send_nak()
 
 
 class MultiAckGraphWalkerImpl(object):
@@ -673,12 +700,7 @@ class MultiAckGraphWalkerImpl(object):
                 # flush but more have lines are still coming
                 continue
             elif command == 'done':
-                # don't nak unless no common commits were found, even if not
-                # everything is satisfied
-                if self._common:
-                    self.walker.send_ack(self._common[-1])
-                else:
-                    self.walker.send_nak()
+                self.walker.notify_done()
                 return None
             elif command == 'have':
                 if self._found_base:
@@ -687,6 +709,14 @@ class MultiAckGraphWalkerImpl(object):
                 return sha
 
     __next__ = next
+
+    def handle_done(self):
+        # don't nak unless no common commits were found, even if not
+        # everything is satisfied
+        if self._common:
+            self.walker.send_ack(self._common[-1])
+        else:
+            self.walker.send_nak()
 
 
 class MultiAckDetailedGraphWalkerImpl(object):
@@ -705,6 +735,8 @@ class MultiAckDetailedGraphWalkerImpl(object):
         while True:
             command, sha = self.walker.read_proto_line(_GRAPH_WALKER_COMMANDS)
             if command is None:
+                if self.walker.all_wants_satisfied(self._common):
+                    self.walker.send_ack(self._common[-1], 'ready')
                 self.walker.send_nak()
                 if self.walker.http_req:
                     # why special case?  if this was "stateless" as in
@@ -714,17 +746,8 @@ class MultiAckDetailedGraphWalkerImpl(object):
                     # as written happy).
                     return None
             elif command == 'done':
-                # This whole mess really needs to be properly redefined
-                # in terms of flags and states and have a better way to
-                # signal things as required rather than poking these
-                # seemingly random variables outside of this class and
-                # hope things work in the intended manner.
-                # XXX walker should have a done notification method.
-                # XXX we don't know if handler will implement that.
-                try:
-                    self.walker.handler._done_received = True
-                except:
-                    pass
+                # Let the walker know that we got a done.
+                self.walker.notify_done()
                 break
             elif command == 'have':
                 # return the sha and let the caller ACK it with the
@@ -732,28 +755,16 @@ class MultiAckDetailedGraphWalkerImpl(object):
                 return sha
         # don't nak unless no common commits were found, even if not
         # everything is satisfied
-        # XXX shouldn't we do this if "no-done"?
-        # TODO implement no-done.
-        if self.walker.all_wants_satisfied(self._common):
-            self.walker.send_ack(self._common[-1], 'ready')
 
-        # XXX if the next part after this can be done by walker.
-        try:
-            # XXX again, this should be handled in the walker
-            if (self.walker.handler._done_required and
-                    not self.walker.handler._done_received):
-                # do not ready.
-                return None
-        except:
-            pass
+    __next__ = next
 
+    def handle_done(self):
+        # don't nak unless no common commits were found, even if not
+        # everything is satisfied
         if self._common:
             self.walker.send_ack(self._common[-1])
         else:
             self.walker.send_nak()
-        return None
-
-    __next__ = next
 
 
 class ReceivePackHandler(Handler):
@@ -767,7 +778,7 @@ class ReceivePackHandler(Handler):
 
     @classmethod
     def capabilities(cls):
-        return ("report-status", "delete-refs", "side-band-64k")
+        return ("report-status", "delete-refs", "side-band-64k", "no-done")
 
     def _apply_pack(self, refs):
         all_exceptions = (IOError, OSError, ChecksumMismatch, ApplyDeltaError,

--- a/dulwich/tests/compat/server_utils.py
+++ b/dulwich/tests/compat/server_utils.py
@@ -260,16 +260,12 @@ class ServerTests(object):
         self.addCleanup(tear_down_repo, self._client_repo)
         port = self._start_server(self._source_repo)
 
-        run_git_or_fail(['config', 'user.email', 'user@example.com'],
+        self.assertRaises(KeyError, self._client_repo.get_object,
+            '02a14da1fc1fc13389bbf32f0af7d8899f2b2323')
+        run_git_or_fail(['fetch', self.url(port), 'master',],
                         cwd=self._client_repo.path)
-        run_git_or_fail(['config', 'user.name', 'User Name'],
-                        cwd=self._client_repo.path)
-        run_git_or_fail(['pull', self.url(port), 'master',],
-                        cwd=self._client_repo.path)
-        # the merge commit will be automatic so hashes are different,
-        # however it being a working directory and done with git it has
-        # a rather predictable result, assuming a default strategy.
-        self.assertEqual(len(os.listdir(self._client_repo.path)), 8)
+        self.assertEqual('commit', self._client_repo.get_object(
+            '02a14da1fc1fc13389bbf32f0af7d8899f2b2323').type_name)
 
     def test_push_to_dulwich_issue_88_standard(self):
         # Same thing, but we reverse the role of the server/client

--- a/dulwich/tests/compat/server_utils.py
+++ b/dulwich/tests/compat/server_utils.py
@@ -260,6 +260,10 @@ class ServerTests(object):
         self.addCleanup(tear_down_repo, self._client_repo)
         port = self._start_server(self._source_repo)
 
+        run_git_or_fail(['config', 'user.email', 'user@example.com'],
+                        cwd=self._client_repo.path)
+        run_git_or_fail(['config', 'user.name', 'User Name'],
+                        cwd=self._client_repo.path)
         run_git_or_fail(['pull', self.url(port), 'master',],
                         cwd=self._client_repo.path)
         # the merge commit will be automatic so hashes are different,

--- a/dulwich/tests/compat/server_utils.py
+++ b/dulwich/tests/compat/server_utils.py
@@ -267,6 +267,20 @@ class ServerTests(object):
         # a rather predictable result, assuming a default strategy.
         self.assertEqual(len(os.listdir(self._client_repo.path)), 8)
 
+    def test_push_to_dulwich_issue_88_standard(self):
+        # Same thing, but we reverse the role of the server/client
+        # and do a push instead.
+        self._source_repo = import_repo('issue88_expect_ack_nak_client.export')
+        self.addCleanup(tear_down_repo, self._source_repo)
+        self._client_repo = import_repo('issue88_expect_ack_nak_server.export',
+                                        as_working_copy=True)
+        self.addCleanup(tear_down_repo, self._client_repo)
+        port = self._start_server(self._source_repo)
+
+        run_git_or_fail(['push', self.url(port), 'master',],
+                        cwd=self._client_repo.path)
+        self.assertReposEqual(self._source_repo, self._client_repo)
+
 
 # TODO(dborowitz): Come up with a better way of testing various permutations of
 # capabilities. The only reason it is the way it is now is that side-band-64k

--- a/dulwich/tests/compat/server_utils.py
+++ b/dulwich/tests/compat/server_utils.py
@@ -237,6 +237,18 @@ class ServerTests(object):
         self.assertEqual([], _get_shallow(clone))
         self.assertReposEqual(clone, self._source_repo)
 
+    def test_fetch_from_dulwich_issue_88(self):
+        self._source_repo = import_repo('issue88_expect_ack_nak_server.export')
+        self.addCleanup(tear_down_repo, self._source_repo)
+        self._client_repo = import_repo('issue88_expect_ack_nak_client.export',
+                                        as_working_copy=True)
+        self.addCleanup(tear_down_repo, self._client_repo)
+        port = self._start_server(self._source_repo)
+
+        run_git_or_fail(['pull', self.url(port), 'master',],
+                        cwd=self._client_repo.path)
+        self.assertReposEqual(self._source_repo, self._client_repo)
+
 
 # TODO(dborowitz): Come up with a better way of testing various permutations of
 # capabilities. The only reason it is the way it is now is that side-band-64k

--- a/dulwich/tests/compat/test_web.py
+++ b/dulwich/tests/compat/test_web.py
@@ -29,6 +29,8 @@ from wsgiref import simple_server
 
 from dulwich.server import (
     DictBackend,
+    UploadPackHandler,
+    ReceivePackHandler,
     )
 from dulwich.tests import (
     SkipTest,
@@ -98,11 +100,33 @@ class SmartWebTestCase(WebTests, CompatTestCase):
         return app
 
 
+def patch_capabilities(handler, caps_removed):
+    # Patch a handler's capabilities by specifying a list of them to be
+    # removed, and return the original classmethod for restoration.
+    original_capabilities = handler.capabilities
+    filtered_capabilities = tuple(
+        i for i in original_capabilities() if i not in caps_removed)
+    def capabilities(cls):
+        return filtered_capabilities
+    handler.capabilities = classmethod(capabilities)
+    return original_capabilities
+
+
 class SmartWebSideBand64kTestCase(SmartWebTestCase):
     """Test cases for smart HTTP server with side-band-64k support."""
 
     # side-band-64k in git-receive-pack was introduced in git 1.7.0.2
     min_git_version = (1, 7, 0, 2)
+
+    def setUp(self):
+        self.o_uph_cap = patch_capabilities(UploadPackHandler, ("no-done",))
+        self.o_rph_cap = patch_capabilities(ReceivePackHandler, ("no-done",))
+        super(SmartWebSideBand64kTestCase, self).setUp()
+
+    def tearDown(self):
+        super(SmartWebSideBand64kTestCase, self).tearDown()
+        UploadPackHandler.capabilities = self.o_uph_cap
+        ReceivePackHandler.capabilities = self.o_rph_cap
 
     def _handlers(self):
         return None  # default handlers include side-band-64k
@@ -111,6 +135,25 @@ class SmartWebSideBand64kTestCase(SmartWebTestCase):
         receive_pack_handler_cls = app.handlers['git-receive-pack']
         caps = receive_pack_handler_cls.capabilities()
         self.assertTrue('side-band-64k' in caps)
+        self.assertFalse('no-done' in caps)
+
+
+class SmartWebSideBand64kNoDoneTestCase(SmartWebTestCase):
+    """Test cases for smart HTTP server with side-band-64k and no-done
+    support.
+    """
+
+    # no-done was introduced in git 1.7.4
+    min_git_version = (1, 7, 4)
+
+    def _handlers(self):
+        return None  # default handlers include side-band-64k
+
+    def _check_app(self, app):
+        receive_pack_handler_cls = app.handlers['git-receive-pack']
+        caps = receive_pack_handler_cls.capabilities()
+        self.assertTrue('side-band-64k' in caps)
+        self.assertTrue('no-done' in caps)
 
 
 class DumbWebTestCase(WebTests, CompatTestCase):

--- a/dulwich/tests/compat/test_web.py
+++ b/dulwich/tests/compat/test_web.py
@@ -141,3 +141,7 @@ class DumbWebTestCase(WebTests, CompatTestCase):
         # Note: remove this if C git and dulwich implement dumb web shallow
         # clones.
         raise SkipTest('Dumb web shallow cloning not supported.')
+
+    def test_push_to_dulwich_issue_88_standard(self):
+        raise SkipTest('Dumb web pushing not supported.')
+

--- a/dulwich/tests/data/repos/issue88_expect_ack_nak_client.export
+++ b/dulwich/tests/data/repos/issue88_expect_ack_nak_client.export
@@ -47,7 +47,7 @@ commit refs/heads/master
 mark :7
 author User <user@localhost> 1427185245 +1300
 committer User <user@localhost> 1427185245 +1300
-data 23
+data 14
 replace a line
 from :5
 M 100644 :6 demo.txt

--- a/dulwich/tests/data/repos/issue88_expect_ack_nak_client.export
+++ b/dulwich/tests/data/repos/issue88_expect_ack_nak_client.export
@@ -1,0 +1,260 @@
+reset refs/heads/master
+commit refs/heads/master
+mark :1
+author User <user@localhost> 1427183369 +1300
+committer User <user@localhost> 1427183369 +1300
+data 6
+empty
+
+blob
+mark :2
+data 35
+We will reproduce a problem here.
+
+commit refs/heads/master
+mark :3
+author User <user@localhost> 1427183376 +1300
+committer User <user@localhost> 1427183376 +1300
+data 11
+demo file.
+from :1
+M 100644 :2 demo.txt
+
+blob
+mark :4
+data 62
+We will reproduce a problem here.
+
+This will take some time.
+
+commit refs/heads/master
+mark :5
+author User <user@localhost> 1427185135 +1300
+committer User <user@localhost> 1427185135 +1300
+data 13
+added a line
+from :3
+M 100644 :4 demo.txt
+
+blob
+mark :6
+data 57
+We will reproduce a problem here.
+
+We will change these.
+
+commit refs/heads/master
+mark :7
+author User <user@localhost> 1427185245 +1300
+committer User <user@localhost> 1427185245 +1300
+data 23
+replace a line
+from :5
+M 100644 :6 demo.txt
+
+blob
+mark :8
+data 52
+We will change these.
+
+Then issues will be proven.
+
+commit refs/heads/master
+mark :9
+author User <user@localhost> 1427185343 +1300
+committer User <user@localhost> 1427185343 +1300
+data 13
+Yes we will.
+from :7
+M 100644 :8 demo.txt
+
+blob
+mark :10
+data 69
+We will change these. 
+
+Then issues will be proven once and for all.
+
+commit refs/heads/master
+mark :11
+author User <user@localhost> 1427185440 +1300
+committer User <user@localhost> 1427185440 +1300
+data 6
+sure.
+from :9
+M 100644 :10 demo.txt
+
+blob
+mark :12
+data 0
+
+commit refs/heads/master
+mark :13
+author User <user@localhost> 1427185512 +1300
+committer User <user@localhost> 1427185516 +1300
+data 26
+not an actual readme, yet
+from :11
+M 100644 :12 readme.txt
+
+blob
+mark :14
+data 61
+This will for sure we will prove a problem exist somewhere.
+
+blob
+mark :15
+data 49
+okay fine add something here this is only a test
+
+commit refs/heads/master
+mark :16
+author User <user@localhost> 1427185569 +1300
+committer User <user@localhost> 1427185569 +1300
+data 12
+more things
+from :13
+M 100644 :14 demo.txt
+M 100644 :15 readme.txt
+
+blob
+mark :17
+data 100
+This will for sure we will prove a problem exist somewhere. 
+
+Just that we need a few more commits.
+
+commit refs/heads/master
+mark :18
+author User <user@localhost> 1427185659 +1300
+committer User <user@localhost> 1427185659 +1300
+data 13
+one more try
+from :16
+M 100644 :17 demo.txt
+
+blob
+mark :19
+data 54
+It might have something to do with number of commits?
+
+commit refs/heads/master
+mark :20
+author User <user@localhost> 1427185905 +1300
+committer User <user@localhost> 1427185905 +1300
+data 18
+is this number 9?
+from :18
+M 100644 :19 commitcount
+
+blob
+mark :21
+data 123
+This will for sure we will prove a problem exist somewhere. 
+
+Just that we need a few more commits.
+
+Hey look we need more
+
+commit refs/heads/master
+mark :22
+author User <user@localhost> 1427185922 +1300
+committer User <user@localhost> 1427185922 +1300
+data 5
+cool
+from :20
+M 100644 :21 demo.txt
+
+blob
+mark :23
+data 50
+Okay fine add something here this is only a test.
+
+commit refs/heads/master
+mark :24
+author User <user@localhost> 1427185936 +1300
+committer User <user@localhost> 1427185936 +1300
+data 7
+readme
+from :22
+M 100644 :23 readme.txt
+
+blob
+mark :25
+data 74
+Okay come on this is getting boring.
+
+Yes I went and edit all the things.
+
+commit refs/heads/master
+mark :26
+author User <user@localhost> 1427185954 +1300
+committer User <user@localhost> 1427185954 +1300
+data 14
+remove a line
+from :24
+M 100644 :25 demo.txt
+
+blob
+mark :27
+data 186
+Okay come on this is getting boring. 
+
+Yes I went and edit all the things. 
+
+Of course, making test data can be somewhat tedious, especially a
+minimum set that can be easily reproduced.
+
+commit refs/heads/master
+mark :28
+author User <user@localhost> 1427185996 +1300
+committer User <user@localhost> 1427185996 +1300
+data 25
+Getting serious mode on.
+from :26
+M 100644 :27 demo.txt
+
+blob
+mark :29
+data 48
+This is taking a bit longer than I remembered.
+
+commit refs/heads/master
+mark :30
+author User <user@localhost> 1427186065 +1300
+committer User <user@localhost> 1427186065 +1300
+data 40
+At least we will have things minimized.
+from :28
+M 100644 :29 demo.txt
+
+blob
+mark :31
+data 11
+there yet?
+
+commit refs/heads/master
+mark :32
+author User <user@localhost> 1427186080 +1300
+committer User <user@localhost> 1427186080 +1300
+data 7
+are we
+from :30
+M 100644 :31 demo.txt
+
+blob
+mark :33
+data 237
+This should be the head commit for the client repo for testing out
+the failure case reported in issue 88.  Just do a git pull from the
+repo that includes the following commit that is hosted with dulwich.
+The issue should be reproduced.
+
+commit refs/heads/master
+mark :34
+author User <user@localhost> 1427186109 +1300
+committer User <user@localhost> 1427186109 +1300
+data 6
+okay?
+from :32
+M 100644 :33 readme.txt

--- a/dulwich/tests/data/repos/issue88_expect_ack_nak_other.export
+++ b/dulwich/tests/data/repos/issue88_expect_ack_nak_other.export
@@ -1,0 +1,293 @@
+blob
+mark :1
+data 33
+We will sneak in a blob like so.
+
+reset refs/heads/master
+commit refs/heads/master
+mark :2
+author User <user@localhost> 1427183369 +1300
+committer User <user@localhost> 1427183369 +1300
+data 7
+sneaky
+M 100644 :1 problem.questionmark
+
+blob
+mark :3
+data 35
+We will introduce a problem here.
+
+
+commit refs/heads/master
+mark :4
+author User <user@localhost> 1427183376 +1300
+committer User <user@localhost> 1427183376 +1300
+data 11
+demo file.
+from :2
+M 100644 :3 demo.rst
+
+blob
+mark :5
+data 62
+We will introduce a problem here.
+
+This will take some time.
+
+
+commit refs/heads/master
+mark :6
+author User <user@localhost> 1427185135 +1300
+committer User <user@localhost> 1427185135 +1300
+data 13
+added a line
+from :4
+M 100644 :5 demo.rst
+
+blob
+mark :7
+data 57
+We will introduce a problem here.
+
+We will change these.
+
+commit refs/heads/master
+mark :8
+author User <user@localhost> 1427185245 +1300
+committer User <user@localhost> 1427185245 +1300
+data 14
+replace a linefrom :6
+M 100644 :7 demo.rst
+
+blob
+mark :9
+data 52
+We will change these.
+
+Then issues will be proven.
+
+
+commit refs/heads/master
+mark :10
+author User <user@localhost> 1427185343 +1300
+committer User <user@localhost> 1427185343 +1300
+data 13
+Yes we will.
+from :8
+M 100644 :9 demo.rst
+
+blob
+mark :11
+data 72
+We will change these. 
+
+Then issues will be construed once and for all.
+
+commit refs/heads/master
+mark :12
+author User <user@localhost> 1427185440 +1300
+committer User <user@localhost> 1427185440 +1300
+data 6
+sure.
+from :10
+M 100644 :11 demo.rst
+
+blob
+mark :13
+data 0
+
+commit refs/heads/master
+mark :14
+author User <user@localhost> 1427185512 +1300
+committer User <user@localhost> 1427185516 +1300
+data 26
+not an actual readme, yet
+from :12
+M 100644 :13 emdaer.txt
+
+blob
+mark :15
+data 58
+This will for sure we will prove issues exist somewhere.
+
+
+blob
+mark :16
+data 49
+okay fine add something here this is only a test
+
+commit refs/heads/master
+mark :17
+author User <user@localhost> 1427185569 +1300
+committer User <user@localhost> 1427185569 +1300
+data 12
+more things
+from :14
+M 100644 :15 demo.rst
+M 100644 :16 emdaer.txt
+
+blob
+mark :18
+data 97
+This will for sure prove issue exist somewhere.
+
+Just that we need a few more commits as usual.
+
+
+commit refs/heads/master
+mark :19
+author User <user@localhost> 1427185659 +1300
+committer User <user@localhost> 1427185659 +1300
+data 13
+one more try
+from :17
+M 100644 :18 demo.rst
+
+blob
+mark :20
+data 54
+It might have something to do with number of commits?
+
+commit refs/heads/master
+mark :21
+author User <user@localhost> 1427185905 +1300
+committer User <user@localhost> 1427185905 +1300
+data 18
+is this number 9?
+from :19
+M 100644 :20 count
+
+blob
+mark :22
+data 119
+This will for sure we will prove issues exist somewhere.
+
+Just that we need a few more commits.
+
+Hey look we need more
+
+commit refs/heads/master
+mark :23
+author User <user@localhost> 1427185922 +1300
+committer User <user@localhost> 1427185922 +1300
+data 5
+cool
+from :21
+M 100644 :22 demo.rst
+
+blob
+mark :24
+data 50
+Okay fine add something here this is only a test.
+
+commit refs/heads/master
+mark :25
+author User <user@localhost> 1427185936 +1300
+committer User <user@localhost> 1427185936 +1300
+data 7
+readme
+from :23
+M 100644 :24 emdaer.txt
+
+blob
+mark :26
+data 74
+Okay come on this is getting boring.
+
+Yes I went and edit all the things.
+
+commit refs/heads/master
+mark :27
+author User <user@localhost> 1427185954 +1300
+committer User <user@localhost> 1427185954 +1300
+data 14
+remove a line
+from :25
+M 100644 :26 demo.rst
+
+blob
+mark :28
+data 186
+Okay come on this is getting boring. 
+
+Yes I went and edit all the things. 
+
+Of course, making test data can be somewhat tedious, especially a
+minimum set that can be easily reproduced.
+
+commit refs/heads/master
+mark :29
+author User <user@localhost> 1427185996 +1300
+committer User <user@localhost> 1427185996 +1300
+data 25
+Getting serious mode on.
+from :27
+M 100644 :28 demo.rst
+
+blob
+mark :30
+data 48
+This is taking a bit longer than I remembered.
+
+
+commit refs/heads/master
+mark :31
+author User <user@localhost> 1427186065 +1300
+committer User <user@localhost> 1427186065 +1300
+data 40
+At least we will have things minimized.
+from :29
+M 100644 :30 demo.rst
+
+blob
+mark :32
+data 11
+there yet?
+
+commit refs/heads/master
+mark :33
+author User <user@localhost> 1427186080 +1300
+committer User <user@localhost> 1427186080 +1300
+data 7
+are we
+from :31
+M 100644 :32 demo.rst
+
+blob
+mark :34
+data 237
+This should be the head commit for the client repo for testing out
+the failure case reported in issue 88.  Just do a git pull from the
+repo that includes the following commit that is hosted with dulwich.
+The issue should be reproduced.
+
+
+commit refs/heads/master
+mark :35
+author User <user@localhost> 1427186109 +1300
+committer User <user@localhost> 1427186109 +1300
+data 6
+okay?
+from :33
+M 100644 :34 emdaer.txt
+
+blob
+mark :36
+data 394
+This should be the commit that will trigger the bug noted in issue 88
+(https://github.com/jelmer/dulwich/issues/88).  To reproduce, run git
+fast-import using this fast-export and host this using dulwich, and
+then make a copy of this, strip out this blob and the following commit
+block, import to another git repo and then git clone from the previous.
+
+Naturally, this is part of the test case.
+
+commit refs/heads/master
+mark :37
+author User <user@localhost> 1427244891 +1300
+committer User <user@localhost> 1427248186 +1300
+data 49
+Added instructions on how to use this to readme.
+from :35
+M 100644 :36 emdaer.txt
+

--- a/dulwich/tests/data/repos/issue88_expect_ack_nak_server.export
+++ b/dulwich/tests/data/repos/issue88_expect_ack_nak_server.export
@@ -47,7 +47,7 @@ commit refs/heads/master
 mark :7
 author User <user@localhost> 1427185245 +1300
 committer User <user@localhost> 1427185245 +1300
-data 23
+data 14
 replace a line
 from :5
 M 100644 :6 demo.txt

--- a/dulwich/tests/data/repos/issue88_expect_ack_nak_server.export
+++ b/dulwich/tests/data/repos/issue88_expect_ack_nak_server.export
@@ -1,0 +1,281 @@
+reset refs/heads/master
+commit refs/heads/master
+mark :1
+author User <user@localhost> 1427183369 +1300
+committer User <user@localhost> 1427183369 +1300
+data 6
+empty
+
+blob
+mark :2
+data 35
+We will reproduce a problem here.
+
+commit refs/heads/master
+mark :3
+author User <user@localhost> 1427183376 +1300
+committer User <user@localhost> 1427183376 +1300
+data 11
+demo file.
+from :1
+M 100644 :2 demo.txt
+
+blob
+mark :4
+data 62
+We will reproduce a problem here.
+
+This will take some time.
+
+commit refs/heads/master
+mark :5
+author User <user@localhost> 1427185135 +1300
+committer User <user@localhost> 1427185135 +1300
+data 13
+added a line
+from :3
+M 100644 :4 demo.txt
+
+blob
+mark :6
+data 57
+We will reproduce a problem here.
+
+We will change these.
+
+commit refs/heads/master
+mark :7
+author User <user@localhost> 1427185245 +1300
+committer User <user@localhost> 1427185245 +1300
+data 23
+replace a line
+from :5
+M 100644 :6 demo.txt
+
+blob
+mark :8
+data 52
+We will change these.
+
+Then issues will be proven.
+
+commit refs/heads/master
+mark :9
+author User <user@localhost> 1427185343 +1300
+committer User <user@localhost> 1427185343 +1300
+data 13
+Yes we will.
+from :7
+M 100644 :8 demo.txt
+
+blob
+mark :10
+data 69
+We will change these. 
+
+Then issues will be proven once and for all.
+
+commit refs/heads/master
+mark :11
+author User <user@localhost> 1427185440 +1300
+committer User <user@localhost> 1427185440 +1300
+data 6
+sure.
+from :9
+M 100644 :10 demo.txt
+
+blob
+mark :12
+data 0
+
+commit refs/heads/master
+mark :13
+author User <user@localhost> 1427185512 +1300
+committer User <user@localhost> 1427185516 +1300
+data 26
+not an actual readme, yet
+from :11
+M 100644 :12 readme.txt
+
+blob
+mark :14
+data 61
+This will for sure we will prove a problem exist somewhere.
+
+blob
+mark :15
+data 49
+okay fine add something here this is only a test
+
+commit refs/heads/master
+mark :16
+author User <user@localhost> 1427185569 +1300
+committer User <user@localhost> 1427185569 +1300
+data 12
+more things
+from :13
+M 100644 :14 demo.txt
+M 100644 :15 readme.txt
+
+blob
+mark :17
+data 100
+This will for sure we will prove a problem exist somewhere. 
+
+Just that we need a few more commits.
+
+commit refs/heads/master
+mark :18
+author User <user@localhost> 1427185659 +1300
+committer User <user@localhost> 1427185659 +1300
+data 13
+one more try
+from :16
+M 100644 :17 demo.txt
+
+blob
+mark :19
+data 54
+It might have something to do with number of commits?
+
+commit refs/heads/master
+mark :20
+author User <user@localhost> 1427185905 +1300
+committer User <user@localhost> 1427185905 +1300
+data 18
+is this number 9?
+from :18
+M 100644 :19 commitcount
+
+blob
+mark :21
+data 123
+This will for sure we will prove a problem exist somewhere. 
+
+Just that we need a few more commits.
+
+Hey look we need more
+
+commit refs/heads/master
+mark :22
+author User <user@localhost> 1427185922 +1300
+committer User <user@localhost> 1427185922 +1300
+data 5
+cool
+from :20
+M 100644 :21 demo.txt
+
+blob
+mark :23
+data 50
+Okay fine add something here this is only a test.
+
+commit refs/heads/master
+mark :24
+author User <user@localhost> 1427185936 +1300
+committer User <user@localhost> 1427185936 +1300
+data 7
+readme
+from :22
+M 100644 :23 readme.txt
+
+blob
+mark :25
+data 74
+Okay come on this is getting boring.
+
+Yes I went and edit all the things.
+
+commit refs/heads/master
+mark :26
+author User <user@localhost> 1427185954 +1300
+committer User <user@localhost> 1427185954 +1300
+data 14
+remove a line
+from :24
+M 100644 :25 demo.txt
+
+blob
+mark :27
+data 186
+Okay come on this is getting boring. 
+
+Yes I went and edit all the things. 
+
+Of course, making test data can be somewhat tedious, especially a
+minimum set that can be easily reproduced.
+
+commit refs/heads/master
+mark :28
+author User <user@localhost> 1427185996 +1300
+committer User <user@localhost> 1427185996 +1300
+data 25
+Getting serious mode on.
+from :26
+M 100644 :27 demo.txt
+
+blob
+mark :29
+data 48
+This is taking a bit longer than I remembered.
+
+commit refs/heads/master
+mark :30
+author User <user@localhost> 1427186065 +1300
+committer User <user@localhost> 1427186065 +1300
+data 40
+At least we will have things minimized.
+from :28
+M 100644 :29 demo.txt
+
+blob
+mark :31
+data 11
+there yet?
+
+commit refs/heads/master
+mark :32
+author User <user@localhost> 1427186080 +1300
+committer User <user@localhost> 1427186080 +1300
+data 7
+are we
+from :30
+M 100644 :31 demo.txt
+
+blob
+mark :33
+data 237
+This should be the head commit for the client repo for testing out
+the failure case reported in issue 88.  Just do a git pull from the
+repo that includes the following commit that is hosted with dulwich.
+The issue should be reproduced.
+
+commit refs/heads/master
+mark :34
+author User <user@localhost> 1427186109 +1300
+committer User <user@localhost> 1427186109 +1300
+data 6
+okay?
+from :32
+M 100644 :33 readme.txt
+
+blob
+mark :35
+data 394
+This should be the commit that will trigger the bug noted in issue 88
+(https://github.com/jelmer/dulwich/issues/88).  To reproduce, run git
+fast-import using this fast-export and host this using dulwich, and
+then make a copy of this, strip out this blob and the following commit
+block, import to another git repo and then git clone from the previous.
+
+Naturally, this is part of the test case.
+
+commit refs/heads/master
+mark :36
+author User <user@localhost> 1427244891 +1300
+committer User <user@localhost> 1427248186 +1300
+data 49
+Added instructions on how to use this to readme.
+from :34
+M 100644 :35 readme.txt
+

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -650,8 +650,8 @@ class ReceivePackTests(PorcelainTestCase):
         exitcode = porcelain.receive_pack(self.repo.path, BytesIO("0000"), outf)
         outlines = outf.getvalue().splitlines()
         self.assertEqual([
-            '005a9e65bdcf4a22cdd4f3700604a275cd2aaf146b23 HEAD\x00report-status '
-            'delete-refs side-band-64k',
+            '00629e65bdcf4a22cdd4f3700604a275cd2aaf146b23 HEAD\x00report-status '
+            'delete-refs side-band-64k no-done',
             '003f9e65bdcf4a22cdd4f3700604a275cd2aaf146b23 refs/heads/master',
             '0000'], outlines)
         self.assertEqual(0, exitcode)

--- a/dulwich/tests/test_server.py
+++ b/dulwich/tests/test_server.py
@@ -739,14 +739,14 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNextEquals(ONE)
         self._walker.done = True
         self._impl.ack(ONE)
-        self.assertAcks([(ONE, 'common'), (ONE, 'ready')])
+        self.assertAck(ONE, 'common')
 
         self.assertNextEquals(THREE)
         self._impl.ack(THREE)
-        self.assertAck(THREE, 'ready')
+        self.assertAck(THREE, 'common')
 
         self.assertNextEquals(None)
-        self.assertAck(THREE)
+        self.assertAcks([(THREE, 'ready'), (THREE, '')])
 
     def test_multi_ack_partial(self):
         self.assertNextEquals(TWO)
@@ -780,14 +780,14 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
 
         self._walker.done = True
         self._impl.ack(ONE)
-        self.assertAcks([(ONE, 'common'), (ONE, 'ready')])
+        self.assertAck(ONE, 'common')
 
         self.assertNextEquals(THREE)
         self._impl.ack(THREE)
-        self.assertAck(THREE, 'ready')
+        self.assertAck(THREE, 'common')
 
         self.assertNextEquals(None)
-        self.assertAck(THREE)
+        self.assertAcks([(THREE, 'ready'), (THREE, '')])
 
     def test_multi_ack_nak(self):
         self.assertNextEquals(TWO)

--- a/dulwich/tests/test_server.py
+++ b/dulwich/tests/test_server.py
@@ -707,8 +707,6 @@ class MultiAckGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(None)
-        # done, re-send ack of last common
-        self._walker.done = True
         self.assertNextEmpty()
         self.assertAck(ONE)
 
@@ -726,7 +724,6 @@ class MultiAckGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNextEquals(ONE)
         self.assertNak()  # nak the flush-pkt
 
-        self._walker.done = True
         self._impl.ack(ONE)
         self.assertAck(ONE, 'continue')
 
@@ -749,7 +746,6 @@ class MultiAckGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(None)
-        self._walker.done = True
         self.assertNextEmpty()
         self.assertNak()
 
@@ -806,7 +802,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(ONE)
-        self._walker.done = True
         self._impl.ack(ONE)
         self.assertAck(ONE, 'common')
 
@@ -828,7 +823,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(ONE)
-        self._walker.done = True
         self._impl.ack(ONE)
         self.assertAck(ONE, 'common')
 
@@ -853,7 +847,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(None)
-        self._walker.done = True
         self.assertNextEmpty()
         self.assertAck(ONE)
 
@@ -873,7 +866,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNextEquals(ONE)
         self.assertNak()  # nak the flush-pkt
 
-        self._walker.done = True
         self._impl.ack(ONE)
         self.assertAck(ONE, 'common')
 
@@ -897,7 +889,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(None)
-        self._walker.done = True
         self.assertNextEmpty()
         self.assertNak()
 
@@ -912,7 +903,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(None)
-        self._walker.done = True
         self.assertNextEmpty()
         self.assertNak()
 
@@ -935,7 +925,6 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(None)
-        self._walker.done = True
         self.assertNextEmpty()
         self.assertNak()
 

--- a/dulwich/tests/test_server.py
+++ b/dulwich/tests/test_server.py
@@ -613,7 +613,6 @@ class SingleAckGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(ONE)
-        self._walker.done = True
         self._impl.ack(ONE)
         self.assertAck(ONE)
 
@@ -632,7 +631,6 @@ class SingleAckGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNoAck()
 
         self.assertNextEquals(ONE)
-        self._walker.done = True
         self._impl.ack(ONE)
         self.assertAck(ONE)
 

--- a/dulwich/tests/test_server.py
+++ b/dulwich/tests/test_server.py
@@ -532,6 +532,7 @@ class TestProtocolGraphWalker(object):
         self.done_required = True
         self.done_received = False
         self._empty = False
+        self.pack_sent = False
 
     def read_proto_line(self, allowed):
         command, sha = self.lines.pop(0)
@@ -557,7 +558,11 @@ class TestProtocolGraphWalker(object):
     def handle_done(self):
         if not self._impl:
             return
-        self._impl.handle_done(self.done_required, self.done_received)
+        # Whether or not PACK is sent after is determined by this, so
+        # record this value.
+        self.pack_sent = self._impl.handle_done(self.done_required,
+            self.done_received)
+        return self.pack_sent
 
     def notify_done(self):
         self.done_received = True
@@ -773,6 +778,8 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self._walker.lines.append((None, None))
         self.assertNextEmpty()
         self.assertAcks([(THREE, 'ready'), (None, 'nak'), (THREE, '')])
+        # PACK is sent
+        self.assertTrue(self._walker.pack_sent)
 
     def test_multi_ack_nodone(self):
         self._walker.done_required = False
@@ -793,6 +800,8 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self._walker.lines.append((None, None))
         self.assertNextEmpty()
         self.assertAcks([(THREE, 'ready'), (None, 'nak'), (THREE, '')])
+        # PACK is sent
+        self.assertTrue(self._walker.pack_sent)
 
     def test_multi_ack_flush_end(self):
         # transmission ends with a flush-pkt without a done but no-done is
@@ -813,6 +822,8 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self._walker.wants_satisified = True
         self.assertNextEmpty()
         self.assertAcks([(THREE, 'ready'), (None, 'nak')])
+        # PACK is NOT sent
+        self.assertFalse(self._walker.pack_sent)
 
     def test_multi_ack_flush_end_nodone(self):
         # transmission ends with a flush-pkt without a done but no-done is
@@ -834,6 +845,8 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self._walker.wants_satisified = True
         self.assertNextEmpty()
         self.assertAcks([(THREE, 'ready'), (None, 'nak'), (THREE, '')])
+        # PACK is sent
+        self.assertTrue(self._walker.pack_sent)
 
     def test_multi_ack_partial(self):
         self.assertNextEquals(TWO)
@@ -888,11 +901,15 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNextEquals(THREE)
         self.assertNoAck()
 
+        # Done is sent here.
         self.assertNextEquals(None)
         self.assertNextEmpty()
         self.assertNak()
+        self.assertNextEmpty()
+        self.assertTrue(self._walker.pack_sent)
 
-    def test_multi_ack_nak(self):
+    def test_multi_ack_nak_nodone(self):
+        self._walker.done_required = False
         self.assertNextEquals(TWO)
         self.assertNoAck()
 
@@ -902,9 +919,13 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNextEquals(THREE)
         self.assertNoAck()
 
+        # Done is sent here.
+        self.assertFalse(self._walker.pack_sent)
         self.assertNextEquals(None)
         self.assertNextEmpty()
+        self.assertTrue(self._walker.pack_sent)
         self.assertNak()
+        self.assertNextEmpty()
 
     def test_multi_ack_nak_flush(self):
         # same as nak test but contains a flush-pkt in the middle
@@ -942,11 +963,37 @@ class MultiAckDetailedGraphWalkerImplTestCase(AckGraphWalkerImplTestCase):
         self.assertNextEquals(THREE)
         self.assertNoAck()
 
+        self.assertFalse(self._walker.pack_sent)
         self.assertNextEquals(None)
         self.assertNak()
 
         self.assertNextEmpty()
         self.assertNoAck()
+        self.assertFalse(self._walker.pack_sent)
+
+    def test_multi_ack_stateless_nodone(self):
+        self._walker.done_required = False
+        # transmission ends with a flush-pkt
+        self._walker.lines[-1] = (None, None)
+        self._walker.http_req = True
+
+        self.assertNextEquals(TWO)
+        self.assertNoAck()
+
+        self.assertNextEquals(ONE)
+        self.assertNoAck()
+
+        self.assertNextEquals(THREE)
+        self.assertNoAck()
+
+        self.assertFalse(self._walker.pack_sent)
+        self.assertNextEquals(None)
+        self.assertNak()
+
+        self.assertNextEmpty()
+        self.assertNoAck()
+        # PACK will still not be sent.
+        self.assertFalse(self._walker.pack_sent)
 
 
 @skipIfPY3


### PR DESCRIPTION
The gist of this gnarly problem is that it looks like the implementation over HTTP behaves as-if the `no-done` capability was enabled but unspecified so the reference client would make a second round trip back with more `haves` but then it doesn't know what to do with the `PACK` that was already sent. Alternatively there are cases where the side-band was used when it was expecting ACK/NAK. There were multiple problems with the code base that made this issue rather hard to stomp out, and here are the fixes (some verbatim from commit messages).

- `MultiAckDetailedGraphWalkerImpl` rebuilt to ensure output generated
  matches the reference implementation, like the git-http-backend. (Even though this is not strictly necessary, repeatedly calling `all_wants_specified` doesn't really change much given that there's only one place where the commits can be added in, which is by the object store through the `ack` method.

- Correction to the communication after all `have` lines have been processed. As a freebie I got `no-done` capability implemented since that's what it looked like before.

- There is another issue where attempts to pull an unrelated repo, the
  various combination of the previous flaws made it difficult to send
  the correct number of NAKs.  Removing the walker.send_ack call from
  the walker implementation and just ensure the ack is the only method
  that will call send_ack simplifies the process of correcting this.

- Added various state variables to the handler to track whether the `done` token is expected.

- Added a couple methods to deal with the handling of the above state variables, which the walker implementations themselves have access to through a method provided by the generic protocol walker class

- Added a method to the graph walker that takes in the state variables provided by the handler to delegate the dealing of the final ACK/NAK line that ends the section to permit the PACK section to begin, which then gets delegated to the Impl instances (which also have been normalized to address this).

- Finally, cleaned up the test cases and added further tests where relevant. Naturally 
one of the earlier commits introduce some test examples that demonstrates this problem.
