### PR TITLE
Fix TypeError: mix str and non-str arguments

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1099,6 +1099,8 @@ class HttpGitClient(GitClient):
             type(self).__name__, self._base_url, self.dumb)
 
     def _get_url(self, path):
+        if not isinstance(path, str):
+            path = path.decode(sys.getfilesystemencoding())
         return urlparse.urljoin(self._base_url, path).rstrip("/") + "/"
 
     def _http_request(self, url, headers={}, data=None):

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -816,6 +816,14 @@ class HttpGitClientTests(TestCase):
         url = c.get_url(path)
         self.assertEqual('https://github.com/jelmer/dulwich', url)
 
+    def test_get_url_bytes_path(self):
+        base_url = 'https://github.com/jelmer/dulwich'
+        path_bytes = b'/jelmer/dulwich'
+        c = HttpGitClient(base_url)
+
+        url = c.get_url(path_bytes)
+        self.assertEqual('https://github.com/jelmer/dulwich', url)
+
     def test_get_url_with_username_and_passwd(self):
         base_url = 'https://github.com/jelmer/dulwich'
         path = '/jelmer/dulwich'


### PR DESCRIPTION
``path`` is supposed to be a bytestring according to [here](https://github.com/jelmer/dulwich/blob/master/dulwich/client.py#L1168) and [there](https://github.com/jelmer/dulwich/blob/master/dulwich/client.py#L1181), while ``self._base_url`` is a ``str``, that will result in ``TypeError: Cannot mix str and non-str arguments`` when calling ``urlparse.urljoin``.