### PR TITLE
A pattern with only a trailing slash should be treated as a glob

### DIFF
--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -36,7 +36,7 @@ def translate(pat):
 
     res = b'(?ms)'
 
-    if b'/' not in pat:
+    if b'/' not in pat[:-1]:
         # If there's no slash, this is a filename-based match
         res = res + b'(.*/)?'
 

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -47,12 +47,14 @@ POSITIVE_MATCH_TESTS = [
     (b"bla.c", b"**/bla.c"),
     (b"foo/bar", b"foo/**/bar"),
     (b"foo/bla/bar", b"foo/**/bar"),
+    (b"foo/bar/", b"bar/"),
 ]
 
 NEGATIVE_MATCH_TESTS = [
     (b"foo.c", b"foo.[dh]"),
     (b"foo/foo.c", b"/foo.c"),
     (b"foo/foo.c", b"/*.c"),
+    (b"foo/bar/", b"/bar/"),
 ]
 
 


### PR DESCRIPTION
A pattern like "bar/" should still ignore "foo/bar/", but "/bar/" should
not.

Related issue: #526

## Reproduction
```sh
git init temp && cd temp
mkdir -p test/foo
cat > .gitignore <<EOF
foo/
EOF
git check-ignore -v test/foo
```

Output:
```
.gitignore:1:foo/       test/foo
```
(The file is ignored)

Dulwich (before fix):
```py
>>> from dulwich import ignore
>>> with open('.gitignore', 'r') as f:
...     a = ignore.IgnoreFilter(ignore.read_ignore_patterns(f))
...
>>> a.is_ignored('test/foo/')
# None
```