### PR TITLE
Fix SSHGitClient on windows python3

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -951,13 +951,14 @@ class SSHGitClient(TraditionalGitClient):
         self.alternative_paths = {}
 
     def _get_cmd_path(self, cmd):
-        return self.alternative_paths.get(cmd, b'git-' + cmd)
+        cmd = cmd.decode('ascii')
+        return self.alternative_paths.get(cmd, 'git-' + cmd)
 
     def _connect(self, cmd, path):
-        if path.startswith(b"/~"):
+        if path.startswith("/~"):
             path = path[1:]
         con = get_ssh_vendor().run_command(
-            self.host, [self._get_cmd_path(cmd) + b" '" + path + b"'"],
+            self.host, [self._get_cmd_path(cmd), path],
             port=self.port, username=self.username)
         return (Protocol(con.read, con.write, con.close,
                          report_activity=self._report_activity),

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -309,8 +309,8 @@ class DulwichTCPClientTest(CompatTestCase, DulwichClientTestBase):
 class TestSSHVendor(object):
     @staticmethod
     def run_command(host, command, username=None, port=None):
-        cmd, path = command[0].replace(b"'", b'').split(b' ')
-        cmd = cmd.split(b'-', 1)
+        cmd, path = command
+        cmd = cmd.split('-', 1)
         p = subprocess.Popen(cmd + [path], bufsize=0, env=get_safe_env(), stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return client.SubprocessWrapper(p)
@@ -333,7 +333,7 @@ class DulwichMockSSHClientTest(CompatTestCase, DulwichClientTestBase):
         return client.SSHGitClient(b'localhost')
 
     def _build_path(self, path):
-        return (self.gitroot + path).encode(sys.getfilesystemencoding())
+        return self.gitroot + path
 
 
 class DulwichSubprocessClientTest(CompatTestCase, DulwichClientTestBase):

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -527,13 +527,13 @@ class SSHGitClientTests(TestCase):
         client.get_ssh_vendor = self.real_vendor
 
     def test_default_command(self):
-        self.assertEqual(b'git-upload-pack',
+        self.assertEqual('git-upload-pack',
                 self.client._get_cmd_path(b'upload-pack'))
 
     def test_alternative_command_path(self):
-        self.client.alternative_paths[b'upload-pack'] = (
-            b'/usr/lib/git/git-upload-pack')
-        self.assertEqual(b'/usr/lib/git/git-upload-pack',
+        self.client.alternative_paths['upload-pack'] = (
+            '/usr/lib/git/git-upload-pack')
+        self.assertEqual('/usr/lib/git/git-upload-pack',
             self.client._get_cmd_path(b'upload-pack'))
 
     def test_connect(self):
@@ -543,13 +543,13 @@ class SSHGitClientTests(TestCase):
         client.username = b"username"
         client.port = 1337
 
-        client._connect(b"command", b"/path/to/repo")
+        client._connect(b"command", "/path/to/repo")
         self.assertEqual(b"username", server.username)
         self.assertEqual(1337, server.port)
-        self.assertEqual([b"git-command '/path/to/repo'"], server.command)
+        self.assertEqual(["git-command", "/path/to/repo"], server.command)
 
-        client._connect(b"relative-command", b"/~/path/to/repo")
-        self.assertEqual([b"git-relative-command '~/path/to/repo'"],
+        client._connect(b"relative-command", "/~/path/to/repo")
+        self.assertEqual(["git-relative-command",  "~/path/to/repo"],
                           server.command)
 
 


### PR DESCRIPTION
On windows python3, executable names (e.g. `args[0]`) must be a string and not bytes. 

This fixes these errors: https://ci.appveyor.com/project/garyvdm/dulwich/build/1.0.171/job/v2mohbox9v14yxyi#L1161