### PR TITLE
Lint fixes

### DIFF
--- a/dulwich/archive.py
+++ b/dulwich/archive.py
@@ -86,7 +86,7 @@ def tar_stream(store, tree, mtime, format=''):
     with closing(tarfile.open(None, "w:%s" % format, buf)) as tar:
         if format == 'gz':
             # Manually correct the gzip header file modification time so that
-            # archives created from the same Git tree are always identical. 
+            # archives created from the same Git tree are always identical.
             # The gzip header file modification time is not currenctly
             # accessible from the tarfile API, see: https://bugs.python.org/issue31526
             buf.seek(0)

--- a/dulwich/archive.py
+++ b/dulwich/archive.py
@@ -88,7 +88,8 @@ def tar_stream(store, tree, mtime, format=''):
             # Manually correct the gzip header file modification time so that
             # archives created from the same Git tree are always identical.
             # The gzip header file modification time is not currenctly
-            # accessible from the tarfile API, see: https://bugs.python.org/issue31526
+            # accessible from the tarfile API, see:
+            # https://bugs.python.org/issue31526
             buf.seek(0)
             assert buf.read(2) == b'\x1f\x8b', 'Invalid gzip header'
             buf.seek(4)

--- a/dulwich/tests/test_archive.py
+++ b/dulwich/tests/test_archive.py
@@ -65,7 +65,8 @@ class ArchiveTests(TestCase):
         t1 = Tree()
         t1.add(b"somename", 0o100644, b1.id)
         store.add_object(t1)
-        stream = b''.join(tar_stream(store, t1, *tar_stream_args, **tar_stream_kwargs))
+        stream = b''.join(
+            tar_stream(store, t1, *tar_stream_args, **tar_stream_kwargs))
         return BytesIO(stream)
 
     def test_simple(self):
@@ -85,6 +86,11 @@ class ArchiveTests(TestCase):
         for format in ['', 'gz', 'bz2']:
             for i in [0, 1]:
                 with patch('time.time', return_value=i):
-                    stream = self._get_example_tar_stream(mtime=0, format=format)
+                    stream = self._get_example_tar_stream(
+                        mtime=0, format=format)
                     contents[i] = stream.getvalue()
-            self.assertEqual(contents[0], contents[1], "Different file contents for format %r" % format)
+            self.assertEqual(
+                contents[0],
+                contents[1],
+                "Different file contents for format %r" % format
+                )

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -147,7 +147,7 @@ class GitClientTests(TestCase):
         self.rin.seek(0)
 
         def check_heads(heads):
-            self.assertEquals({}, heads)
+            self.assertEqual({}, heads)
             return []
         ret = self.client.fetch_pack(b'bla', check_heads, None, None, None)
         self.assertEqual({}, ret.refs)


### PR DESCRIPTION
I noticed in #579 that code style checks fail CI builds after 64e084e77d1e833455a89d5ac1ff482782e28096. This should fix that, as well as remove a deprecation warning when running unit tests by changing a `self.assertEquals` to `self.assertEqual`.