### PR TITLE
Parse user:passwords for HTTPGitClient

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -949,13 +949,18 @@ def default_urllib2_opener(config):
 
 class HttpGitClient(GitClient):
 
-    def __init__(self, base_url, dumb=None, opener=None, config=None, **kwargs):
+    def __init__(self, base_url, dumb=None, opener=None, config=None, 
+                 user='',passwd='', **kwargs):
         self.base_url = base_url.rstrip("/") + "/"
         self.dumb = dumb
         if opener is None:
             self.opener = default_urllib2_opener(config)
         else:
             self.opener = opener
+        if user:
+            pass_man=urllib2.HTTPPasswordMgrWithDefaultRealm()
+            pass_man.add_password(None,base_url,user,passwd)
+            self.opener.add_handler(urllib2.HTTPBasicAuthHandler(pass_man))
         GitClient.__init__(self, **kwargs)
 
     def __repr__(self):
@@ -1111,6 +1116,7 @@ def get_transport_and_path_from_url(url, config=None, **kwargs):
     :return: Tuple with client instance and relative path.
     """
     parsed = urlparse.urlparse(url)
+    auth, host = urllib2.splituser(parsed.netloc)
     if parsed.scheme == 'git':
         return (TCPGitClient(parsed.hostname, port=parsed.port, **kwargs),
                 parsed.path)
@@ -1121,8 +1127,9 @@ def get_transport_and_path_from_url(url, config=None, **kwargs):
         return SSHGitClient(parsed.hostname, port=parsed.port,
                             username=parsed.username, **kwargs), path
     elif parsed.scheme in ('http', 'https'):
-        return HttpGitClient(urlparse.urlunparse(parsed), config=config,
-                **kwargs), parsed.path
+        base_url = urlparse.urlunparse(parsed._replace(netloc=host))
+        return HttpGitClient(base_url, config=config, user=parsed.username, 
+                             passwd=parsed.password, **kwargs), parsed.path
     elif parsed.scheme == 'file':
         return default_local_git_client_cls(**kwargs), parsed.path
 


### PR DESCRIPTION
This solves #249, allowing get_transport_and_path to use http basic auth user:pass style urls, or to directly specify user/pass in a HTTPGitClient.

This works in porcelain as well (push, etc).

One possible issue: when using porcelain to push, using user:pass urls, the password will be displayed in the success /failure messages.  probably not a major issue if using the default outstream and errstream, but if logging is implemented, passwords would be displayed in the clear.  The solution might be to use client.base_url for httpgitclients, rather than remote_location.
