### PR TITLE
Fix hang on Gzip decompression

### DIFF
--- a/dulwich/web.py
+++ b/dulwich/web.py
@@ -415,7 +415,7 @@ def make_wsgi_chain(*args, **kwargs):
     correctly wrapped with needed middleware.
     """
     app = HTTPGitApplication(*args, **kwargs)
-    wrapped_app = GunzipFilter(LimitedInputFilter(app))
+    wrapped_app = LimitedInputFilter(GunzipFilter(app))
     return wrapped_app
 
 


### PR DESCRIPTION
'LimitedInputFilter' should be applied before the Gzip middleware as 'CONTENT_LENGTH' refers to the size of the *compressed* body.  If applied in wrong order, this may cause 'copyfileobj()' to try to read more data from the socket than is available, resulting in a call to 'recv()' that hangs forever.