### PR TITLE
subprocess's mswindows attribute has gone private in 3.5

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -662,7 +662,7 @@ class SubprocessWrapper(object):
         self.write = proc.stdin.write
 
     def can_read(self):
-        if subprocess.mswindows:
+        if sys.platform == 'win32':
             from msvcrt import get_osfhandle
             from win32pipe import PeekNamedPipe
             handle = get_osfhandle(self.proc.stdout.fileno())


### PR DESCRIPTION
See: https://bugs.python.org/issue10838
Elsewhere, we look at `sys.platform` directly, so do it here too.

As seen in https://launchpad.net/ubuntu/+source/dulwich/0.11.2-1ubuntu2