### PR TITLE
Approve my contributions being relicensed

### DIFF
--- a/relicensing-apachev2.txt
+++ b/relicensing-apachev2.txt
@@ -44,7 +44,6 @@ Martin Packman <gzlist@googlemail.com>
 max <max0d41@github.com>
 Nick Ward <ward.nickjames@gmail.com>
 Nix <nix@esperi.co.uk>
-Paul Hummer <paul@eventuallyanyway.com>
 Risto Kankkunen <risto.kankkunen@f-secure.com> <risto.kankkunen@iki.fi>
 Rod Cloutier <rodcloutier@gmail.com>
 Ronald Blaschke <ron@rblasch.org>


### PR DESCRIPTION
Removing my name from the list of people needed to be tracked down in order to relicense dulwich.