### PR TITLE
MemoryObjectStore loses objects

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -685,6 +685,14 @@ class MemoryObjectStore(BaseObjectStore):
             This dict only accept bytestring of 40 as keys and ShaFile
             instances for values.
         """
+        def __init__(self, copy_only=True):
+            """
+                :param copy_only: (bool)
+                        If set at False the store will behave like a normal
+                        dictionary and will not return copies of the stored
+                        object. True by default.
+            """
+            self._copy_only = copy_only
 
         def __getitem__(self, key):
             if not len(key) == 40 or not isinstance(key, bytes):
@@ -694,7 +702,7 @@ class MemoryObjectStore(BaseObjectStore):
 
             sha_object = super(MemoryObjectStore.Store, self).__getitem__(key)
 
-            return sha_object.copy()
+            return sha_object.copy() if self._copy_only else sha_object
 
         def __setitem__(self, key, value):
             if not len(key) == 40 or not isinstance(key, bytes):
@@ -708,7 +716,7 @@ class MemoryObjectStore(BaseObjectStore):
                     )
                 )
 
-            sha_object = value.copy()
+            sha_object = value.copy() if self._copy_only else value
 
             super(MemoryObjectStore.Store, self).__setitem__(key, sha_object)
 
@@ -721,9 +729,14 @@ class MemoryObjectStore(BaseObjectStore):
                 for sha_object in super(Store, self).values()
             )
 
-    def __init__(self):
+    def __init__(self, safe_store=True):
+        """
+            :param safe_store: (bool)
+                If set to False the store may lose objects if there are
+                updated directly. True by default.
+        """
         super(MemoryObjectStore, self).__init__()
-        self._data = MemoryObjectStore.Store()
+        self._data = MemoryObjectStore.Store(copy_only=safe_store)
 
     def _to_hexsha(self, sha):
         if len(sha) == 40:

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -678,8 +678,7 @@ class MemoryObjectStore(BaseObjectStore):
     """Object store that keeps all objects in memory."""
 
     class Store(dict):
-        """Store the object as raw string and always returns a new object when
-            accessed.
+        """Store the object but always returns a new object when accessed.
             This prevent to lose objects by updating directly an object and
             losing the previous version.
 
@@ -693,11 +692,9 @@ class MemoryObjectStore(BaseObjectStore):
                     "'key' must be bytestring, not %.80s" % type(key).__name__
                 )
 
-            type_num, raw_string = super(
-                MemoryObjectStore.Store, self
-            ).__getitem__(key)
+            sha_object = super(MemoryObjectStore.Store, self).__getitem__(key)
 
-            return ShaFile.from_raw_string(type_num, raw_string, key)
+            return sha_object.copy()
 
         def __setitem__(self, key, value):
             if not len(key) == 40 or not isinstance(key, bytes):
@@ -711,17 +708,17 @@ class MemoryObjectStore(BaseObjectStore):
                     )
                 )
 
-            super(MemoryObjectStore.Store, self).__setitem__(
-                key, (value.type, value.as_raw_string())
-            )
+            sha_object = value.copy()
+
+            super(MemoryObjectStore.Store, self).__setitem__(key, sha_object)
 
         def get(self, key):
             return self[key]
 
         def values(self):
             return (
-                ShaFile.from_raw_string(*values)
-                for values in super(Store, self).values()
+                self[sha_object.id]
+                for sha_object in super(Store, self).values()
             )
 
     def __init__(self):

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -957,9 +957,19 @@ class MemoryRepo(BaseRepo):
     those have a stronger dependency on the filesystem.
     """
 
-    def __init__(self):
+    def __init__(self, safe_store=True):
+        """
+            :param safe_store: (bool)
+                If set to False the store may lose objects if there are
+                updated directly. True by default.
+        """
         from dulwich.config import ConfigFile
-        BaseRepo.__init__(self, MemoryObjectStore(), DictRefsContainer({}))
+        BaseRepo.__init__(
+            self,
+            MemoryObjectStore(safe_store=safe_store),
+            DictRefsContainer({})
+        )
+
         self._named_files = {}
         self.bare = True
         self._config = ConfigFile()
@@ -1009,15 +1019,18 @@ class MemoryRepo(BaseRepo):
         return None
 
     @classmethod
-    def init_bare(cls, objects, refs):
+    def init_bare(cls, objects, refs, safe_store=True):
         """Create a new bare repository in memory.
 
         :param objects: Objects for the new repository,
             as iterable
         :param refs: Refs as dictionary, mapping names
             to object SHA1s
+        :param safe_store: (bool)
+                If set to False the store may lose objects if there are
+                updated directly. True by default.
         """
-        ret = cls()
+        ret = cls(safe_store=safe_store)
         for obj in objects:
             ret.object_store.add_object(obj)
         for refname, sha in refs.items():

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -87,6 +87,20 @@ class ObjectStoreTests(object):
         # access to a serialized form.
         self.store.add_objects([])
 
+    def test_store_resilience(self):
+        """Test if updating an existing stored object doesn't erase the
+        object from the store.
+        """
+        test_object = make_object(Blob, data=b'data')
+
+        self.store.add_object(test_object)
+        test_object_id = test_object.id
+        test_object.data = test_object.data + b'update'
+        stored_test_object = self.store[test_object_id]
+
+        self.assertNotEqual(test_object.id, stored_test_object.id)
+        self.assertEqual(stored_test_object.id, test_object_id)
+
     def test_add_object(self):
         self.store.add_object(testobject)
         self.assertEqual(set([testobject.id]), set(self.store))

--- a/dulwich/tests/test_web.py
+++ b/dulwich/tests/test_web.py
@@ -128,12 +128,12 @@ class WebTestCase(TestCase):
         self.assertTrue(('Content-Type', expected) in self._headers)
 
 
-def _test_backend(objects, refs=None, named_files=None):
+def _test_backend(objects, refs=None, named_files=None, safe_store=True):
     if not refs:
         refs = {}
     if not named_files:
         named_files = {}
-    repo = MemoryRepo.init_bare(objects, refs)
+    repo = MemoryRepo.init_bare(objects, refs, safe_store=safe_store)
     for path, contents in named_files.items():
         repo._put_named_file(path, contents)
     return DictBackend({'/': repo})
@@ -214,7 +214,7 @@ class DumbHandlersTestCase(WebTestCase):
 
     def test_get_loose_object_error(self):
         blob = make_object(Blob, data=b'foo')
-        backend = _test_backend([blob])
+        backend = _test_backend([blob], safe_store=False)
         mat = re.search('^(..)(.{38})$', blob.id.decode('ascii'))
 
         def as_legacy_object_error():


### PR DESCRIPTION
With the current implementation of the `MemoryObjectStore` the store loses the object if you update the object, e.g `store[b'sha'].data = b'new data'`.

This pull request use a customized dict to make sure that don't happen.

``` python
from dulwich.repo import MemoryRepo, Blob, Repo
repository = MemoryRepo() 
blob = Blob.from_string(b'data')
blob_sha = blob.id 
repository.object_store.add_object(blob)
blob.data = b'' 
assert blob.id != blob_sha 
assert repository[blob_sha].id == blob_sha  # that assert fail, the initial blob she should be equal to the stored one.
```