### PR TITLE
Fix losing error message when socket connection fails

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -672,7 +672,7 @@ class TCPGitClient(TraditionalGitClient):
             try:
                 s.connect(sockaddr)
                 break
-            except socket.error as err:
+            except socket.error:
                 if s is not None:
                     s.close()
                 s = None


### PR DESCRIPTION
I don't know if the err variable here was intentional or not.
But this does not behave properly.
This breaks with UnboundLocalError, thus losing a precious information about the initial problem.

- Tests are still ok 
- runtime gives the right error message with this patch applied.

Related #459