### PR TITLE
fix encoding name check in test_refs when LANG=C

### DIFF
--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -438,7 +438,7 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
                          self._refs.read_ref(b'refs/heads/packed'))
         self.assertEqual(None, self._refs.read_ref(b'nonexistant'))
 
-    @skipIf(sys.getfilesystemencoding() == 'ascii',
+    @skipIf(sys.getfilesystemencoding() == 'ANSI_X3.4-1968',
             "filesystem encoding doesn't support non-ascii characters")
     def test_non_ascii(self):
         p = os.path.join(self._repo.path, 'refs', 'tags', 'schön')


### PR DESCRIPTION
The value of sys.getfilesystemencoding() yields 'ANSI_X3.4-1968' and not
'ascii' (at least on linux systems).

(I'm not sure if this is true for all UNIX)