### PR TITLE
Update porcelain docs example to add and commit correctly

### DIFF
--- a/docs/tutorial/porcelain.txt
+++ b/docs/tutorial/porcelain.txt
@@ -30,5 +30,5 @@ Commit changes
 
   >>> r = porcelain.init("testrepo")
   >>> open("testrepo/testfile", "w").write("data")
-  >>> porcelain.add(r, "testrepo/testfile")
-  >>> porcelain.commit(r, "A sample commit")
+  >>> porcelain.add(r, "testfile")
+  >>> porcelain.commit(r, b"A sample commit")


### PR DESCRIPTION
Fixes the example `porcelain.add()` to successfully stage the file. Also makes example `porcelain.commit()` py3 compatible since the file is open for writing with bytes in `prepare_msg()`.

`make doc` succeeds and html output appears as expected.