### PR TITLE
Improve handling of checkout paths

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -463,13 +463,13 @@ def validate_path(path, element_validator=validate_path_element_default):
         return True
 
 
-def build_index_from_tree(prefix, index_path, object_store, tree_id,
+def build_index_from_tree(root_path, index_path, object_store, tree_id,
                           honor_filemode=True,
                           validate_path_element=validate_path_element_default):
     """Generate and materialize index from a tree
 
     :param tree_id: Tree to materialize
-    :param prefix: Target dir for materialized index files
+    :param root_path: Target dir for materialized index files
     :param index_path: Target path for generated index
     :param object_store: Non-empty object store holding tree contents
     :param honor_filemode: An optional flag to honor core.filemode setting in
@@ -486,7 +486,8 @@ def build_index_from_tree(prefix, index_path, object_store, tree_id,
     for entry in object_store.iter_tree_contents(tree_id):
         if not validate_path(entry.path, validate_path_element):
             continue
-        full_path = os.path.join(prefix, entry.path.decode(sys.getfilesystemencoding()))
+        fs_path = tree_to_fs_path(entry.path.decode(sys.getfilesystemencoding()))
+        full_path = os.path.join(root_path, fs_path)
 
         if not os.path.exists(os.path.dirname(full_path)):
             os.makedirs(os.path.dirname(full_path))
@@ -502,37 +503,66 @@ def build_index_from_tree(prefix, index_path, object_store, tree_id,
     index.write()
 
 
-def blob_from_path_and_stat(path, st):
+def blob_from_path_and_stat(fs_path, st):
     """Create a blob from a path and a stat object.
 
-    :param path: Full path to file
+    :param fs_path: Full file system path to file
     :param st: A stat object
     :return: A `Blob` object
     """
     blob = Blob()
     if not stat.S_ISLNK(st.st_mode):
-        with open(path, 'rb') as f:
+        with open(fs_path, 'rb') as f:
             blob.data = f.read()
     else:
         if platform.python_implementation() == 'PyPy':
             # os.readlink on pypy seems to require bytes
             # TODO: GaryvdM: test on other pypy configurations,
             # e.g. windows, pypy3.
-            path = path.encode(sys.getfilesystemencoding())
-        blob.data = os.readlink(path).encode(sys.getfilesystemencoding())
+            fs_path = fs_path.encode(sys.getfilesystemencoding())
+        blob.data = os.readlink(fs_path).encode(sys.getfilesystemencoding())
     return blob
 
 
-def get_unstaged_changes(index, path):
+def get_unstaged_changes(index, root_path):
     """Walk through an index and check for differences against working tree.
 
     :param index: index to check
-    :param path: path in which to find files
+    :param root_path: path in which to find files
     :return: iterator over paths with unstaged changes
     """
     # For each entry in the index check the sha1 & ensure not staged
-    for name, entry in index.iteritems():
-        fp = os.path.join(path, name.decode(sys.getfilesystemencoding()))
-        blob = blob_from_path_and_stat(fp, os.lstat(fp))
+    for tree_path, entry in index.iteritems():
+        fs_path = tree_to_fs_path(tree_path.decode(sys.getfilesystemencoding()))
+        full_path = os.path.join(root_path, fs_path)
+        blob = blob_from_path_and_stat(full_path, os.lstat(full_path))
         if blob.id != entry.sha:
-            yield name
+            yield tree_path
+
+
+def tree_to_fs_path(tree_path):
+    """Convert a git tree path to a file system path.
+
+    :param tree_path: Git tree path as bytes
+
+    :return: File system path.
+    """
+    if os.sep != '/':
+        sep_corrected_path = tree_path.replace(b'/', os.sep)
+    else:
+        sep_corrected_path = tree_path
+    return sep_corrected_path
+
+
+def fs_to_tree_path(fs_path):
+    """Convert a git tree path to a file system path.
+
+    :param fs_path: File system path.
+
+    :return:  Git tree path as bytes
+    """
+    if os.sep != '/':
+        tree_path = fs_path.replace(os.sep, '/')
+    else:
+        tree_path = fs_path
+    return tree_path

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -730,32 +730,34 @@ class Repo(BaseRepo):
         # missing index file, which is treated as empty.
         return not self.bare
 
-    def stage(self, paths, fsencoding=sys.getfilesystemencoding()):
+    def stage(self, fs_paths, fsencoding=sys.getfilesystemencoding()):
         """Stage a set of paths.
 
-        :param paths: List of paths, relative to the repository path
+        :param fs_paths: List of paths, relative to the repository path
         """
-        if not isinstance(paths, list):
-            paths = [paths]
+        if not isinstance(fs_paths, list):
+            fs_paths = [fs_paths]
         from dulwich.index import (
             blob_from_path_and_stat,
             index_entry_from_stat,
+            fs_to_tree_path,
             )
         index = self.open_index()
-        for path in paths:
-            full_path = os.path.join(self.path, path)
+        for fs_path in fs_paths:
+            tree_path = fs_to_tree_path(fs_path).encode(fsencoding)
+            full_path = os.path.join(self.path, fs_path)
             try:
                 st = os.lstat(full_path)
             except OSError:
                 # File no longer exists
                 try:
-                    del index[path.encode(fsencoding)]
+                    del index[tree_path]
                 except KeyError:
                     pass  # already removed
             else:
                 blob = blob_from_path_and_stat(full_path, st)
                 self.object_store.add_object(blob)
-                index[path.encode(fsencoding)] = index_entry_from_stat(st, blob.id, 0)
+                index[tree_path] = index_entry_from_stat(st, blob.id, 0)
         index.write()
 
     def clone(self, target_path, mkdir=True, bare=False,

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -730,11 +730,15 @@ class Repo(BaseRepo):
         # missing index file, which is treated as empty.
         return not self.bare
 
-    def stage(self, fs_paths, fsencoding=sys.getfilesystemencoding()):
+    def stage(self, fs_paths):
         """Stage a set of paths.
 
         :param fs_paths: List of paths, relative to the repository path
         """
+
+        root_path_bytes = self.path.encode(sys.getfilesystemencoding())
+        root_path_str = self.path
+
         if not isinstance(fs_paths, list):
             fs_paths = [fs_paths]
         from dulwich.index import (
@@ -744,8 +748,10 @@ class Repo(BaseRepo):
             )
         index = self.open_index()
         for fs_path in fs_paths:
-            tree_path = fs_to_tree_path(fs_path).encode(fsencoding)
-            full_path = os.path.join(self.path, fs_path)
+            tree_path = fs_to_tree_path(fs_path)
+            full_path = os.path.join(
+                root_path_bytes if isinstance(fs_path, bytes) else root_path_str,
+                fs_path)
             try:
                 st = os.lstat(full_path)
             except OSError:

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # test_index.py -- Tests for the git index
 # Copyright (C) 2008-2009 Jelmer Vernooij <jelmer@samba.org>
 #
@@ -42,6 +43,8 @@ from dulwich.index import (
     write_cache_time,
     write_index,
     write_index_dict,
+    tree_to_fs_path,
+    fs_to_tree_path,
     )
 from dulwich.object_store import (
     MemoryObjectStore,
@@ -442,3 +445,17 @@ class TestValidatePathElement(TestCase):
         self.assertFalse(validate_path_element_ntfs(b".giT"))
         self.assertFalse(validate_path_element_ntfs(b".."))
         self.assertFalse(validate_path_element_ntfs(b"git~1"))
+
+
+class TestTreeFSPathConversion(TestCase):
+
+    def test_tree_to_fs_path(self):
+        tree_path = u'délwíçh/foo'
+        fs_path = tree_to_fs_path(tree_path)
+        self.assertEqual(fs_path, os.path.join(u'délwíçh', u'foo'))
+
+    def test_fs_to_tree_path_bytes(self):
+        fs_path = os.path.join(os.path.join(u'délwíçh', u'foo'))
+        tree_path = fs_to_tree_path(fs_path)
+        self.assertEqual(tree_path, u'délwíçh/foo')
+

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -482,12 +482,16 @@ class TestValidatePathElement(TestCase):
 class TestTreeFSPathConversion(TestCase):
 
     def test_tree_to_fs_path(self):
-        tree_path = u'délwíçh/foo'
+        tree_path = u'délwíçh/foo'.encode('utf8')
         fs_path = tree_to_fs_path(tree_path)
-        self.assertEqual(fs_path, os.path.join(u'délwíçh', u'foo'))
+        self.assertEqual(fs_path, os.path.join(u'délwíçh', u'foo').encode('utf8'))
 
-    def test_fs_to_tree_path_bytes(self):
+    def test_fs_to_tree_path_str(self):
         fs_path = os.path.join(os.path.join(u'délwíçh', u'foo'))
         tree_path = fs_to_tree_path(fs_path)
-        self.assertEqual(tree_path, u'délwíçh/foo')
+        self.assertEqual(tree_path, u'délwíçh/foo'.encode(sys.getfilesystemencoding()))
 
+    def test_fs_to_tree_path_bytes(self):
+        fs_path = os.path.join(os.path.join(u'délwíçh', u'foo').encode('utf8'))
+        tree_path = fs_to_tree_path(fs_path)
+        self.assertEqual(tree_path, u'délwíçh/foo'.encode('utf8'))

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -53,7 +53,7 @@ missing_sha = b'b91fa4d900e17e99b433218e988c4eb4a3e9a097'
 
 
 def mkdtemp_unicode():
-    suffix = u'déłwíçh'
+    suffix = u'délwíçh'
     return tempfile.mkdtemp(suffix=suffix)
 
 

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -25,9 +25,9 @@ import locale
 import os
 import stat
 import shutil
+import sys
 import tempfile
 import warnings
-import sys
 
 from dulwich import errors
 from dulwich.object_store import (
@@ -522,6 +522,7 @@ class BuildRepoRootTests(TestCase):
         self._repo_dir = self.get_repo_dir()
         os.makedirs(self._repo_dir)
         r = self._repo = Repo.init(self._repo_dir)
+        self.addCleanup(tear_down_repo, r)
         self.assertFalse(r.bare)
         self.assertEqual(b'ref: refs/heads/master', r.refs.read_ref(b'HEAD'))
         self.assertRaises(KeyError, lambda: r.refs[b'refs/heads/master'])
@@ -536,10 +537,6 @@ class BuildRepoRootTests(TestCase):
                                  author_timestamp=12345, author_timezone=0)
         self.assertEqual([], r[commit_sha].parents)
         self._root_commit = commit_sha
-
-    def tearDown(self):
-        tear_down_repo(self._repo)
-        super(BuildRepoRootTests, self).tearDown()
 
     def test_build_repo(self):
         r = self._repo
@@ -747,3 +744,29 @@ class BuildRepoRootTests(TestCase):
         os.remove(os.path.join(r.path, 'a'))
         r.stage(['a'])
         r.stage(['a'])  # double-stage a deleted path
+
+    def test_commit_no_encode_decode(self):
+        r = self._repo
+        repo_path_bytes = r.path.encode(sys.getfilesystemencoding())
+        encodings = ('utf8', 'latin1')
+        names = [u'À'.encode(encoding) for encoding in encodings]
+        for name, encoding in zip(names, encodings):
+            full_path = os.path.join(repo_path_bytes, name)
+            with open(full_path, 'wb') as f:
+                f.write(encoding.encode('ascii'))
+            # These files are break tear_down_repo, so cleanup these files
+            # ourselves.
+            self.addCleanup(os.remove, full_path)
+
+        r.stage(names)
+        commit_sha = r.do_commit(b'Files with different encodings',
+             committer=b'Test Committer <test@nodomain.com>',
+             author=b'Test Author <test@nodomain.com>',
+             commit_timestamp=12395, commit_timezone=0,
+             author_timestamp=12395, author_timezone=0,
+             ref=None, merge_heads=[self._root_commit])
+
+        for name, encoding in zip(names, encodings):
+            mode, id = tree_lookup_path(r.get_object, r[commit_sha].tree, name)
+            self.assertEqual(stat.S_IFREG | 0o644, mode)
+            self.assertEqual(encoding.encode('ascii'), r[id].data)


### PR DESCRIPTION
This supersedes #285.

This is split into 2 main commits  + 1 test adding commit to hopefully make it easier to review. It also excludes changes that were made in #285, that I will resubmit later. 

This includes the following changes (copied from commit messages):

* Add `index.fs_to_tree_path` and `index.tree_to_fs_path` to translate between git
  tree paths, and checkout file system paths. These methods just translate the
  path separators for now. Use these methods where needed.
* Rename path arguments and variables to make it clear if they refer to a git
  tree paths, or checkout file system paths, or a checkout root.
* Add test to ensure we don't fiddle with checkout path encoding.
* `index.build_index_from_tree` will not decode tree paths, but will write to the
  file system using the bytes paths.
* `Repo.stage` will accept either a bytes or string path. Only if the path is a
  string with the path be encoded with `sys.getfilesystemencoding()`, otherwise
  the bytes will be used directly to write to the git tree.

This excludes:

* A fix for #203.
* A way to translate tree encodings.
