### PR TITLE
Correctly handle include, exclude than include in .gitignore

### DIFF
--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -144,8 +144,7 @@ class IgnoreFilter(object):
         for pattern in self._patterns:
             if pattern[0:1] == b'!':
                 if match_pattern(path, pattern[1:]):
-                    # Explicitly excluded.
-                    return False
+                    status = False
             else:
                 if pattern[0:1] == b'\\':
                     pattern = pattern[1:]

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -132,6 +132,10 @@ class IgnoreFilterTests(unittest.TestCase):
         self.assertFalse(filter.is_ignored(b'c.c'))
         self.assertIs(None, filter.is_ignored(b'd.c'))
 
+    def test_include_exclude_include(self):
+        filter = IgnoreFilter([b'a.c', b'!a.c', b'a.c'])
+        filter.assertTrue(filter.isignored('a.c'))
+
 
 class IgnoreFilterStackTests(unittest.TestCase):
 
@@ -144,4 +148,3 @@ class IgnoreFilterStackTests(unittest.TestCase):
         self.assertIs(True, stack.is_ignored(b'c.c'))
         self.assertIs(False, stack.is_ignored(b'd.c'))
         self.assertIs(None, stack.is_ignored(b'e.c'))
-


### PR DESCRIPTION
For example, for a .gitignore file like:
```
test
!test
test
```

"test" should be ignored.

Related issue: #526

## Reproduction
```sh
git init temp && cd temp
touch test
cat > .gitignore <<EOF
test
!test
test
EOF
git check-ignore -v test
```

Output:
```
.gitignore:3:test       test
```
(The file is ignored)

Dulwich (before fix):
```py
>>> from dulwich import ignore
>>> with open('.gitignore', 'r') as f:
...     a = ignore.IgnoreFilter(ignore.read_ignore_patterns(f))
...
>>> a.is_ignored('test')
False
```