### PR TITLE
Removing .git dirs requires a bit more effort on windows.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,11 @@
     open resources. (Gary van der Merwe)
   * Support 'git.bat' in SubprocessGitClient on Windows.
     (Stefan Zimmermann)
+  * Switched `default_local_git_client_cls` to `LocalGitClient`.
+    (Gary van der Merwe)
+  * `get_transport_and_path_from_url` and `get_transport_and_path` now accept
+    a new `local_git_client_cls` argument that can be used to override the
+    `default_local_git_client_cls`. (Gary van der Merwe)
 
 0.10.1  2015-03-25
 

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -725,7 +725,7 @@ class LocalGitClient(GitClient):
 
         with closing(Repo(path)) as target:
             old_refs = target.get_refs()
-            new_refs = determine_wants(old_refs)
+            new_refs = determine_wants(dict(old_refs))
 
             have = [sha1 for sha1 in old_refs.values() if sha1 != ZERO_SHA]
             want = []
@@ -779,10 +779,6 @@ class LocalGitClient(GitClient):
             if objects_iter is None:
                 return
             write_pack_objects(ProtocolFile(None, pack_data), objects_iter)
-
-
-# What Git client to use for local access
-default_local_git_client_cls = SubprocessGitClient
 
 
 class SSHVendor(object):
@@ -1133,17 +1129,23 @@ class HttpGitClient(GitClient):
         finally:
             resp.close()
 
+# What Git client to use for local access
+default_local_git_client_cls = LocalGitClient
 
-def get_transport_and_path_from_url(url, config=None, **kwargs):
+def get_transport_and_path_from_url(url, local_git_client_cls=None, config=None, **kwargs):
     """Obtain a git client from a URL.
 
     :param url: URL to open
+    :param local_git_client_cls: Class to use for local (file) urls.
     :param config: Optional config object
     :param thin_packs: Whether or not thin packs should be retrieved
     :param report_activity: Optional callback for reporting transport
         activity.
     :return: Tuple with client instance and relative path.
     """
+    if local_git_client_cls is None:
+        local_git_client_cls = default_local_git_client_cls
+
     parsed = urlparse.urlparse(url)
     if parsed.scheme == 'git':
         return (TCPGitClient(parsed.hostname, port=parsed.port, **kwargs),
@@ -1158,31 +1160,37 @@ def get_transport_and_path_from_url(url, config=None, **kwargs):
         return HttpGitClient(urlparse.urlunparse(parsed), config=config,
                 **kwargs), parsed.path
     elif parsed.scheme == 'file':
-        return default_local_git_client_cls(**kwargs), parsed.path
+        return local_git_client_cls(**kwargs), parsed.path
 
     raise ValueError("unknown scheme '%s'" % parsed.scheme)
 
 
-def get_transport_and_path(location, **kwargs):
+def get_transport_and_path(location, local_git_client_cls=None, **kwargs):
     """Obtain a git client from a URL.
 
     :param location: URL or path
+    :param local_git_client_cls: Class to use for local locations.
     :param config: Optional config object
     :param thin_packs: Whether or not thin packs should be retrieved
     :param report_activity: Optional callback for reporting transport
         activity.
     :return: Tuple with client instance and relative path.
     """
+
+    if local_git_client_cls is None:
+        local_git_client_cls = default_local_git_client_cls
+
     # First, try to parse it as a URL
     try:
-        return get_transport_and_path_from_url(location, **kwargs)
+        return get_transport_and_path_from_url(
+            location, local_git_client_cls=local_git_client_cls, **kwargs)
     except ValueError:
         pass
 
     if (sys.platform == 'win32' and
             location[0].isalpha() and location[1:3] == ':\\'):
         # Windows local path
-        return default_local_git_client_cls(**kwargs), location
+        return local_git_client_cls(**kwargs), location
 
     if ':' in location and not '@' in location:
         # SSH with no user@, zero or one leading slash.
@@ -1195,4 +1203,4 @@ def get_transport_and_path(location, **kwargs):
         return SSHGitClient(host, username=user, **kwargs), path
 
     # Otherwise, assume it's a local path.
-    return default_local_git_client_cls(**kwargs), location
+    return local_git_client_cls(**kwargs), location

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -1041,7 +1041,7 @@ class MissingObjectFinder(object):
         if sha in self._tagged:
             self.add_todo([(self._tagged[sha], None, True)])
         self.sha_done.add(sha)
-        self.progress("counting objects: %d\r" % len(self.sha_done))
+        self.progress(("counting objects: %d\r" % len(self.sha_done)).encode('ascii'))
         return (sha, name)
 
     __next__ = next

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -56,7 +56,10 @@ import os
 import sys
 import time
 
-from dulwich.client import get_transport_and_path
+from dulwich.client import (
+    get_transport_and_path,
+    SubprocessGitClient,
+    )
 from dulwich.errors import (
     SendPackError,
     UpdateRefsError,
@@ -116,7 +119,8 @@ def archive(location, committish=None, outstream=sys.stdout,
     :param errstream: Error stream (defaults to stderr)
     """
 
-    client, path = get_transport_and_path(location)
+    client, path = get_transport_and_path(
+        location, local_git_client_cls=SubprocessGitClient)
     if committish is None:
         committish = "HEAD"
     # TODO(jelmer): This invokes C git; this introduces a dependency.

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -387,15 +387,15 @@ class TestGetTransportAndPath(TestCase):
         self.assertEqual('user', c.username)
         self.assertEqual('bar/baz', path)
 
-    def test_subprocess(self):
+    def test_local(self):
         c, path = get_transport_and_path('foo.bar/baz')
-        self.assertTrue(isinstance(c, SubprocessGitClient))
+        self.assertTrue(isinstance(c, LocalGitClient))
         self.assertEqual('foo.bar/baz', path)
 
     @skipIf(sys.platform != 'win32', 'Behaviour only happens on windows.')
     def test_local_abs_windows_path(self):
         c, path = get_transport_and_path('C:\\foo.bar\\baz')
-        self.assertTrue(isinstance(c, SubprocessGitClient))
+        self.assertTrue(isinstance(c, LocalGitClient))
         self.assertEqual('C:\\foo.bar\\baz', path)
 
     def test_error(self):
@@ -409,6 +409,12 @@ class TestGetTransportAndPath(TestCase):
         c, path = get_transport_and_path(url)
         self.assertTrue(isinstance(c, HttpGitClient))
         self.assertEqual('/jelmer/dulwich', path)
+
+    def test_local_specified_cls(self):
+        c, path = get_transport_and_path(
+            'foo.bar/baz', local_git_client_cls=SubprocessGitClient)
+        self.assertTrue(isinstance(c, SubprocessGitClient))
+        self.assertEqual('foo.bar/baz', path)
 
 
 class TestGetTransportAndPathFromUrl(TestCase):
@@ -485,6 +491,12 @@ class TestGetTransportAndPathFromUrl(TestCase):
 
     def test_file(self):
         c, path = get_transport_and_path_from_url('file:///home/jelmer/foo')
+        self.assertTrue(isinstance(c, LocalGitClient))
+        self.assertEqual('/home/jelmer/foo', path)
+
+    def test_file_specified_local_cls(self):
+        c, path = get_transport_and_path_from_url(
+            'file:///home/jelmer/foo', local_git_client_cls=SubprocessGitClient)
         self.assertTrue(isinstance(c, SubprocessGitClient))
         self.assertEqual('/home/jelmer/foo', path)
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -473,13 +473,12 @@ class PushTests(PorcelainTestCase):
 
         # Check that the target and source
         with closing(Repo(clone_path)) as r_clone:
+            self.assertEqual(r_clone[b'HEAD'].id, self.repo[refs_path].id)
 
             # Get the change in the target repo corresponding to the add
             # this will be in the foo branch.
             change = list(tree_changes(self.repo, self.repo[b'HEAD'].tree,
                                        self.repo[b'refs/heads/foo'].tree))[0]
-
-            self.assertEqual(r_clone[b'HEAD'].id, self.repo[refs_path].id)
             self.assertEqual(os.path.basename(fullpath), change.new.path.decode('ascii'))
 
 


### PR DESCRIPTION
shutils.rmtree on .git dirs fails on windows due to the read only attribute being set, so we need to do some additional work to unset the attribute.