### PR TITLE
Fixing #482

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -481,9 +481,12 @@ class DiskObjectStore(PackBasedObjectStore):
         pack_files = set()
         for name in pack_dir_contents:
             assert isinstance(name, basestring if sys.version_info[0] == 2 else str)
-            # TODO: verify that idx exists first
             if name.startswith("pack-") and name.endswith(".pack"):
-                pack_files.add(name[:-len(".pack")])
+                # verify that idx exists first (otherwise the pack was not yet fully written)
+                idx_name = os.path.splitext(name)[0] + ".idx"
+                if idx_name in pack_dir_contents:
+                    pack_name = name[:-len(".pack")]
+                    pack_files.add(pack_name)
 
         # Open newly appeared pack files
         for f in pack_files:


### PR DESCRIPTION
I believe I have found the problem with #482: Pack files were sometimes loaded into the object store when they were not yet completely written by a different thread. It seems like there is a very small time window where this could happen.

With this change, my automated tests run without errors (multiple clients repeatedly cloning and pushing to the same server repository, running on Windows with Apache and mod_wsgi).
