### PR TITLE
gitignore patterns without a trailing slash should match directories too

### DIFF
--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -81,6 +81,10 @@ def translate(pat):
                 res = res + b'[' + stuff + b']'
         else:
             res = res + re.escape(c)
+
+    if not res.endswith(b'/'):
+        res = res + b'/?'
+
     return res + b'\Z'
 
 

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -48,6 +48,7 @@ POSITIVE_MATCH_TESTS = [
     (b"foo/bar", b"foo/**/bar"),
     (b"foo/bla/bar", b"foo/**/bar"),
     (b"foo/bar/", b"bar/"),
+    (b"foo/bar/", b"bar"),
 ]
 
 NEGATIVE_MATCH_TESTS = [
@@ -59,16 +60,17 @@ NEGATIVE_MATCH_TESTS = [
 
 
 TRANSLATE_TESTS = [
-    (b"*.c", b'(?ms)(.*/)?[^/]+\\.c\\Z'),
-    (b"foo.c", b'(?ms)(.*/)?foo\\.c\\Z'),
-    (b"/*.c", b'(?ms)[^/]+\\.c\\Z'),
-    (b"/foo.c", b'(?ms)foo\\.c\\Z'),
-    (b"foo.c", b'(?ms)(.*/)?foo\\.c\\Z'),
-    (b"foo.[ch]", b'(?ms)(.*/)?foo\\.[ch]\\Z'),
-    (b"foo/**", b'(?ms)foo(/.*)?\\Z'),
-    (b"foo/**/blie.c", b'(?ms)foo(/.*)?\\/blie\\.c\\Z'),
-    (b"**/bla.c", b'(?ms)(.*/)?bla\\.c\\Z'),
-    (b"foo/**/bar", b'(?ms)foo(/.*)?\\/bar\\Z'),
+    (b"*.c", b'(?ms)(.*/)?[^/]+\\.c/?\\Z'),
+    (b"foo.c", b'(?ms)(.*/)?foo\\.c/?\\Z'),
+    (b"/*.c", b'(?ms)[^/]+\\.c/?\\Z'),
+    (b"/foo.c", b'(?ms)foo\\.c/?\\Z'),
+    (b"foo.c", b'(?ms)(.*/)?foo\\.c/?\\Z'),
+    (b"foo.[ch]", b'(?ms)(.*/)?foo\\.[ch]/?\\Z'),
+    (b"bar/", b'(?ms)(.*/)?bar\\/\\Z'),
+    (b"foo/**", b'(?ms)foo(/.*)?/?\\Z'),
+    (b"foo/**/blie.c", b'(?ms)foo(/.*)?\\/blie\\.c/?\\Z'),
+    (b"**/bla.c", b'(?ms)(.*/)?bla\\.c/?\\Z'),
+    (b"foo/**/bar", b'(?ms)foo(/.*)?\\/bar/?\\Z'),
 ]
 
 


### PR DESCRIPTION
gitignore patterns with a trailing slash should match both directories and files, while patterns with a trailing slash should match only directories.

I added a '/?' to any pattern that doesn't end in a slash. Please review if this is the right way to handle this.

Related issue: #526

## Reproduction
A pattern without a trailing slash should match both files and directories:
```sh
git init temp && cd temp
mkdir -p foo/bar
cat > .gitignore <<EOF
bar
EOF
git check-ignore -v foo/bar
```

Output:
```
.gitignore:1:bar.       foo/bar/
```

Dulwich (Before fix):
```py
>>> from dulwich import ignore
>>> with open('.gitignore', 'r') as f:
...     a = ignore.IgnoreFilter(ignore.read_ignore_patterns(f))
... 
>>> a.is_ignored('foo/bar/')
# None
```