### PR TITLE
Support git.bat on Windows

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -663,7 +663,14 @@ class SubprocessGitClient(TraditionalGitClient):
 
     git = ['git']
     if sys.platform == 'win32': # support .exe, .bat and .cmd
-        git = ['cmd', '/c'] + git
+        try: # to avoid overhead
+            import win32api
+        except ImportError: # run through cmd.exe with some overhead
+            git = ['cmd', '/c'] + git
+        else:
+            status, git = win32api.FindExecutable('git')
+            #TODO: need to check status? (exc is raised if not found)
+            git = [git]
 
     def _connect(self, service, path):
         import subprocess

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -46,8 +46,6 @@ import socket
 import subprocess
 import sys
 
-WIN = sys.platform.startswith('win')
-
 try:
     import urllib2
     import urlparse
@@ -663,11 +661,13 @@ class SubprocessGitClient(TraditionalGitClient):
             del kwargs['stderr']
         TraditionalGitClient.__init__(self, *args, **kwargs)
 
+    git = ['git']
+    if sys.platform == 'win32': # support .exe, .bat and .cmd
+        git = ['cmd', '/c'] + git
+
     def _connect(self, service, path):
         import subprocess
-        argv = ['git', service, path]
-        if WIN: # support git.exe and git.bat
-            argv = ['cmd', '/c'] + argv
+        argv = self.git + [service, path]
         p = SubprocessWrapper(
             subprocess.Popen(argv, bufsize=0, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -46,6 +46,8 @@ import socket
 import subprocess
 import sys
 
+WIN = sys.platform.startswith('win')
+
 try:
     import urllib2
     import urlparse
@@ -664,6 +666,8 @@ class SubprocessGitClient(TraditionalGitClient):
     def _connect(self, service, path):
         import subprocess
         argv = ['git', service, path]
+        if WIN: # support git.exe and git.bat
+            argv = ['cmd', '/c'] + argv
         p = SubprocessWrapper(
             subprocess.Popen(argv, bufsize=0, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,


### PR DESCRIPTION
I have only __git.bat__ in my Windows PATH, which made dulwich always complain about the missing __git__ executable :) I changed the `Popen` call to prepend `['cmd', '/c']` on Windows. Now __git.bat__ works as well as __git.exe__