### PR TITLE
Consent to GPLv2/Apachev2 relicense on behalf of Googlers

### DIFF
--- a/relicensing-apachev2.txt
+++ b/relicensing-apachev2.txt
@@ -41,9 +41,7 @@ dak180 <dak180@users.sourceforge.net>
 Damien Tournoud <damien@commerceguys.com>
 Dan Callaghan <dcallagh@redhat.com>
 Daniele Sluijters <daniele.sluijters@gmail.com>
-David Bennett <davbennett@google.com>
 David Blewett <davidb@sixfeetup.com>
-David Borowitz <dborowitz@google.com>
 David Carr <david@carrclan.us>
 David Keijser <david.keijser@klarna.com>
 David Ostrovsky <david@ostrovsky.org>
@@ -76,8 +74,6 @@ Max Bowsher <maxb@f2s.com>
 max <max0d41@github.com>
 Max Shawabkeh <max99x@gmail.com>
 Michael K <michael-k@users.noreply.github.com>
-Mike Edgar <adgar@google.com>
-Mike Williams <miwilliams@google.com>
 Nick Stenning <nick@whiteink.com>
 Nick Ward <ward.nickjames@gmail.com>
 Nix <nix@esperi.co.uk>
@@ -87,7 +83,6 @@ Paul Hummer <paul@eventuallyanyway.com>
 rfaulk <rfaulkner@wikimedia.org>
 Ricardo Salveti <ricardo.salveti@openbossa.org>
 Risto Kankkunen <risto.kankkunen@f-secure.com> <risto.kankkunen@iki.fi>
-Robert Brown <robert.brown@gmail.com>
 Rod Cloutier <rodcloutier@gmail.com>
 Roland Mas <lolando@debian.org>
 Ronald Blaschke <ron@rblasch.org>


### PR DESCRIPTION
Google opensource licensing has approved the relicensing of all Googlers' contributions to dulwich.