### PR TITLE
Fix issue #247 'TypeError when fetching empty updates into MemoryRepo'

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1094,6 +1094,10 @@ class PackData(object):
         # TODO(dborowitz): Merge this with iterobjects, if we can change its
         # return type.
         self._file.seek(self._header_size)
+        
+        if self._num_objects is None:
+            return
+        
         for _ in xrange(self._num_objects):
             offset = self._file.tell()
             unpacked, unused = unpack_object(

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -214,6 +214,11 @@ class MemoryObjectStoreTests(ObjectStoreTests, TestCase):
         else:
             commit()
 
+    def test_add_pack_emtpy(self):
+        o = MemoryObjectStore()
+        f, commit, abort = o.add_pack()
+        commit()
+
     def test_add_thin_pack(self):
         o = MemoryObjectStore()
         blob = make_object(Blob, data='yummy data')


### PR DESCRIPTION
by adding check for _num_objects is None when iterating pack data.