### PR TITLE
Make config keys (sections and names) case insensitive

### DIFF
--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -96,10 +96,15 @@ class ConfigFileTests(TestCase):
         self.assertEqual(b"bar", cf.get((b"core", ), b"foo"))
         self.assertEqual(b"bar", cf.get((b"core", b"foo"), b"foo"))
 
-    def test_from_file_section_case_insensitive(self):
+    def test_from_file_section_case_insensitive_lower(self):
         cf = self.from_file(b"[cOre]\nfOo = bar\n")
         self.assertEqual(b"bar", cf.get((b"core", ), b"foo"))
         self.assertEqual(b"bar", cf.get((b"core", b"foo"), b"foo"))
+
+    def test_from_file_section_case_insensitive_mixed(self):
+        cf = self.from_file(b"[cOre]\nfOo = bar\n")
+        self.assertEqual(b"bar", cf.get((b"core", ), b"fOo"))
+        self.assertEqual(b"bar", cf.get((b"cOre", b"fOo"), b"fOo"))
 
     def test_from_file_with_mixed_quoted(self):
         cf = self.from_file(b"[core]\nfoo = \"bar\"la\n")


### PR DESCRIPTION
This is done to match the behaviour of git itself.

The main change here is to add the lower_key function and the CaseInsensitiveDict class.

lower_key coerces keys that are used in DictConfig to make sure all keys consist only of lower-cased strings.

CaseInsensitiveDict has altered __getitem__ and __setitem__ methods to call lower_key on the key for both get and set operations.

CaseInsensitiveDict.make takes care of the creation logic found in ConfigDict.__init__ as well as converting any passed-in dicts to CaseInsensitiveDict.

CaseInsensitiveDict.get and CaseInsensitiveDict.setdefault allow the default value returned to be a CaseInsensitiveDict without repeating it everywhere.

ConfigDict.check_section_and_name just moves some logic that was previously repeated.

Fixes #599