### PR TITLE
Avoid crashing when accessing the tag_time of a headerless tag.

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -655,6 +655,9 @@ class Tag(ShaFile):
 
     def __init__(self):
         super(Tag, self).__init__()
+        self._tagger = None
+        self._tag_time = None
+        self._tag_timezone = None
         self._tag_timezone_neg_utc = False
 
     @classmethod
@@ -714,6 +717,9 @@ class Tag(ShaFile):
     def _deserialize(self, chunks):
         """Grab the metadata attached to the tag"""
         self._tagger = None
+        self._tag_time = None
+        self._tag_timezone = None
+        self._tag_timezone_neg_utc = False
         for field, value in _parse_message(chunks):
             if field == _OBJECT_HEADER:
                 self._object_sha = value


### PR DESCRIPTION
I had a crash while using [klaus](https://github.com/jonashaag/klaus) to display the linux kernel (see https://github.com/jonashaag/klaus/issues/164).

The cause of the crash was this tag: https://github.com/torvalds/linux/releases/tag/v2.6.13-rc1

The problem seems to be that tags made by old git versions don't have a tagger header (see https://www.spinics.net/lists/git/msg121692.html and following) so `Tag._deserialize` doesn't set `self._tag_time` since it never enters the `elif field == _TAGGER_HEADER:`.

I'm not sure what's the best way to solve this issue but this patch fixes the crash in klaus at least.