### PR TITLE
Make unreachable `raise ValueError` come into play

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -283,8 +283,9 @@ class ConfigFile(ConfigDict):
                 # Parse section header ("[bla]")
                 if len(line) > 0 and line[:1] == b"[":
                     line = _strip_comments(line).rstrip()
-                    last = line.index(b"]")
-                    if last == -1:
+                    try:
+                        last = line.index(b"]")
+                    except ValueError:
                         raise ValueError("expected trailing ]")
                     pts = line[1:last].split(b" ", 1)
                     line = line[last+1:]

--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -95,7 +95,10 @@ class ConfigFileTests(TestCase):
         cf = self.from_file(b"[core]\nfoo = \"bar\"la\n")
         self.assertEqual(b"barla", cf.get((b"core", ), b"foo"))
 
-    def test_from_file_with_open_quoted(self):
+    def test_from_file_section_with_open_brackets(self):
+        self.assertRaises(ValueError, self.from_file, b"[core\nfoo = bar\n")
+
+    def test_from_file_value_with_open_quoted(self):
         self.assertRaises(ValueError, self.from_file, b"[core]\nfoo = \"bar\n")
 
     def test_from_file_with_quotes(self):


### PR DESCRIPTION
The current code looks for a `-1` return value from the `string.index` method (as e.g. `string.find` yields), but `string.index` will raise a `ValueError` if the character is not found, breaking out of the block before being able to check the value.

Catch the `ValueError` from `string.index` and raise a new one with the intended exception message instead.

Added a test for incorrectly formatted section headers that should trigger this exception as well (somewhat related to #579).

(I tried to keep with the surrounding code style even though [the contribution guide](https://github.com/jelmer/dulwich/blob/master/CONTRIBUTING.md) preferred `'` as string delimiter.)