### PR TITLE
fastexport module : Invalid dataref 

### DIFF
--- a/dulwich/fastexport.py
+++ b/dulwich/fastexport.py
@@ -87,8 +87,10 @@ class GitFastExporter(object):
             if old_path != new_path and old_path is not None:
                 yield commands.FileRenameCommand(old_path, new_path)
             if old_mode != new_mode or old_hexsha != new_hexsha:
-                yield commands.FileModifyCommand(new_path, new_mode, marker,
-                    None)
+                prefixed_marker = b':%s' %  (marker,)
+                yield commands.FileModifyCommand(
+                    new_path, new_mode, prefixed_marker, None
+                )
 
     def _export_commit(self, commit, ref, base_tree=None):
         file_cmds = list(self._iter_files(base_tree, commit.tree))

--- a/dulwich/tests/test_fastexport.py
+++ b/dulwich/tests/test_fastexport.py
@@ -84,7 +84,7 @@ author Jelmer <jelmer@host> 1271345553 +0000
 committer Jelmer <jelmer@host> 1271345553 +0000
 data 3
 msg
-M 644 1 foo
+M 644 :1 foo
 """, self.stream.getvalue())
 
 


### PR DESCRIPTION
The `fastexport.GitFastExporter` generating invalid exports, like this one: 
```
$ > git fast-import << EOF
blob
mark :1
data 17
{"name": "Felix"}
commit refs/heads/master
mark :2
author Foo Bar <foo.bar@foo.bar> 1461062670 -0200
committer Foo Bar <foo.bar@foo.bar> 1461062670 -0200
data 14
Initial commit
M 644 1 test
EOF
$ > fatal: Invalid dataref: M 644 1 test
```
The line`M 644 1 test`  should be `M 644 :1 test` 

I fixed `fastexport.GitFastExporter._iter_files` method and the corresponding test.