### PR TITLE
Rework travis config so that it uses containers & pip caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,28 @@
 language: python
-# Workaround to make 2.7 use system site packages, and 2.6 and 3.4 not use system
-# site packages.
-# https://github.com/travis-ci/travis-ci/issues/2219#issuecomment-41804942
-python:
-- "2.6"
-- "2.7_with_system_site_packages"
-- "3.4"
-- "pypy"
+sudo: false
+env:
+  global: TEST_RUNNER=unittest PYTHONHASHSEED=random
+matrix:
+  include:
+    - python: "2.6"
+      env: TEST_RUNNER=unittest2.__main__ TEST_REQUIRE="gevent geventhttpclient fastimport unittest2"
+    - python: "2.7"
+      env: TEST_REQUIRE="gevent geventhttpclient fastimport"
+    - python: "pypy"
+      env: TEST_REQUIRE="fastimport"
+    - python: "3.4"
+      env: TEST_REQUIRE=
+cache:
+  directories:
+    - $HOME/.cache/pip
 script:
-  - PYTHONHASHSEED=random python setup.py test
-  - make check-noextensions
-install:
-  - sudo apt-get update
-  - sudo apt-get install -qq git python-setuptools python-gevent python-fastimport python-mock
-  - if [[ $TRAVIS_PYTHON_VERSION == 2* ]]; then pip install unittest2; fi
+  - pip install pip --upgrade
+  - pip install $TEST_REQUIRE
+
+  # Test without c extensions
+  - python -m $TEST_RUNNER dulwich.tests.test_suite
+
+  # Test with c extensions
+  - python setup.py build_ext -i
+  - python -m $TEST_RUNNER dulwich.tests.test_suite
+

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,12 @@ if sys.version_info[0] == 2:
     tests_require = ['fastimport', 'mock']
     if not '__pypy__' in sys.modules and not sys.platform == 'win32':
         tests_require.extend(['gevent', 'geventhttpclient'])
+    if sys.version_info < (2, 7):
+        tests_require.append('unittest2')
 else:
     # fastimport, gevent, geventhttpclient are not available for PY3
     # mock only used for test_swift, which requires gevent/geventhttpclient
     tests_require = []
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
 
 if sys.version_info[0] > 2 and sys.platform == 'win32':
     # C Modules don't build for python3 windows, and prevent tests from running


### PR DESCRIPTION
Travis now allows you to run your in a docker container rather than in a VM. The main advantage is that the tests start running much sooner after a push, due to both a faster startup time for the container vs the vm, but also because the vm queues are often full. 

http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
https://www.traviscistatus.com/#month

The issue with this is that you can't use `apt-get` to install dependencies, because you can't use `sudo` in the container. If I understand correctly, the reason for using `apt-get` vs `pip` was for performance reasons (Installing gevent/geventhttpclient is quicker with `apt-get` than with `pip`.)

However `pip` gained a new feature in 7.0 (thanks to @rbtcollins) to build a binary wheel, and cache it. This cache can be propagated between jobs on travis, and used to speed up future installs.

A disadvantage of this is that we have to use `pip` to install the test dependences instead of letting `setup.py test` install them. This means we need to specify the dependences in `.travis.yml`. 

Test times for individual environment are all faster, 2.6 and pypy are much faster:

Version | Before | After
----------|----------|-------
Python 2.6 | 5:12 | 2:15
Python 2.7 | 2:27 | 2:06
Python 3.4 | 1:15 | 1:01
PyPy | 4:12 | 2:38

The other dependency that we try upgrade using `apt-get` is `git`. However currently is the latest version in availbile for precise, and travis seem pretty good at keeping it up to date in the image.

So there are pros and cons to this, but I believe that the pros out weigh the cons.