### PR TITLE
Fix test_client.TestGetTransportAndPath.test_local_abs_windows_path

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1135,7 +1135,7 @@ def get_transport_and_path(location, **kwargs):
         pass
 
     if (sys.platform == 'win32' and
-            location[0].isalpha() and location[1:2] == ':\\'):
+            location[0].isalpha() and location[1:3] == ':\\'):
         # Windows local path
         return default_local_git_client_cls(**kwargs), location
 


### PR DESCRIPTION
This fixes a bug from a mistake I made. I'm not sure how I did not pick it up. I probably changed it and did not run the test, and the test dose not run on travis as it is windows only.