### PR TITLE
Repo: enable "with" statement support for closing

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,11 @@
   * Fixed failing test-cases on windows.
     (Koen Martens)
 
+ API CHANGES
+
+  * Repo is now a context manager, so that it can be easily
+    closed using a ``with`` statement.
+
  TEST FIXES
 
   * Only run worktree list compat tests against git 2.7.0,

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1057,6 +1057,12 @@ class Repo(BaseRepo):
         """Close any files opened by this repository."""
         self.object_store.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
 
 class MemoryRepo(BaseRepo):
     """Repo that stores refs, objects, and named files in memory.

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -20,7 +20,6 @@
 
 """Compatibilty tests between the Dulwich client and the cgit server."""
 
-from contextlib import closing
 import copy
 from io import BytesIO
 import os
@@ -87,8 +86,8 @@ class DulwichClientTestBase(object):
     def assertDestEqualsSrc(self):
         repo_dir = os.path.join(self.gitroot, 'server_new.export')
         dest_repo_dir = os.path.join(self.gitroot, 'dest')
-        with closing(repo.Repo(repo_dir)) as src:
-            with closing(repo.Repo(dest_repo_dir)) as dest:
+        with repo.Repo(repo_dir) as src:
+            with repo.Repo(dest_repo_dir) as dest:
                 self.assertReposEqual(src, dest)
 
     def _client(self):
@@ -100,7 +99,7 @@ class DulwichClientTestBase(object):
     def _do_send_pack(self):
         c = self._client()
         srcpath = os.path.join(self.gitroot, 'server_new.export')
-        with closing(repo.Repo(srcpath)) as src:
+        with repo.Repo(srcpath) as src:
             sendrefs = dict(src.get_refs())
             del sendrefs[b'HEAD']
             c.send_pack(self._build_path(b'/dest'), lambda _: sendrefs,
@@ -120,7 +119,7 @@ class DulwichClientTestBase(object):
         c = self._client()
         c._send_capabilities.remove(b'report-status')
         srcpath = os.path.join(self.gitroot, 'server_new.export')
-        with closing(repo.Repo(srcpath)) as src:
+        with repo.Repo(srcpath) as src:
             sendrefs = dict(src.get_refs())
             del sendrefs[b'HEAD']
             c.send_pack(self._build_path(b'/dest'), lambda _: sendrefs,
@@ -157,7 +156,7 @@ class DulwichClientTestBase(object):
         dest, dummy_commit = self.disable_ff_and_make_dummy_commit()
         dest.refs[b'refs/heads/master'] = dummy_commit
         repo_dir = os.path.join(self.gitroot, 'server_new.export')
-        with closing(repo.Repo(repo_dir)) as src:
+        with repo.Repo(repo_dir) as src:
             sendrefs, gen_pack = self.compute_send(src)
             c = self._client()
             try:
@@ -175,7 +174,7 @@ class DulwichClientTestBase(object):
         branch, master = b'refs/heads/branch', b'refs/heads/master'
         dest.refs[branch] = dest.refs[master] = dummy
         repo_dir = os.path.join(self.gitroot, 'server_new.export')
-        with closing(repo.Repo(repo_dir)) as src:
+        with repo.Repo(repo_dir) as src:
             sendrefs, gen_pack = self.compute_send(src)
             c = self._client()
             try:
@@ -200,7 +199,7 @@ class DulwichClientTestBase(object):
 
     def test_fetch_pack(self):
         c = self._client()
-        with closing(repo.Repo(os.path.join(self.gitroot, 'dest'))) as dest:
+        with repo.Repo(os.path.join(self.gitroot, 'dest')) as dest:
             refs = c.fetch(self._build_path(b'/server_new.export'), dest)
             for r in refs.items():
                 dest.refs.set_if_equals(r[0], None, r[1])
@@ -212,7 +211,7 @@ class DulwichClientTestBase(object):
         dest.refs[b'refs/heads/master'] = dummy
         c = self._client()
         repo_dir = os.path.join(self.gitroot, 'server_new.export')
-        with closing(repo.Repo(repo_dir)) as dest:
+        with repo.Repo(repo_dir) as dest:
             refs = c.fetch(self._build_path(b'/dest'), dest)
             for r in refs.items():
                 dest.refs.set_if_equals(r[0], None, r[1])
@@ -221,7 +220,7 @@ class DulwichClientTestBase(object):
     def test_fetch_pack_no_side_band_64k(self):
         c = self._client()
         c._fetch_capabilities.remove(b'side-band-64k')
-        with closing(repo.Repo(os.path.join(self.gitroot, 'dest'))) as dest:
+        with repo.Repo(os.path.join(self.gitroot, 'dest')) as dest:
             refs = c.fetch(self._build_path(b'/server_new.export'), dest)
             for r in refs.items():
                 dest.refs.set_if_equals(r[0], None, r[1])
@@ -231,14 +230,14 @@ class DulwichClientTestBase(object):
         # zero sha1s are already present on the client, and should
         # be ignored
         c = self._client()
-        with closing(repo.Repo(os.path.join(self.gitroot, 'dest'))) as dest:
+        with repo.Repo(os.path.join(self.gitroot, 'dest')) as dest:
             refs = c.fetch(self._build_path(b'/server_new.export'), dest,
                 lambda refs: [protocol.ZERO_SHA])
             for r in refs.items():
                 dest.refs.set_if_equals(r[0], None, r[1])
 
     def test_send_remove_branch(self):
-        with closing(repo.Repo(os.path.join(self.gitroot, 'dest'))) as dest:
+        with repo.Repo(os.path.join(self.gitroot, 'dest')) as dest:
             dummy_commit = self.make_dummy_commit(dest)
             dest.refs[b'refs/heads/master'] = dummy_commit
             dest.refs[b'refs/heads/abranch'] = dummy_commit
@@ -256,7 +255,7 @@ class DulwichClientTestBase(object):
         refs = c.get_refs(self._build_path(b'/server_new.export'))
 
         repo_dir = os.path.join(self.gitroot, 'server_new.export')
-        with closing(repo.Repo(repo_dir)) as dest:
+        with repo.Repo(repo_dir) as dest:
             self.assertDictEqual(dest.refs.as_dict(), refs)
 
 

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -18,7 +18,6 @@
 # License, Version 2.0.
 #
 
-from contextlib import closing
 from io import BytesIO
 import sys
 import shutil
@@ -753,7 +752,7 @@ class LocalGitClientTests(TestCase):
 
         target_path = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, target_path)
-        with closing(Repo.init_bare(target_path)) as target:
+        with Repo.init_bare(target_path) as target:
             self.send_and_verify(b"master", local, target)
 
     def test_get_refs(self):

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -23,7 +23,6 @@
 """Tests for the index."""
 
 
-from contextlib import closing
 from io import BytesIO
 import os
 import shutil
@@ -267,7 +266,7 @@ class BuildIndexTests(TestCase):
     def test_empty(self):
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
-        with closing(Repo.init(repo_dir)) as repo:
+        with Repo.init(repo_dir) as repo:
             tree = Tree()
             repo.object_store.add_object(tree)
 
@@ -284,7 +283,7 @@ class BuildIndexTests(TestCase):
     def test_git_dir(self):
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
-        with closing(Repo.init(repo_dir)) as repo:
+        with Repo.init(repo_dir) as repo:
 
             # Populate repo
             filea = Blob.from_string(b'file a')
@@ -318,7 +317,7 @@ class BuildIndexTests(TestCase):
     def test_nonempty(self):
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
-        with closing(Repo.init(repo_dir)) as repo:
+        with Repo.init(repo_dir) as repo:
 
             # Populate repo
             filea = Blob.from_string(b'file a')
@@ -371,7 +370,7 @@ class BuildIndexTests(TestCase):
     def test_symlink(self):
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
-        with closing(Repo.init(repo_dir)) as repo:
+        with Repo.init(repo_dir) as repo:
 
             # Populate repo
             filed = Blob.from_string(b'file d')
@@ -403,7 +402,7 @@ class BuildIndexTests(TestCase):
         repo_dir = tempfile.mkdtemp()
         repo_dir_bytes = repo_dir.encode(sys.getfilesystemencoding())
         self.addCleanup(shutil.rmtree, repo_dir)
-        with closing(Repo.init(repo_dir)) as repo:
+        with Repo.init(repo_dir) as repo:
 
             # Populate repo
             file = Blob.from_string(b'foo')
@@ -438,7 +437,7 @@ class GetUnstagedChangesTests(TestCase):
 
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
-        with closing(Repo.init(repo_dir)) as repo:
+        with Repo.init(repo_dir) as repo:
 
             # Commit a dummy file then modify it
             foo1_fullpath = os.path.join(repo_dir, 'foo1')

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -20,7 +20,6 @@
 
 """Tests for dulwich.porcelain."""
 
-from contextlib import closing
 from io import BytesIO
 try:
     from StringIO import StringIO
@@ -148,11 +147,11 @@ class CloneTests(PorcelainTestCase):
         target_path = tempfile.mkdtemp()
         errstream = BytesIO()
         self.addCleanup(shutil.rmtree, target_path)
-        with closing(porcelain.clone(self.repo.path, target_path,
-                                     checkout=True,
-                                     errstream=errstream)) as r:
+        with porcelain.clone(self.repo.path, target_path,
+                             checkout=True,
+                             errstream=errstream) as r:
             self.assertEqual(r.path, target_path)
-        with closing(Repo(target_path)) as r:
+        with Repo(target_path) as r:
             self.assertEqual(r.head(), c3.id)
         self.assertTrue('f1' in os.listdir(target_path))
         self.assertTrue('f2' in os.listdir(target_path))
@@ -519,7 +518,7 @@ class PushTests(PorcelainTestCase):
             errstream=errstream)
 
         # Check that the target and source
-        with closing(Repo(clone_path)) as r_clone:
+        with Repo(clone_path) as r_clone:
             self.assertEqual({
                 b'HEAD': new_id,
                 b'refs/heads/foo': r_clone[b'HEAD'].id,
@@ -606,7 +605,7 @@ class PullTests(PorcelainTestCase):
             outstream=outstream, errstream=errstream)
 
         # Check the target repo for pushed changes
-        with closing(Repo(self.target_path)) as r:
+        with Repo(self.target_path) as r:
             self.assertEqual(r[b'HEAD'].id, self.repo[b'HEAD'].id)
 
     def test_no_refspec(self):
@@ -618,7 +617,7 @@ class PullTests(PorcelainTestCase):
                        errstream=errstream)
 
         # Check the target repo for pushed changes
-        with closing(Repo(self.target_path)) as r:
+        with Repo(self.target_path) as r:
             self.assertEqual(r[b'HEAD'].id, self.repo[b'HEAD'].id)
 
 
@@ -838,7 +837,7 @@ class FetchTests(PorcelainTestCase):
             errstream=errstream)
 
         # Check the target repo for pushed changes
-        with closing(Repo(target_path)) as r:
+        with Repo(target_path) as r:
             self.assertTrue(self.repo[b'HEAD'].id in r)
 
 

--- a/dulwich/tests/test_repository.py
+++ b/dulwich/tests/test_repository.py
@@ -21,7 +21,6 @@
 
 """Tests for the repository."""
 
-from contextlib import closing
 import locale
 import os
 import stat
@@ -239,7 +238,7 @@ class RepositoryRootTests(TestCase):
         r = self.open_repo('a.git')
         tmp_dir = self.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
-        with closing(r.clone(tmp_dir, mkdir=False)) as t:
+        with r.clone(tmp_dir, mkdir=False) as t:
             self.assertEqual({
                 b'HEAD': b'a90fa2d900a17e99b433217e988c4eb4a2e9a097',
                 b'refs/remotes/origin/master':
@@ -330,7 +329,7 @@ class RepositoryRootTests(TestCase):
                         os.path.join(temp_dir, 'a.git'), symlinks=True)
         rel = os.path.relpath(os.path.join(repo_dir, 'submodule'), temp_dir)
         os.symlink(os.path.join(rel, 'dotgit'), os.path.join(temp_dir, '.git'))
-        with closing(Repo(temp_dir)) as r:
+        with Repo(temp_dir) as r:
             self.assertEqual(r.head(), b'a90fa2d900a17e99b433217e988c4eb4a2e9a097')
 
     def test_common_revisions(self):
@@ -531,7 +530,7 @@ exit 1
         bare = self.open_repo('a.git')
         tmp_dir = self.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
-        with closing(bare.clone(tmp_dir, mkdir=False)) as nonbare:
+        with bare.clone(tmp_dir, mkdir=False) as nonbare:
             check(nonbare)
             check(bare)
 


### PR DESCRIPTION
This makes Repo a context manager to allow closing using `with` (like most other closable dulwich classes).

As demonstrated by the test suite changes, this can dramatically simplify some uses. :)