### PR TITLE
remove Siddharth Agarwal from relicensing text file

### DIFF
--- a/relicensing-apachev2.txt
+++ b/relicensing-apachev2.txt
@@ -57,7 +57,6 @@ Ronald Blaschke <ron@rblasch.org>
 Ryan Faulkner <rfaulk@yahoo-inc.com> <rfaulkner@wikimedia.org>
 Ryan McKern <ryan@orangefort.com>
 Sam Vilain <svilain@saymedia.com>
-Siddharth Agarwal <sid0@fb.com>
 Stefan Zimmermann <zimmermann.code@gmail.com>
 Takeshi Kanemoto <tak.kanemoto@gmail.com>
 Tay Ray Chuan <rctay89@gmail.com>


### PR DESCRIPTION
This code is copyright my employer, Facebook, which already licensed my
contribution as GPLv2 or later + Apache v2 at the time it was submitted. See
https://github.com/jelmer/dulwich/pull/159.