### PR TITLE
Relicensing (Dmitry Czarkoff)

### DIFF
--- a/relicensing-apachev2.txt
+++ b/relicensing-apachev2.txt
@@ -46,7 +46,6 @@ DeeKey <dkomarov@gmail.com>
 Dirk <dirk@opani.com>
 diryboy <lancevdance@gmail.com>
 D-Key <dkomarov@gmail.com>
-Dmitrij D. Czarkoff <czarkoff@gmail.com>
 Dmitriy <dkomarov@gmail.com>
 Dov Feldstern <dovdevel@gmail.com>
 Fabien Boucher <fabien.boucher@enovance.com>


### PR DESCRIPTION
I concent to relicensing Dulwich under dual GPLv2+/Apachev2+ license.