### PR TITLE
Symlinks stuff

### DIFF
--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -50,7 +50,10 @@ from dulwich.objects import (
     Tree,
     )
 from dulwich.repo import Repo
-from dulwich.tests import TestCase
+from dulwich.tests import (
+    TestCase,
+    skipIf,
+)
 
 class IndexTestCase(TestCase):
 
@@ -271,10 +274,8 @@ class BuildIndexTests(TestCase):
             # Verify no files
             self.assertEqual(['.git'], os.listdir(repo.path))
 
+    @skipIf(not getattr(os, 'symlink', None), 'Requires symlink support')
     def test_git_dir(self):
-        if os.name != 'posix':
-            self.skipTest("test depends on POSIX shell")
-
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
         with closing(Repo.init(repo_dir)) as repo:
@@ -308,10 +309,8 @@ class BuildIndexTests(TestCase):
                 stat.S_IFREG | 0o644, 1, filee.id)
             self.assertFileContents(epath, b'd')
 
+    @skipIf(not getattr(os, 'symlink', None), 'Requires symlink support')
     def test_nonempty(self):
-        if os.name != 'posix':
-            self.skipTest("test depends on POSIX shell")
-
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
         with closing(Repo.init(repo_dir)) as repo:

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -25,6 +25,7 @@ import os
 import shutil
 import stat
 import struct
+import sys
 import tempfile
 
 from dulwich.index import (
@@ -386,8 +387,10 @@ class BuildIndexTests(TestCase):
             # symlink to d
             epath = os.path.join(repo.path, 'c', 'e')
             self.assertTrue(os.path.exists(epath))
-            self.assertReasonableIndexEntry(index[b'c/e'],
-                stat.S_IFLNK, 1, filee.id)
+            self.assertReasonableIndexEntry(
+                index[b'c/e'], stat.S_IFLNK,
+                0 if sys.platform == 'win32' else 1,
+                filee.id)
             self.assertFileContents(epath, 'd', symlink=True)
 
 class GetUnstagedChangesTests(TestCase):

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -305,7 +305,7 @@ class RepositoryRootTests(TestCase):
         r = self.open_repo('ooo_merge.git')
         self.assertIsInstance(r.get_config_stack(), Config)
 
-    @skipIf(sys.platform == 'win32', 'Requires symlink support')
+    @skipIf(not getattr(os, 'symlink', None), 'Requires symlink support')
     def test_submodule(self):
         temp_dir = self.mkdtemp()
         self.addCleanup(shutil.rmtree, temp_dir)
@@ -565,7 +565,7 @@ class BuildRepoRootTests(TestCase):
         self.assertEqual(stat.S_IFREG | 0o644, a_mode)
         self.assertEqual(b'new contents', r[a_id].data)
 
-    @skipIf(sys.platform == 'win32', 'Requires symlink support')
+    @skipIf(not getattr(os, 'symlink', None), 'Requires symlink support')
     def test_commit_symlink(self):
         r = self._repo
         os.symlink('a', os.path.join(r.path, 'b'))


### PR DESCRIPTION
I recently discovered that `os.symlink` & `os.readlink` are available on windows as of python 3.2.

So where we have tests that require symlink support, we should check if symlinks are available with ` hasattr(os, 'symlink')` rather than checking `sys.platform` or `os.name`. This enables running these tests on Windows with python >= 3.2.

This introduces a new test failure on Windows python 3, but this is fixed by #290. (https://ci.appveyor.com/project/garyvdm/dulwich/build/1.0.164/job/2u7ra0kyj3onass1#L1131)

This also fixes a test windows failure due to a difference `stat_val.st_size` between windows and unix (on unix 1 byte, on windows 0 bytes.)

This also splits up `BuildIndexTests.test_nonempty` so that the symlink specific code is in a separate test, so that the majority of `BuildIndexTests.test_nonempty` is also run on windows python2
