### PR TITLE
Fix porcelain.reset to not ignore committish argument.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,9 @@
 
  BUG FIXES
 
+  * Fix ``porcelain.reset`` to respect the comittish argument.
+    (Koen Martens)
+
   * Fix handling of ``Commit.tree`` being set to an actual
    tree object rather than a tree id. (Jelmer Vernooij)
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -628,7 +628,7 @@ def reset(repo, mode, committish="HEAD"):
 
     with open_repo_closing(repo) as r:
         tree = r[committish].tree
-        r.reset_index()
+        r.reset_index(tree)
 
 
 def push(repo, remote_location, refspecs=None,

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -444,6 +444,30 @@ class ResetTests(PorcelainTestCase):
 
         self.assertEqual([], changes)
 
+    def test_hard_commit(self):
+        with open(os.path.join(self.repo.path, 'foo'), 'w') as f:
+            f.write("BAR")
+        porcelain.add(self.repo.path, paths=["foo"])
+        sha = porcelain.commit(self.repo.path, message=b"Some message",
+                committer=b"Jane <jane@example.com>",
+                author=b"John <john@example.com>")
+
+        with open(os.path.join(self.repo.path, 'foo'), 'wb') as f:
+            f.write(b"BAZ")
+        porcelain.add(self.repo.path, paths=["foo"])
+        porcelain.commit(self.repo.path, message=b"Some other message",
+                committer=b"Jane <jane@example.com>",
+                author=b"John <john@example.com>")
+
+        porcelain.reset(self.repo, "hard", sha)
+
+        index = self.repo.open_index()
+        changes = list(tree_changes(self.repo,
+                       index.commit(self.repo.object_store),
+                       self.repo[sha].tree))
+
+        self.assertEqual([], changes)
+
 
 class PushTests(PorcelainTestCase):
 


### PR DESCRIPTION
Spotted a bug, wrote test-case for it, fixed the bug.

This is just a prelude to fixing a more elaborate issue, which is that porcelain.reset() will leave files in the working directory that should be removed when doing a hard reset.