### PR TITLE
File-like objects' encodings can be set, and None.

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -585,7 +585,7 @@ def push(repo, remote_location, refspecs=None,
                     refs[rh] = r.refs[lh]
             return refs
 
-        err_encoding = getattr(errstream, 'encoding', 'utf-8')
+        err_encoding = getattr(errstream, 'encoding', None) or 'utf-8'
         remote_location_bytes = remote_location.encode(err_encoding)
         try:
             client.send_pack(path, update_refs,


### PR DESCRIPTION
Separately, it seems quite unfortunate that this function's method of communicating errors is by writing to a stream and swallowing the exception. Wouldn't it be useful to have high level git operations but still actually communicate errors in a way that can be handled programmatically?