### PR TITLE
Buffer the subpocess.stdout files for SubprocessGitClient on python3.

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -38,7 +38,7 @@ Known capabilities that are not supported:
 
 __docformat__ = 'restructuredText'
 
-from io import BytesIO
+from io import BytesIO, BufferedReader
 import dulwich
 import select
 import socket
@@ -625,7 +625,10 @@ class SubprocessWrapper(object):
 
     def __init__(self, proc):
         self.proc = proc
-        self.read = proc.stdout.read
+        if sys.version_info[0] == 2:
+            self.read = proc.stdout.read
+        else:
+            self.read = BufferedReader(proc.stdout).read
         self.write = proc.stdin.write
 
     def can_read(self):


### PR DESCRIPTION
We have been getting intermittent `GitProtocolError:  Length of pkt read....` errors on Python 3. e.g.: https://travis-ci.org/jelmer/dulwich/jobs/59521569 .  

I can reliably reproduces this by running multiple instances of the test suite from pycharm. I think it happens when the system IO queues are long.

This is due to a change in the way `subprocess.POpen(bufsize=0` works in python3 vs python2. See. http://bugs.python.org/issue17488 

We still need a `bufsize=0` on the stdin, but need the stdout to be buffered. This patch dose this by wrapping the stderr in a io.BufferedReader.