### PR TITLE
Username and password support for HttpGitClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
 matrix:
   include:
     - python: "2.7"
-      env: TEST_REQUIRE="gevent greenlet geventhttpclient fastimport"
+      env: TEST_REQUIRE="gevent greenlet geventhttpclient fastimport mock"
     - python: "pypy"
-      env: TEST_REQUIRE="fastimport"
+      env: TEST_REQUIRE="fastimport mock"
     - python: "3.4"
       env: TEST_REQUIRE="gevent greenlet geventhttpclient fastimport"
     - python: "3.5"

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -998,16 +998,16 @@ def default_urllib2_opener(config):
 class HttpGitClient(GitClient):
 
     def __init__(self, base_url, dumb=None, opener=None, config=None,
-                 user='',passwd='', **kwargs):
+                 username=None, passwd=None, **kwargs):
         self._base_url = base_url.rstrip("/") + "/"
         self.dumb = dumb
         if opener is None:
             self.opener = default_urllib2_opener(config)
         else:
             self.opener = opener
-        if user:
+        if username is not None:
             pass_man=urllib2.HTTPPasswordMgrWithDefaultRealm()
-            pass_man.add_password(None,base_url,user,passwd)
+            pass_man.add_password(None, base_url, username, passwd)
             self.opener.add_handler(urllib2.HTTPBasicAuthHandler(pass_man))
         GitClient.__init__(self, **kwargs)
 
@@ -1194,7 +1194,7 @@ def get_transport_and_path_from_url(url, config=None, **kwargs):
                             username=parsed.username, **kwargs), path
     elif parsed.scheme in ('http', 'https'):
         base_url = urlparse.urlunparse(parsed._replace(netloc=host))
-        return HttpGitClient(base_url, config=config, user=parsed.username,
+        return HttpGitClient(base_url, config=config, username=parsed.username,
                              passwd=parsed.password, **kwargs), parsed.path
     elif parsed.scheme == 'file':
         return default_local_git_client_cls(**kwargs), parsed.path

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1005,7 +1005,11 @@ class HttpGitClient(GitClient):
             self.opener = default_urllib2_opener(config)
         else:
             self.opener = opener
-        if username is not None:
+
+        if passwd is None:
+            passwd = ""
+
+        if username:
             pass_man=urllib2.HTTPPasswordMgrWithDefaultRealm()
             pass_man.add_password(None, base_url, username, passwd)
             self.opener.add_handler(urllib2.HTTPBasicAuthHandler(pass_man))

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -997,13 +997,18 @@ def default_urllib2_opener(config):
 
 class HttpGitClient(GitClient):
 
-    def __init__(self, base_url, dumb=None, opener=None, config=None, **kwargs):
+    def __init__(self, base_url, dumb=None, opener=None, config=None,
+                 user='',passwd='', **kwargs):
         self._base_url = base_url.rstrip("/") + "/"
         self.dumb = dumb
         if opener is None:
             self.opener = default_urllib2_opener(config)
         else:
             self.opener = opener
+        if user:
+            pass_man=urllib2.HTTPPasswordMgrWithDefaultRealm()
+            pass_man.add_password(None,base_url,user,passwd)
+            self.opener.add_handler(urllib2.HTTPBasicAuthHandler(pass_man))
         GitClient.__init__(self, **kwargs)
 
     def get_url(self, path):
@@ -1177,6 +1182,7 @@ def get_transport_and_path_from_url(url, config=None, **kwargs):
     :return: Tuple with client instance and relative path.
     """
     parsed = urlparse.urlparse(url)
+    auth, host = urllib2.splituser(parsed.netloc)
     if parsed.scheme == 'git':
         return (TCPGitClient(parsed.hostname, port=parsed.port, **kwargs),
                 parsed.path)
@@ -1187,8 +1193,9 @@ def get_transport_and_path_from_url(url, config=None, **kwargs):
         return SSHGitClient(parsed.hostname, port=parsed.port,
                             username=parsed.username, **kwargs), path
     elif parsed.scheme in ('http', 'https'):
-        return HttpGitClient(urlparse.urlunparse(parsed), config=config,
-                **kwargs), parsed.path
+        base_url = urlparse.urlunparse(parsed._replace(netloc=host))
+        return HttpGitClient(base_url, config=config, user=parsed.username,
+                             passwd=parsed.password, **kwargs), parsed.path
     elif parsed.scheme == 'file':
         return default_local_git_client_cls(**kwargs), parsed.path
 

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -22,6 +22,11 @@ import sys
 import shutil
 import tempfile
 
+try:
+    # Python >= 3.3
+    from unittest import mock
+except ImportError:
+    import mock
 
 import dulwich
 from dulwich import (
@@ -463,6 +468,38 @@ class TestGetTransportAndPath(TestCase):
         self.assertTrue(isinstance(c, HttpGitClient))
         self.assertEqual('/jelmer/dulwich', path)
 
+    def test_http_auth(self):
+        url = 'https://user:passwd@github.com/jelmer/dulwich'
+
+        with mock.patch('dulwich.client.HttpGitClient.__init__') as init_mock:
+            init_mock.return_value = None
+            c, path = get_transport_and_path(url)
+
+            self.assertTrue(isinstance(c, HttpGitClient))
+            self.assertEqual('/jelmer/dulwich', path)
+
+            init_mock.assert_called_once_with(
+                'https://github.com/jelmer/dulwich',
+                config=None,
+                username='user',
+                passwd='passwd')
+
+    def test_http_no_auth(self):
+        url = 'https://github.com/jelmer/dulwich'
+
+        with mock.patch('dulwich.client.HttpGitClient.__init__') as init_mock:
+            init_mock.return_value = None
+            c, path = get_transport_and_path(url)
+
+            self.assertTrue(isinstance(c, HttpGitClient))
+            self.assertEqual('/jelmer/dulwich', path)
+
+            init_mock.assert_called_once_with(
+                'https://github.com/jelmer/dulwich',
+                config=None,
+                username=None,
+                passwd=None)
+
 
 class TestGetTransportAndPathFromUrl(TestCase):
 
@@ -743,6 +780,31 @@ class HttpGitClientTests(TestCase):
         url = c.get_url(path)
         self.assertEqual('https://github.com/jelmer/dulwich', url)
 
+    def test_get_url_with_username_and_passwd(self):
+        base_url = 'https://github.com/jelmer/dulwich'
+        path = '/jelmer/dulwich'
+        c = HttpGitClient(base_url, username='USERNAME', passwd='PASSWD')
+
+        url = c.get_url(path)
+        self.assertEqual('https://github.com/jelmer/dulwich', url)
+
+    def test_init_username_passwd_set(self):
+        url = 'https://user:passwd@github.com/jelmer/dulwich'
+
+        with mock.patch('dulwich.client.urllib2.HTTPPasswordMgrWithDefaultRealm.add_password') as passman_mock:
+
+            c = HttpGitClient(url, config=None, username='user', passwd='passwd')
+            passman_mock.assert_called_once_with(
+                None,
+                url, 'user', 'passwd')
+
+    def test_init_no_username_passwd(self):
+        url = 'https://github.com/jelmer/dulwich'
+
+        with mock.patch('dulwich.client.urllib2.HTTPPasswordMgrWithDefaultRealm.add_password') as passman_mock:
+
+            c = HttpGitClient(url, config=None)
+            self.assertFalse(passman_mock.called)
 
 class TCPGitClientTests(TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,18 @@ commands = make check
 recreate = True
 whitelist_externals = make
 
+[testenv:py27]
+deps = mock
+
+[testenv:pypy]
+deps = mock
+
 [testenv:py27-noext]
+deps = mock
 commands = make check-noextensions
 
 [testenv:pypy-noext]
+deps = mock
 commands = make check-noextensions
 
 [testenv:py34-noext]


### PR DESCRIPTION
Added tests for original pull request #404 by @jsbain and rebased jsbain's changes against master. Original pull request fixes issue #249. Additionally added support for only supplying username which allows to use github personal access tokens in url. This should fix issue #428.

I wrote few tests for this that make sure that username and password end up in HttpGitClient when using get_transport_and_path. Additionally tests make sure that init actually ends up calling HTTPPasswordMgrWithDefaultRealm.add_password.
