### PR TITLE
Increase appveyor matrix, and enable bdist_wheel builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,20 +1,29 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      PYTHON_ARCH: "32"
       PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe"
 
     - PYTHON: "C:\\Python34"
-      PYTHON_ARCH: "32"
       PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py3.4.exe"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win-amd64-py3.4.exe"
 
 install:
   - ps: (new-object net.webclient).DownloadFile($env:PYWIN32_URL, 'c:\\pywin32.exe')
   - "%PYTHON%/Scripts/easy_install.exe c:\\pywin32.exe"
+  - "%PYTHON%/Scripts/easy_install.exe wheel"
 
 build: off
 
 test_script:
   - "%WITH_COMPILER% %PYTHON%/python setup.py test"
 
+after_test:
+  - "%WITH_COMPILER% %PYTHON%/python setup.py bdist_wheel"
 
+artifacts:
+  - path: dist\*


### PR DESCRIPTION
This is to resolve #222. 

We can't build Python 2.6 because it is not available on appveyor.
Building of the C extensions is broken on Python 3.4, so the wheels are a bit pointless.
The Python 2.7 build are correct.

Once a job is finished, the wheels are available on the artifacts page for that job. e.g. 

* Build: https://ci.appveyor.com/project/garyvdm/dulwich/build/1.0.201
* 2.7 Job: https://ci.appveyor.com/project/garyvdm/dulwich/build/1.0.201/job/50q2j12r0nkbw6n6
* 2.7 Artifacts: https://ci.appveyor.com/project/garyvdm/dulwich/build/1.0.201/job/50q2j12r0nkbw6n6/artifacts

The `bdist_wheel` step will not run if the tests failed, and hence the wheels will be missing if the tests fail.