### PR TITLE
Improve handling of comment characters in Git configuration files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,10 @@
   * Make `dulwich.archive` set the gzip header file modification time so that
     archives created from the same Git tree are always identical.
     (#577, Jonas Haag)
+
+  * Allow comment characters (#, ;) within configuration file strings
+    (Daniel Andersson, #579)
+
 0.18.6	2017-11-11
 
  BUG FIXES

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -262,8 +262,16 @@ def _check_section_name(name):
 
 
 def _strip_comments(line):
-    line = line.split(b"#")[0]
-    line = line.split(b";")[0]
+    comment_bytes = {ord(b"#"), ord(b";")}
+    quote = ord(b'"')
+    string_open = False
+    # Normalize line to bytearray for simple 2/3 compatibility
+    for i, character in enumerate(bytearray(line)):
+        # Comment characters outside balanced quotes denote comment start
+        if character == quote:
+            string_open = not string_open
+        elif not string_open and character in comment_bytes:
+            return line[:i]
     return line
 
 

--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -81,6 +81,16 @@ class ConfigFileTests(TestCase):
         cf = self.from_file(b"[section]\nbar= foo # a comment\n")
         self.assertEqual(ConfigFile({(b"section", ): {b"bar": b"foo"}}), cf)
 
+    def test_comment_character_within_value_string(self):
+        cf = self.from_file(b"[section]\nbar= \"foo#bar\"\n")
+        self.assertEqual(
+            ConfigFile({(b"section", ): {b"bar": b"foo#bar"}}), cf)
+
+    def test_comment_character_within_section_string(self):
+        cf = self.from_file(b"[branch \"foo#bar\"] # a comment\nbar= foo\n")
+        self.assertEqual(
+            ConfigFile({(b"branch", b"foo#bar"): {b"bar": b"foo"}}), cf)
+
     def test_from_file_section(self):
         cf = self.from_file(b"[core]\nfoo = bar\n")
         self.assertEqual(b"bar", cf.get((b"core", ), b"foo"))


### PR DESCRIPTION
Comment characters (`#` , `;`) that are within balanced quotes should not discard the rest of the line:

    [branch "my#branch"]

is a valid section for a branch named `my#branch` ([`#` is a valid character in a branch name](https://git-scm.com/docs/git-check-ref-format)). Previously this normalized to:

    [branch "my

which raised an exception for finding an invalid section header.

Adhering strictly to the exact allowed comment format might require more care, but this should at least fix some problems I have had with real-life repositories.

(I tried to keep with the surrounding code style even though [the contribution guide](https://github.com/jelmer/dulwich/blob/master/CONTRIBUTING.md) preferred `'` as string delimiter.)