### PR TITLE
Add missing DECREF on local variable

### DIFF
--- a/dulwich/_pack.c
+++ b/dulwich/_pack.c
@@ -249,6 +249,7 @@ void init_pack(void)
 		return;
 
 	PyExc_ApplyDeltaError = PyObject_GetAttrString(errors_module, "ApplyDeltaError");
+	Py_DECREF(errors_module);
 	if (PyExc_ApplyDeltaError == NULL)
 		return;
 


### PR DESCRIPTION
The local variable `errors_module` wasn't decref-ed.