### PR TITLE
Improve handling of unicode checkout paths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,13 @@
     open resources. (Gary van der Merwe)
   * Support 'git.bat' in SubprocessGitClient on Windows.
     (Stefan Zimmermann)
+  * For methods that deal with the transition between checkout files and tree
+    entries, the unicode handling of paths has changed. By default, on unix
+    systems, the path in bytes form is simply copied (this is unchanged), and
+    Windows system, the tree path encoding is assumed to be utf-8. On all
+    systems, the encoding of tree paths can be specified by the tree_encoding
+    argument. This can be use to translate a tree with path encoding different
+    to that of the filesystem. (Gary van der Merwe)
 
 0.10.1  2015-03-25
 

--- a/docs/tutorial/repo.txt
+++ b/docs/tutorial/repo.txt
@@ -53,7 +53,7 @@ so only non-bare repositories will have an index, too. To open the index, simply
 call::
 
     >>> index = repo.open_index()
-    >>> print(index.path.decode(sys.getfilesystemencoding()))
+    >>> print(index.path)
     myrepo/.git/index
 
 Since the repository was just created, the index will be empty::
@@ -71,11 +71,11 @@ aren't tracked explicitly by git. Let's create a simple text file and stage it::
     >>> _ = f.write(b"monty")
     >>> f.close()
 
-    >>> repo.stage([b"foo"])
+    >>> repo.stage(["foo"])
 
 It will now show up in the index::
 
-    >>> print(",".join([f.decode(sys.getfilesystemencoding()) for f in repo.open_index()]))
+    >>> print(b",".join(repo.open_index()))
     foo
 
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -240,11 +240,12 @@ def clone(source, target=None, bare=False, checkout=None, errstream=sys.stdout, 
     return r
 
 
-def add(repo=".", paths=None):
+def add(repo=".", paths=None, tree_encoding=None):
     """Add files to the staging area.
 
     :param repo: Repository for the files
     :param paths: Paths to add.  No value passed stages all modified files.
+    :param tree_encoding: Unicode encoding of the Git tree.
     """
     # FIXME: Support patterns, directories.
     with open_repo_closing(repo) as r:
@@ -257,7 +258,7 @@ def add(repo=".", paths=None):
                     dirnames.remove('.git')
                 for filename in filenames:
                     paths.append(os.path.join(dirpath[len(r.path)+1:], filename))
-        r.stage(paths)
+        r.stage(paths, tree_encoding)
 
 
 def rm(repo=".", paths=None):
@@ -570,10 +571,11 @@ def pull(repo, remote_location, refs_path,
         r.reset_index()
 
 
-def status(repo="."):
+def status(repo=".", tree_encoding=None):
     """Returns staged, unstaged, and untracked changes relative to the HEAD.
 
     :param repo: Path to repository or repository object
+    :param tree_encoding: Unicode encoding of the Git tree.
     :return: GitStatus tuple,
         staged -    list of staged paths (diff index/HEAD)
         unstaged -  list of unstaged paths (diff index/working-tree)
@@ -583,7 +585,7 @@ def status(repo="."):
         # 1. Get status of staged
         tracked_changes = get_tree_changes(r)
         # 2. Get status of unstaged
-        unstaged_changes = list(get_unstaged_changes(r.open_index(), r.path))
+        unstaged_changes = list(get_unstaged_changes(r.open_index(), r.path, tree_encoding))
         # TODO - Status of untracked - add untracked changes, need gitignore.
         untracked_changes = []
         return GitStatus(tracked_changes, unstaged_changes, untracked_changes)


### PR DESCRIPTION
We currently have 2 issues with the way we handle unicode checkout paths:

* Issue #203. On windows, the file system api is unicode, and so we can't just store the bytes of the path and not care about the encoding, as we do on unix. 

* We use to just store the bytes from the tree path as the filesystem path. But we no longer do this (due to a change from the python3 porting.)  This means we used to be able to checkout the following repo with delwich 0.10.1, but can no longer do so:  `git@github.com:garyvdm/git_unicode_files2.git`

So this PR fixes this by making methods that deal with the transition between checkout files and tree entries work in the following way:

* By default, on unix systems, the path in bytes form is simply copied, (Back to how it was before.)
* By default on windows system, the tree path encoding is assumed to be utf-8, and the decoded unicode path is used to write to the filesystem, and an encoded path is used to write to a git tree.
* On all systems, the encoding of tree paths can be specified by a new `tree_encoding` argument. This could be use to translate a tree with path encoding different to that of the encoding of the filesystem.

Note that this PR includes the commits from PR #284. 