### PR TITLE
Incorrect id value after copying a Tree

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -484,10 +484,15 @@ class ShaFile(object):
     def copy(self):
         """Create a new copy of this SHA1 object from its raw string"""
         obj_class = object_class(self.get_type())
+        # The id need to be retrieved before calling as_raw_string because
+        # that method can overwrite the flag _needs_serialization and by
+        # side effect the self.id property can return an outdated id.
+        hex_sha_id = self.id
+
         return obj_class.from_raw_string(
             self.get_type(),
             self.as_raw_string(),
-            self.id)
+            hex_sha_id)
 
     @property
     def id(self):

--- a/dulwich/tests/test_objects.py
+++ b/dulwich/tests/test_objects.py
@@ -937,6 +937,21 @@ class TagParseTests(ShaFileCheckTests):
             else:
                 self.assertCheckFails(Tag, text)
 
+    def test_tree_copy_after_update(self):
+        """Check if the id of the Tree is correctly
+           updated when the tree is copied after being
+           updated
+        """   
+        shas = []
+        tree = Tree()
+        shas.append(tree.id)
+        tree.add(b'data', 0o644, Blob().id)
+        copied = tree.copy()
+        shas.append(tree.id)
+        shas.append(copied.id)
+
+        self.assertTrue(shas[0] not in shas[1:])
+        self.assertTrue(shas[1] == shas[2])
 
 class CheckTests(TestCase):
 


### PR DESCRIPTION
If a `Tree` is updated and copied the `id` isn't recomputed and the `_need_serializing` value is lost.
That can lead to weird bugs.
The pull-request update the `ShaFile.copy` method to be sure that the id is correct before copying.

```python

from dulwich.objects import Tree, Blob

shas = []
tree = Tree()
shas.append(tree.id)
_ = tree.add(b'data', 0o644, Blob().id)
copied = tree.copy()
shas.append(tree.id)
shas.append(copied.id)

assert shas[0] not in shas[1:] #  fail the initial sha is the same after and before the add operation
assert shas[1] == shas[2]
```