### PR TITLE
Add get_url()-method to clients

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -971,7 +971,7 @@ def default_urllib2_opener(config):
 class HttpGitClient(GitClient):
 
     def __init__(self, base_url, dumb=None, opener=None, config=None, **kwargs):
-        self.base_url = base_url.rstrip("/") + "/"
+        self._base_url = base_url.rstrip("/") + "/"
         self.dumb = dumb
         if opener is None:
             self.opener = default_urllib2_opener(config)
@@ -980,10 +980,10 @@ class HttpGitClient(GitClient):
         GitClient.__init__(self, **kwargs)
 
     def __repr__(self):
-        return "%s(%r, dumb=%r)" % (type(self).__name__, self.base_url, self.dumb)
+        return "%s(%r, dumb=%r)" % (type(self).__name__, self._base_url, self.dumb)
 
     def _get_url(self, path):
-        return urlparse.urljoin(self.base_url, path).rstrip("/") + "/"
+        return urlparse.urljoin(self._base_url, path).rstrip("/") + "/"
 
     def _http_request(self, url, headers={}, data=None):
         req = urllib2.Request(url, headers=headers, data=data)

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -590,7 +590,7 @@ def push(repo, remote_location, refspecs=None,
             return new_refs
 
         err_encoding = getattr(errstream, 'encoding', None) or 'utf-8'
-        remote_location_bytes = remote_location.encode(err_encoding)
+        remote_location_bytes = client.get_url(path).encode(err_encoding)
         try:
             client.send_pack(path, update_refs,
                 r.object_store.generate_pack_contents, progress=errstream.write)

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -582,6 +582,20 @@ class SSHGitClientTests(TestCase):
         super(SSHGitClientTests, self).tearDown()
         client.get_ssh_vendor = self.real_vendor
 
+    def test_get_url(self):
+        path = '/tmp/repo.git'
+        c = SSHGitClient('git.samba.org')
+
+        url = c.get_url(path)
+        self.assertEqual('ssh://git.samba.org/tmp/repo.git', url)
+
+    def test_get_url_with_username_and_port(self):
+        path = '/tmp/repo.git'
+        c = SSHGitClient('git.samba.org', port=2222, username='user')
+
+        url = c.get_url(path)
+        self.assertEqual('ssh://user@git.samba.org:2222/tmp/repo.git', url)
+
     def test_default_command(self):
         self.assertEqual(b'git-upload-pack',
                 self.client._get_cmd_path(b'upload-pack'))
@@ -640,6 +654,13 @@ class ReportStatusParserTests(TestCase):
 
 
 class LocalGitClientTests(TestCase):
+
+    def test_get_url(self):
+        path = "/tmp/repo.git"
+        c = LocalGitClient()
+
+        url = c.get_url(path)
+        self.assertEqual('file:///tmp/repo.git', url)
 
     def test_fetch_into_empty(self):
         c = LocalGitClient()
@@ -710,3 +731,34 @@ class LocalGitClientTests(TestCase):
         obj_local = local.get_object(new_refs[ref_name])
         obj_target = target.get_object(new_refs[ref_name])
         self.assertEqual(obj_local, obj_target)
+
+
+class HttpGitClientTests(TestCase):
+
+    def test_get_url(self):
+        base_url = 'https://github.com/jelmer/dulwich'
+        path = '/jelmer/dulwich'
+        c = HttpGitClient(base_url)
+
+        url = c.get_url(path)
+        self.assertEqual('https://github.com/jelmer/dulwich', url)
+
+
+class TCPGitClientTests(TestCase):
+
+    def test_get_url(self):
+        host = 'github.com'
+        path = '/jelmer/dulwich'
+        c = TCPGitClient(host)
+
+        url = c.get_url(path)
+        self.assertEqual('git://github.com/jelmer/dulwich', url)
+
+    def test_get_url_with_port(self):
+        host = 'github.com'
+        path = '/jelmer/dulwich'
+        port = 9090
+        c = TCPGitClient(host, port=9090)
+
+        url = c.get_url(path)
+        self.assertEqual('git://github.com:9090/jelmer/dulwich', url)


### PR DESCRIPTION
Adds get_url()-method for getting nice looking urls from clients. This url can be used for example for log or debug messages. 

This pull request is in preparation for adding support for http-authentication where username and password are in url and should not  be written to log.