### PR TITLE
Make check_ref_format follow Git doc

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -72,18 +72,24 @@ def check_ref_format(refname):
     """
     # These could be combined into one big expression, but are listed
     # separately to parallel [1].
-    if b"/." in refname or refname.startswith(b"."):
+    if b"/." in refname:
         return False
     if b"/" not in refname:
+        return False
+    if b"//" in refname:
         return False
     if b".." in refname:
         return False
     for i, c in enumerate(refname):
         if ord(refname[i : i + 1]) < 0o40 or c in BAD_REF_CHARS:
             return False
+    if refname[0] in b"/.":
+        return False
     if refname[-1] in b"/.":
         return False
     if refname.endswith(b".lock"):
+        return False
+    if b".lock/" in refname:
         return False
     if b"@{" in refname:
         return False
@@ -714,7 +720,8 @@ class DiskRefsContainer(RefsContainer):
                 refname = b"/".join(([dir] if dir else []) + [filename])
                 # check_ref_format requires at least one /, so we prepend the
                 # base before calling it.
-                if check_ref_format(base + b"/" + refname):
+
+                if check_ref_format(base.strip(b"/") + b"/" + refname):
                     subkeys.add(refname)
         for key in self.get_packed_refs():
             if key.startswith(base):

--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -64,7 +64,6 @@ class CheckRefFormatTests(TestCase):
     def test_valid(self):
         self.assertTrue(check_ref_format(b"heads/foo"))
         self.assertTrue(check_ref_format(b"foo/bar/baz"))
-        self.assertTrue(check_ref_format(b"refs///heads/foo"))
         self.assertTrue(check_ref_format(b"foo./bar"))
         self.assertTrue(check_ref_format(b"heads/foo@bar"))
         self.assertTrue(check_ref_format(b"heads/fix.lock.error"))
@@ -72,11 +71,14 @@ class CheckRefFormatTests(TestCase):
     def test_invalid(self):
         self.assertFalse(check_ref_format(b"foo"))
         self.assertFalse(check_ref_format(b"heads/foo/"))
+        self.assertFalse(check_ref_format(b"/heads/foo"))
+        self.assertFalse(check_ref_format(b"refs///heads/foo"))
         self.assertFalse(check_ref_format(b"./foo"))
         self.assertFalse(check_ref_format(b".refs/foo"))
         self.assertFalse(check_ref_format(b"heads/foo..bar"))
         self.assertFalse(check_ref_format(b"heads/foo?bar"))
         self.assertFalse(check_ref_format(b"heads/foo.lock"))
+        self.assertFalse(check_ref_format(b"heads/foo.lock/bar"))
         self.assertFalse(check_ref_format(b"heads/v@{ation"))
         self.assertFalse(check_ref_format(b"heads/foo\bar"))
 


### PR DESCRIPTION
Fix #906

- Add two rules:
    1. They cannot begin or end with a slash / or contain multiple consecutive slashes
    2. but no slash-separated component can begin with a dot . or end with the sequence .lock.
- Add tests for them.