### PR TITLE
ci: fix flake8 lint error

### DIFF
--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -48,9 +48,6 @@ from dulwich.repo import (
     NoIndexPresent,
     Repo,
 )
-from dulwich.index import (
-    _fs_to_tree_path,
-)
 from dulwich.tests import (
     TestCase,
 )


### PR DESCRIPTION
Fixes flake8 unused import warning that's currently breaking CI