### PR TITLE
Decode path when reading symlink on windows.

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -516,7 +516,12 @@ def blob_from_path_and_stat(fs_path, st):
         with open(fs_path, 'rb') as f:
             blob.data = f.read()
     else:
-        blob.data = os.readlink(fs_path)
+        if sys.platform == 'win32':
+            fs_encoding = sys.getfilesystemencoding()
+            blob.data = (os.readlink(fs_path.decode(fs_encoding))
+                         .encode(fs_encoding))
+        else:
+            blob.data = os.readlink(fs_path)
     return blob
 
 


### PR DESCRIPTION
This fixes a new failure on windows: https://ci.appveyor.com/project/garyvdm/dulwich/build/1.0.187/job/7mj30hg52ylb2x71#L1193

I though I handled this previously, but missed it some how.

`os.readlink` has differing behaviours on windows vs unix. For the path argument, and the return value, it must be/is 

| OS | cpython | pypy |
| --- | --- | --- |
| unix | either. Return value is same as argument | bytes |
| windows | unicode string | Not sure. Have not tested. |

So on windows, We have to decode the path argument, and encode the return value.
