### PR TITLE
server: trivial comment fix

### DIFF
--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -266,7 +266,7 @@ class PackHandler(Handler):
 
 
 class UploadPackHandler(PackHandler):
-    """Protocol handler for uploading a pack to the server."""
+    """Protocol handler for uploading a pack to the client."""
 
     def __init__(self, backend, args, proto, http_req=None,
                  advertise_refs=False):


### PR DESCRIPTION
`UploadPackHandler` is for uploading a pack _to_ the client. Fix the class comment.