### PR TITLE
appveyor: upgrade win32 to build-220, add py3.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,22 @@
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py2.7.exe"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win32-py2.7.exe"
 
     - PYTHON: "C:\\Python34"
-      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win32-py3.4.exe"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win32-py3.4.exe"
+
+    - PYTHON: "C:\\Python35"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win32-py3.5.exe"
 
     - PYTHON: "C:\\Python27-x64"
-      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win-amd64-py2.7.exe"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win-amd64-py2.7.exe"
 
     - PYTHON: "C:\\Python34-x64"
-      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20219/pywin32-219.win-amd64-py3.4.exe"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win-amd64-py3.4.exe"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYWIN32_URL: "https://downloads.sourceforge.net/project/pywin32/pywin32/Build%20220/pywin32-220.win-amd64-py3.5.exe"
 
 install:
   - ps: (new-object net.webclient).DownloadFile($env:PYWIN32_URL, 'c:\\pywin32.exe')


### PR DESCRIPTION
- Added PY3.5 (32 & 64 bit).
- Upgraded *win32* lib from [build-219(2014) --> build-220(2016)](https://sourceforge.net/projects/pywin32/files/pywin32/).
- The success ratio has not changed (neither with the new *win32* lib nor under PY35):

  - [2014-win32 (build-219)](https://ci.appveyor.com/project/ankostis/dulwich/build/1.0.2):
    - PY27-32bit: (failures=1, skipped=147, expected failures=1)
    - PY34-32bit: (errors=25, skipped=153, expected failures=1)
    - PY35-32bit: (errors=25, skipped=153, expected failures=1)
    - PY27-64bit: (failures=1, skipped=147, expected failures=1)
    - PY34-64bit: (errors=25, skipped=153, expected failures=1)
    - PY35-64bit: (errors=25, skipped=153, expected failures=1)
  
  - [2016-win32 (build-220)](https://ci.appveyor.com/project/ankostis/dulwich/build/1.0.3):
    - PY27-32bit: (failures=1, skipped=147, expected failures=1)
    - PY34-32bit: (errors=25, skipped=153, expected failures=1)
    - PY35-32bit: (errors=25, skipped=153, expected failures=1)
    - PY27-64bit: (failures=1, skipped=147, expected failures=1)
    - PY34-64bit: (errors=25, skipped=153, expected failures=1)
    - PY35-64bit: (errors=25, skipped=153, expected failures=1) (!!)

Unfortunately, on Win+PY35 the TCs fo not alwasy finishe!
See this job, where it stuck on `test_get_refs (dulwich.tests.compat.test_client.DulwichTCPClientTest)`: https://ci.appveyor.com/project/ankostis/dulwich/build/1.0.4/job/kbnrqno5gk6q25bp