### PR TITLE
Don't use os.path.sep since that changes with the platform

### DIFF
--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -243,11 +243,11 @@ class IgnoreFilterManager(object):
         if os.path.isabs(path):
             path = os.path.relpath(path, self._top_path)
         filters = [(0, f) for f in self._global_filters]
-        parts = path.split(os.path.sep)
+        parts = path.split('/')
         for i in range(len(parts)+1):
-            dirname = os.path.sep.join(parts[:i])
+            dirname = '/'.join(parts[:i])
             for s, f in filters:
-                relpath = os.path.sep.join(parts[s:i])
+                relpath = '/'.join(parts[s:i])
                 status = f.is_ignored(relpath)
                 if status is not None:
                     return status


### PR DESCRIPTION
We might want to convert all paths to POSIX to make this work with platform specific paths (Windows paths 😛) See https://github.com/jelmer/dulwich/issues/526#issuecomment-315002252.