### PR TITLE
Add `discover` classmethod

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -687,12 +687,13 @@ class Repo(BaseRepo):
 
         :param start: The directory to start discovery from (defaults to '.')
         """
+        remaining = True
         path = os.path.abspath(start)
-        while path != '/':
+        while remaining:
             try:
                 return cls(path)
             except NotGitRepository:
-                path, _ = os.path.split(path)
+                path, remaining = os.path.split(path)
         raise NotGitRepository(
             "No git repository was found at %(path)s" % dict(path=start)
         )

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -679,19 +679,20 @@ class Repo(BaseRepo):
         self.hooks['post-commit'] = PostCommitShellHook(self.controldir())
 
     @classmethod
-    def discover(cls, start):
-        """
+    def discover(cls, start='.'):
+        """Iterate parent directories to discover a repository
+
         Return a Repo object for the first parent directory that looks like a
         Git repository.
 
-        :param start: The directory to start discovery from
+        :param start: The directory to start discovery from (defaults to '.')
         """
-        abs_split = os.path.abspath(start)[1:].split(os.path.sep)
-        for _ in range(len(abs_split)):
+        path = os.path.abspath(start)
+        while path != '/':
             try:
-                return cls(os.path.join('/', *abs_split))
+                return cls(path)
             except NotGitRepository:
-                abs_split.pop()
+                path, _ = os.path.split(path)
         raise NotGitRepository(
             "No git repository was found at %(path)s" % dict(path=start)
         )

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -678,6 +678,24 @@ class Repo(BaseRepo):
         self.hooks['commit-msg'] = CommitMsgShellHook(self.controldir())
         self.hooks['post-commit'] = PostCommitShellHook(self.controldir())
 
+    @classmethod
+    def discover(cls, start):
+        """
+        Return a Repo object for the first parent directory that looks like a
+        Git repository.
+
+        :param start: The directory to start discovery from
+        """
+        abs_split = os.path.abspath(start)[1:].split(os.path.sep)
+        for _ in range(len(abs_split)):
+            try:
+                return cls(os.path.join('/', *abs_split))
+            except NotGitRepository:
+                abs_split.pop()
+        raise NotGitRepository(
+            "No git repository was found at %(path)s" % dict(path=start)
+        )
+
     def controldir(self):
         """Return the path of the control directory."""
         return self._controldir

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -777,4 +777,5 @@ class BuildRepoRootTests(TestCase):
         self.assertEqual(r.head(), self._repo.head())
 
     def test_discover_notrepo(self):
-        self.assertRaises(NotGitRepository, Repo.discover('/'))
+        with self.assertRaises(NotGitRepository):
+            Repo.discover('/')

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -765,3 +765,8 @@ class BuildRepoRootTests(TestCase):
             mode, id = tree_lookup_path(r.get_object, r[commit_sha].tree, name)
             self.assertEqual(stat.S_IFREG | 0o644, mode)
             self.assertEqual(encoding.encode('ascii'), r[id].data)
+
+    def test_discover(self):
+        path = os.path.join(self._repo_dir, 'b/c')
+        r = Repo.discover(path)
+        self.assertEqual(r.head(), self._repo.head())

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -35,6 +35,7 @@ from dulwich.object_store import (
     )
 from dulwich import objects
 from dulwich.config import Config
+from dulwich.errors import NotGitRepository
 from dulwich.repo import (
     Repo,
     MemoryRepo,
@@ -766,7 +767,14 @@ class BuildRepoRootTests(TestCase):
             self.assertEqual(stat.S_IFREG | 0o644, mode)
             self.assertEqual(encoding.encode('ascii'), r[id].data)
 
-    def test_discover(self):
+    def test_discover_intended(self):
         path = os.path.join(self._repo_dir, 'b/c')
         r = Repo.discover(path)
         self.assertEqual(r.head(), self._repo.head())
+
+    def test_discover_isrepo(self):
+        r = Repo.discover(self._repo_dir)
+        self.assertEqual(r.head(), self._repo.head())
+
+    def test_discover_notrepo(self):
+        self.assertRaises(NotGitRepository, Repo.discover('/'))


### PR DESCRIPTION
Method to instantiate a `Repo` object from a subdirectory of a repository (this is kind of normal Git CLI behaviour), they have it in the [Rust lib](https://github.com/alexcrichton/git2-rs/blob/master/src/repo.rs#L64-L74) so I "borrowed" it.