### PR TITLE
Add single quotes around the path argument in SSH clients

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -909,7 +909,7 @@ class SSHGitClient(TraditionalGitClient):
             raise TypeError(path)
         if path.startswith(b"/~"):
             path = path[1:]
-        argv = self._get_cmd_path(cmd) + [path]
+        argv = self._get_cmd_path(cmd) + ["'" + path + "'"]
         con = self.ssh_vendor.run_command(
             self.host, argv, port=self.port, username=self.username)
         return (Protocol(con.read, con.write, con.close,

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -909,7 +909,7 @@ class SSHGitClient(TraditionalGitClient):
             raise TypeError(path)
         if path.startswith(b"/~"):
             path = path[1:]
-        argv = self._get_cmd_path(cmd) + ["'" + path + "'"]
+        argv = self._get_cmd_path(cmd) + [b"'" + path + b"'"]
         con = self.ssh_vendor.run_command(
             self.host, argv, port=self.port, username=self.username)
         return (Protocol(con.read, con.write, con.close,

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -326,7 +326,7 @@ class TestSSHVendor(object):
     def run_command(host, command, username=None, port=None):
         cmd, path = command
         cmd = cmd.split(b'-', 1)
-        path = path.replace("'", "")
+        path = path.replace(b"'", b"")
         p = subprocess.Popen(cmd + [path], bufsize=0, env=get_safe_env(), stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return client.SubprocessWrapper(p)

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -326,6 +326,7 @@ class TestSSHVendor(object):
     def run_command(host, command, username=None, port=None):
         cmd, path = command
         cmd = cmd.split(b'-', 1)
+        path = path.replace("'", "")
         p = subprocess.Popen(cmd + [path], bufsize=0, env=get_safe_env(), stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return client.SubprocessWrapper(p)

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -560,10 +560,10 @@ class SSHGitClientTests(TestCase):
         client._connect(b"command", b"/path/to/repo")
         self.assertEqual(b"username", server.username)
         self.assertEqual(1337, server.port)
-        self.assertEqual([b"git-command", b"/path/to/repo"], server.command)
+        self.assertEqual([b"git-command", b"'/path/to/repo'"], server.command)
 
         client._connect(b"relative-command", b"/~/path/to/repo")
-        self.assertEqual([b"git-relative-command", b"~/path/to/repo"],
+        self.assertEqual([b"git-relative-command", b"'~/path/to/repo'"],
                           server.command)
 
 


### PR DESCRIPTION
gitolite, which restricts access to repositories through SSH without allowing "full" SSH access, uses the following regular expression to determine if a command is a "valid" git command:
```
if ( $soc =~ m(^($git_commands) '?/?(.*?)(?:\.git(\d)?)?'?$) )
```
https://github.com/sitaramc/gitolite/blob/24171564e63d4072b2eeeb3e4dad7d2b231b31ec/src/gitolite-shell#L156

This means that gitolite will only accept commands that have the repository path in single quotes (and nothing else). This pull request adds the single quotes around the repository path in SSHGitClient again.

Fixes #384.