### PR TITLE
Fix two typos

### DIFF
--- a/dulwich/objectspec.py
+++ b/dulwich/objectspec.py
@@ -80,7 +80,7 @@ def parse_reftuple(lh_container, rh_container, refspec):
         (lh, rh) = refspec.split(b":")
     else:
         lh = rh = refspec
-    if rh == b"":
+    if lh == b"":
         lh = None
     else:
         lh = parse_ref(lh_container, lh)

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -489,9 +489,9 @@ def tag_create(repo, tag, author=None, message=None, annotated=False,
             tag_obj.message = message
             tag_obj.name = tag
             tag_obj.object = (type(object), object.id)
-            tag_obj.tag_time = tag_time
             if tag_time is None:
                 tag_time = int(time.time())
+            tag_obj.tag_time = tag_time
             if tag_timezone is None:
                 # TODO(jelmer) Use current user timezone rather than UTC
                 tag_timezone = 0

--- a/dulwich/tests/test_objectspec.py
+++ b/dulwich/tests/test_objectspec.py
@@ -162,6 +162,16 @@ class ParseReftupleTests(TestCase):
         self.assertEqual((b"refs/heads/foo", b"refs/heads/foo", False),
             parse_reftuple(r, r, b"refs/heads/foo"))
 
+    def test_no_left_ref(self):
+        r = {b"refs/heads/foo": "bla"}
+        self.assertEqual((None, b"refs/heads/foo", False),
+            parse_reftuple(r, r, b":refs/heads/foo"))
+
+    def test_no_right_ref(self):
+        r = {b"refs/heads/foo": "bla"}
+        self.assertEqual((b"refs/heads/foo", None, False),
+            parse_reftuple(r, r, b"refs/heads/foo:"))
+
 
 class ParseReftuplesTests(TestCase):
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -28,6 +28,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+import time
 
 from dulwich import porcelain
 from dulwich.diff_tree import tree_changes
@@ -375,6 +376,7 @@ class TagCreateTests(PorcelainTestCase):
         self.assertTrue(isinstance(tag, Tag))
         self.assertEqual(b"foo <foo@bar.com>", tag.tagger)
         self.assertEqual(b"bar", tag.message)
+        self.assertLess(time.time() - tag.tag_time, 5)
 
     def test_unannotated(self):
         c1, c2, c3 = build_commit_graph(self.repo.object_store, [[1], [2, 1],


### PR DESCRIPTION
One in ref parsing, one in annotated tag times.

As discussed on IRC, the former still doesn't fix deleting tags from a remote repo, but I'll follow up on that after this.

Thanks!