### PR TITLE
Fix thinpack support over http

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -232,14 +232,22 @@ class GitClient(object):
         :param progress: Optional progress function
         :return: remote refs as dictionary
         """
+        
         if determine_wants is None:
             determine_wants = target.object_store.determine_wants_all
-
-        f, commit, abort = target.object_store.add_pack()
+        if CAPABILITY_THIN_PACK in self._fetch_capabilities:
+           f=BytesIO()
+           def commit():
+              if f.tell():
+                f.seek(0)
+                target.object_store.add_thin_pack(f.read, None)
+        else:
+           f, commit, abort = target.object_store.add_pack()
         try:
             result = self.fetch_pack(
                 path, determine_wants, target.get_graph_walker(), f.write,
                 progress)
+
         except:
             abort()
             raise


### PR DESCRIPTION
Checks fetch capabilities for thinpack support, and properly calls add_thin_pack instead of add_pack.
This is mainly for Http, but the fix had to be implemented in GitClient due to the way fetch is structured.  Fixes #226.