### PR TITLE
Fix #448

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -569,9 +569,9 @@ class DiskObjectStore(PackBasedObjectStore):
         pack_base_name = self._get_pack_basepath(entries)
         try:
             os.rename(path, pack_base_name + '.pack')
-        except OSError:
+        except WindowsError:
             os.remove(pack_base_name + '.pack')
-            os.rename(path, pack_base_name + '.pack')   
+            os.rename(path, pack_base_name + '.pack')
 
         # Write the index.
         index_file = GitFile(pack_base_name + '.idx', 'wb')

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -567,7 +567,11 @@ class DiskObjectStore(PackBasedObjectStore):
         # Move the pack in.
         entries.sort()
         pack_base_name = self._get_pack_basepath(entries)
-        os.rename(path, pack_base_name + '.pack')
+        try:
+            os.rename(path, pack_base_name + '.pack')
+        except OSError:
+            os.remove(pack_base_name + '.pack')
+            os.rename(path, pack_base_name + '.pack')   
 
         # Write the index.
         index_file = GitFile(pack_base_name + '.idx', 'wb')


### PR DESCRIPTION
* On Windows, os.rename will thrown WindowsError if the destination already exists.