### PR TITLE
fastexport: restore handling of markers in commit commands

### DIFF
--- a/dulwich/fastexport.py
+++ b/dulwich/fastexport.py
@@ -168,6 +168,8 @@ class GitImportProcessor(processor.ImportProcessor):
         commit.message = cmd.message
         commit.parents = []
         if cmd.from_:
+            if cmd.from_.startswith(b":"):
+                cmd.from_ = self.markers[cmd.from_[1:]]
             self._reset_base(cmd.from_)
         for filecmd in cmd.iter_files():
             if filecmd.name == b"filemodify":


### PR DESCRIPTION
For some reason the code was moved around and refactored and there was a regression for the handling of markers in commit commands. This restores the behavior I initially introduced in a2edfbf9f1f31850589fcb9a10df89089d6a030b .