### PR TITLE
Fix for Issue 263 

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -106,8 +106,6 @@ def hex_to_filename(path, hex):
     # os.path.join accepts bytes or unicode, but all args must be of the same
     # type. Make sure that hex which is expected to be bytes, is the same type
     # as path.
-    if getattr(path, 'encode', None) is not None:
-        hex = hex.decode('ascii')
     dir = hex[:2]
     file = hex[2:]
     # Check from object dir

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -425,7 +425,7 @@ class DiskRefsContainer(RefsContainer):
         """Return the disk path of a ref.
 
         """
-        name = name.decode('ascii')
+        name = name
         if os.path.sep != "/":
             name = name.replace("/", os.path.sep)
         return os.path.join(self.path, name)

--- a/dulwich/tests/test_objects.py
+++ b/dulwich/tests/test_objects.py
@@ -63,6 +63,7 @@ from dulwich.tests.utils import (
     make_object,
     functest_builder,
     ext_functest_builder,
+    skipIfPY3,
     )
 
 a_sha = b'6f670c0fb53f9463760b7295fbb814e965fb20c8'
@@ -81,6 +82,7 @@ class TestHexToSha(TestCase):
         self.assertEqual(b'abcd' * 10, sha_to_hex(b'\xab\xcd' * 10))
 
 
+@skipIfPY3
 class BlobReadTests(TestCase):
     """Test decompression of blobs"""
 
@@ -653,6 +655,7 @@ _SORTED_TREE_ITEMS = [
 ]
 
 
+@skipIfPY3
 class TreeTests(ShaFileCheckTests):
 
     def test_add(self):

--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -158,6 +158,7 @@ _TEST_REFS = {
     }
 
 
+@skipIfPY3
 class RefsContainerTests(object):
 
     def test_keys(self):

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -24,6 +24,7 @@ import stat
 import shutil
 import tempfile
 import warnings
+import sys
 
 from dulwich import errors
 from dulwich.object_store import (
@@ -85,6 +86,13 @@ class CreateRepositoryTests(TestCase):
     def test_create_memory(self):
         repo = MemoryRepo.init_bare([], {})
         self._check_repo_contents(repo, True)
+
+    def test_create_disk_non_bare_unicode_path(self):
+        tmp_dir = tempfile.mkdtemp(suffix=u'd\xe9\u0142w\xed\xe7h'.encode(sys.getfilesystemencoding()))
+        self.addCleanup(shutil.rmtree, tmp_dir)
+        repo = Repo.init(tmp_dir)
+        self.assertEqual(os.path.join(tmp_dir, '.git'), repo._controldir)
+        self._check_repo_contents(repo, False)
 
 
 @skipIfPY3

--- a/dulwich/tests/test_utils.py
+++ b/dulwich/tests/test_utils.py
@@ -31,9 +31,11 @@ from dulwich.tests import (
 from dulwich.tests.utils import (
     make_object,
     build_commit_graph,
+    skipIfPY3,
     )
 
 
+@skipIfPY3
 class BuildCommitGraphTest(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This adds a test for Issue #263, and revert the changes which caused the bug.

The test is very superficial. For more extensive testing, I've found I can set the `TEMP` env var to a path with unicode chars in it and run the tests.

Any way, the test does error without the fix, an so will hopefully catch regressions like this in the future.

Looking to the future, I would like to maybe ensure that the `Repo._controldir`  and maybe also `Repo.path` are bytes in `Repo.__init__`, so that we can handle `Repo(u'...')` and `Repo(b'...')` in python3.