### PR TITLE
Extend clients to support listing remote refs

### DIFF
--- a/bin/dulwich
+++ b/bin/dulwich
@@ -342,6 +342,16 @@ def cmd_status(args):
         sys.stdout.write("\n")
 
 
+def cmd_ls_remote(args):
+    opts, args = getopt(args, '', [])
+    if len(args) < 1:
+        print('Usage: dulwich ls-remote URL')
+        sys.exit(1)
+    refs = porcelain.ls_remote(args[0])
+    for ref in sorted(refs):
+        sys.stdout.write("%s\t%s\n" % (ref, refs[ref]))
+
+
 commands = {
     "add": cmd_add,
     "archive": cmd_archive,
@@ -357,6 +367,7 @@ commands = {
     "fetch": cmd_fetch,
     "init": cmd_init,
     "log": cmd_log,
+    "ls-remote": cmd_ls_remote,
     "receive-pack": cmd_receive_pack,
     "reset": cmd_reset,
     "rev-list": cmd_rev_list,

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -29,6 +29,7 @@ Currently implemented:
  * diff-tree
  * fetch
  * init
+ * ls-remote
  * pull
  * push
  * rm
@@ -762,3 +763,8 @@ def fetch(repo, remote_location, outstream=sys.stdout, errstream=sys.stderr):
         client, path = get_transport_and_path(remote_location)
         remote_refs = client.fetch(path, r, progress=errstream.write)
     return remote_refs
+
+
+def ls_remote(remote):
+    client, host_path = get_transport_and_path(remote)
+    return client.get_refs(host_path)

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -254,6 +254,14 @@ class DulwichClientTestBase(object):
             c.send_pack(self._build_path('/dest'), lambda _: sendrefs, gen_pack)
             self.assertFalse(b"refs/heads/abranch" in dest.refs)
 
+    def test_get_refs(self):
+        c = self._client()
+        refs = c.get_refs(self._build_path('/server_new.export'))
+
+        repo_dir = os.path.join(self.gitroot, 'server_new.export')
+        with closing(repo.Repo(repo_dir)) as dest:
+            self.assertDictEqual(dest.refs.as_dict(), refs)
+
 
 class DulwichTCPClientTest(CompatTestCase, DulwichClientTestBase):
 

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -627,6 +627,14 @@ class LocalGitClientTests(TestCase):
         with closing(Repo.init_bare(target_path)) as target:
             self.send_and_verify(b"master", local, target)
 
+    def test_get_refs(self):
+        local = open_repo('refs.git')
+        self.addCleanup(tear_down_repo, local)
+
+        client = LocalGitClient()
+        refs = client.get_refs(local.path)
+        self.assertDictEqual(local.refs.as_dict(), refs)
+
     def send_and_verify(self, branch, local, target):
         client = LocalGitClient()
         ref_name = b"refs/heads/" + branch


### PR DESCRIPTION
Includes an ls-remote porcelain command to demonstrate the new functionality.