### PR TITLE
Prevent clean files from showing up as untracked

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -168,11 +168,12 @@ def open_repo_closing(path_or_repo):
 def path_to_tree_path(repopath, path):
     """Convert a path to a path usable in e.g. an index.
 
-    :param repo: Repository
+    :param repopath: Repository
     :param path: A path
     :return: A path formatted for use in e.g. an index
     """
-    os.path.relpath(path, repopath)
+    if os.path.isabs(path):
+        path = os.path.relpath(path, repopath)
     if os.path.sep != '/':
         path = path.replace(os.path.sep, '/')
     return path.encode(sys.getfilesystemencoding())


### PR DESCRIPTION
Looking at the code in porcelain.path_to_tree_path, this looks like there was an attempt at this in 85b5383fb816fece4a36faa538f6477703595139, however relpath is non-destructive, and has no effect unless the result is assigned to something. If this were assigned when path is relative, then relpath would assume path was at root, and so we must check that the path is absolute before calling relpath.

Fixes #598