### PR TITLE
Remove unnecessary #noqa comments

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -387,7 +387,7 @@ class ConfigFile(ConfigDict):
         super(ConfigFile, self).__init__(values=values, encoding=encoding)
         self.path = None
 
-    @classmethod  # noqa: C901
+    @classmethod
     def from_file(cls, f: BinaryIO) -> "ConfigFile":  # noqa: C901
         """Read configuration from a file-like object."""
         ret = cls()

--- a/dulwich/contrib/diffstat.py
+++ b/dulwich/contrib/diffstat.py
@@ -323,14 +323,14 @@ index 3b41fd80..64914c78 100644
  2. open Sigil.app to the normal nearly blank template epub it generates when opened
  3. use Plugins->Manage Plugins menu and make sure the "Use Bundled Python" checkbox is checked
  4. use the "Add Plugin" button to navigate to and add testplugin.zip and then hit "Okay" to exit the Manage Plugins Dialog
-"""  # noqa: E501 W293
+"""
 
     testoutput = b""" docs/qt512.7_remove_bad_workaround.patch            | 15 ++++++++++++
  docs/testplugin_v017.zip                            | Bin
  ci_scripts/macgddeploy.py => ci_scripts/gddeploy.py |  0 
  docs/qt512.6_backport_009abcd_fix.patch             | 26 ---------------------
  docs/Building_Sigil_On_MacOSX.txt                   |  2 +-
- 5 files changed, 16 insertions(+), 27 deletions(-)"""  # noqa: W291
+ 5 files changed, 16 insertions(+), 27 deletions(-)"""
 
     # return 0 on success otherwise return -1
     result = diffstat(selftest.split(b"\n"))

--- a/dulwich/fastexport.py
+++ b/dulwich/fastexport.py
@@ -30,14 +30,14 @@ from dulwich.objects import (
     Tag,
     ZERO_SHA,
 )
-from fastimport import (  # noqa: E402
+from fastimport import (
     commands,
     errors as fastimport_errors,
     parser,
     processor,
 )
 
-import stat  # noqa: E402
+import stat
 
 
 def split_email(text):

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -66,15 +66,15 @@ else:
 if sys.platform == "Plan9":
     has_mmap = False
 
-from dulwich.errors import (  # noqa: E402
+from dulwich.errors import (
     ApplyDeltaError,
     ChecksumMismatch,
 )
-from dulwich.file import GitFile  # noqa: E402
-from dulwich.lru_cache import (  # noqa: E402
+from dulwich.file import GitFile
+from dulwich.lru_cache import (
     LRUSizeCache,
 )
-from dulwich.objects import (  # noqa: E402
+from dulwich.objects import (
     ShaFile,
     hex_to_sha,
     sha_to_hex,

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -70,7 +70,7 @@ from dulwich.objects import (
 from dulwich.pack import (
     write_pack_objects,
 )
-from dulwich.protocol import (  # noqa: F401
+from dulwich.protocol import (
     BufferedPktLineWriter,
     capability_agent,
     CAPABILITIES_REF,

--- a/dulwich/tests/__init__.py
+++ b/dulwich/tests/__init__.py
@@ -145,12 +145,12 @@ def self_test_suite():
 
 
 def tutorial_test_suite():
-    import dulwich.client  # noqa: F401
-    import dulwich.config  # noqa: F401
-    import dulwich.index  # noqa: F401
-    import dulwich.reflog  # noqa: F401
-    import dulwich.repo  # noqa: F401
-    import dulwich.server  # noqa: F401
+    import dulwich.client
+    import dulwich.config
+    import dulwich.index
+    import dulwich.reflog
+    import dulwich.repo
+    import dulwich.server
     import dulwich.patch  # noqa: F401
 
     tutorial = [

--- a/dulwich/tests/test_ignore.py
+++ b/dulwich/tests/test_ignore.py
@@ -116,7 +116,7 @@ class ReadIgnorePatterns(TestCase):
 with trailing whitespace 
 with escaped trailing whitespace\\ 
 """
-        )  # noqa: W291
+        )
         self.assertEqual(
             list(read_ignore_patterns(f)),
             [

--- a/dulwich/tests/test_objects.py
+++ b/dulwich/tests/test_objects.py
@@ -434,7 +434,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 Merge ../b
 """,
             commit.as_raw_string(),
-        )  # noqa: W291,W293
+        )
 
     def test_serialize_mergetag(self):
         tag = make_object(
@@ -472,7 +472,7 @@ mergetag object a38d6181ff27824c79fc7df825164a212eff6a3f
 Merge ../b
 """,
             commit.as_raw_string(),
-        )  # noqa: W291,W293
+        )
 
     def test_serialize_mergetags(self):
         tag = make_object(
@@ -523,7 +523,7 @@ mergetag object a38d6181ff27824c79fc7df825164a212eff6a3f
 Merge ../b
 """,
             commit.as_raw_string(),
-        )  # noqa: W291,W293
+        )
 
     def test_deserialize_mergetag(self):
         tag = make_object(
@@ -756,7 +756,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 
 foo
 """
-        )  # noqa: W291,W293
+        )
         self.assertEqual(b"foo\n", c.message)
         self.assertEqual([], c.extra)
         self.assertEqual(
@@ -801,7 +801,7 @@ gpgsig -----BEGIN PGP SIGNATURE-----
 
 3.3.0 version bump and docs
 """
-        )  # noqa: W291,W293
+        )
         self.assertEqual([], c.extra)
         self.assertEqual(
             b"""\

--- a/dulwich/tests/test_patch.py
+++ b/dulwich/tests/test_patch.py
@@ -93,7 +93,7 @@ Subject: [PATCH 1/2] Remove executable bit from prey.ico (triggers a warning).
 
 -- 
 1.7.0.4
-"""  # noqa: W291
+"""
         c, diff, version = git_am_patch_split(StringIO(text.decode("utf-8")), "utf-8")
         self.assertEqual(b"Jelmer Vernooij <jelmer@samba.org>", c.committer)
         self.assertEqual(b"Jelmer Vernooij <jelmer@samba.org>", c.author)
@@ -125,7 +125,7 @@ Subject: [PATCH 1/2] Remove executable bit from prey.ico (triggers a warning).
 
 -- 
 1.7.0.4
-"""  # noqa: W291
+"""
         c, diff, version = git_am_patch_split(BytesIO(text))
         self.assertEqual(b"Jelmer Vernooij <jelmer@samba.org>", c.committer)
         self.assertEqual(b"Jelmer Vernooij <jelmer@samba.org>", c.author)
@@ -160,7 +160,7 @@ Subject:  [Dulwich-users] [PATCH] Added unit tests for
 
 -- 
 1.7.0.4
-"""  # noqa: W291
+"""
         c, diff, version = git_am_patch_split(BytesIO(text), "utf-8")
         self.assertEqual(
             b"""\
@@ -192,7 +192,7 @@ From: Jelmer Vernooij <jelmer@debian.org>
 
 -- 
 1.7.0.4
-"""  # noqa: W291
+"""
         c, diff, version = git_am_patch_split(BytesIO(text), "utf-8")
         self.assertEqual(b"Jelmer Vernooij <jelmer@debian.org>", c.author)
         self.assertEqual(
@@ -242,7 +242,7 @@ diff --git a/dulwich/tests/test_patch.py b/dulwich/tests/test_patch.py
  
  
  class DiffTests(TestCase):
-"""  # noqa: W291,W293
+"""
         text = (
             """\
 From dulwich-users-bounces+jelmer=samba.org@lists.launchpad.net \
@@ -265,7 +265,7 @@ More help   : https://help.launchpad.net/ListHelp
 
 """
             % expected_diff
-        )  # noqa: W291
+        )
         c, diff, version = git_am_patch_split(BytesIO(text))
         self.assertEqual(expected_diff, diff)
         self.assertEqual(None, version)

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -2208,7 +2208,7 @@ class ReceivePackTests(PorcelainTestCase):
         outlines = outf.getvalue().splitlines()
         self.assertEqual(
             [
-                b"0091319b56ce3aee2d489f759736a79cc552c9bb86d9 HEAD\x00 report-status "  # noqa: E501
+                b"0091319b56ce3aee2d489f759736a79cc552c9bb86d9 HEAD\x00 report-status "
                 b"delete-refs quiet ofs-delta side-band-64k "
                 b"no-done symref=HEAD:refs/heads/master",
                 b"003f319b56ce3aee2d489f759736a79cc552c9bb86d9 refs/heads/master",


### PR DESCRIPTION
Remove unnecessary #noqa comments.


This merge proposal was created automatically by the [Janitor bot](https://janitor.jelmer.uk/yesqa).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.jelmer.uk/yesqa.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.jelmer.uk/yesqa/pkg/dulwich/394e4017-0497-4760-b54d-6d9e3223d1f2.