### PR TITLE
Git ignore *.pyd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ apidocs
 *,cover
 .testrepository
 *.pyc
+*.pyd
 *.so
 *~
 *.swp


### PR DESCRIPTION
Compiled extension modules on Windows. Created by `setup.py build_ext --inplace`/`setup.py develop`/`pip install -e`.