### PR TITLE
Replace PyString_AsString with PyString_AS_STRING

### DIFF
--- a/dulwich/_diff_tree.c
+++ b/dulwich/_diff_tree.c
@@ -38,7 +38,6 @@ typedef int Py_ssize_t;
 #define PyInt_AsLong PyLong_AsLong
 #define PyInt_AS_LONG PyLong_AS_LONG
 #define PyString_AS_STRING PyBytes_AS_STRING
-#define PyString_AsString PyBytes_AsString
 #define PyString_AsStringAndSize PyBytes_AsStringAndSize
 #define PyString_Check PyBytes_Check
 #define PyString_CheckExact PyBytes_CheckExact

--- a/dulwich/_pack.c
+++ b/dulwich/_pack.c
@@ -24,7 +24,7 @@
 #if PY_MAJOR_VERSION >= 3
 #define PyInt_FromLong PyLong_FromLong
 #define PyString_AS_STRING PyBytes_AS_STRING
-#define PyString_AsString PyBytes_AsString
+#define PyString_AS_STRING PyBytes_AS_STRING
 #define PyString_Check PyBytes_Check
 #define PyString_CheckExact PyBytes_CheckExact
 #define PyString_FromStringAndSize PyBytes_FromStringAndSize
@@ -133,7 +133,7 @@ static PyObject *py_apply_delta(PyObject *self, PyObject *args)
 		Py_DECREF(py_delta);
 		return NULL;
 	}
-	out = (uint8_t *)PyString_AsString(ret);
+	out = (uint8_t *)PyString_AS_STRING(ret);
 	while (index < delta_len) {
 		uint8_t cmd = delta[index];
 		index++;
@@ -238,7 +238,7 @@ static PyObject *py_bisect_find_sha(PyObject *self, PyObject *args)
 			Py_DECREF(file_sha);
 			return NULL;
 		}
-		cmp = memcmp(PyString_AsString(file_sha), sha, 20);
+		cmp = memcmp(PyString_AS_STRING(file_sha), sha, 20);
 		Py_DECREF(file_sha);
 		if (cmp < 0)
 			start = i + 1;


### PR DESCRIPTION
Fix issue #509: Replace PyString_AsString with PyString_AS_STRING to
workaround a PyPy bug in cpyext (PyPy older than 5.6).