### PR TITLE
Ensure git config is available in a linked working tree

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1517,7 +1517,7 @@ class Repo(BaseRepo):
         """
         from dulwich.config import ConfigFile
 
-        path = os.path.join(self._controldir, "config")
+        path = os.path.join(self._commondir, "config")
         try:
             return ConfigFile.from_path(path)
         except FileNotFoundError:


### PR DESCRIPTION
See #926 more details on the problem as it relates to Dulwich.

This ensures that the repo's common dir is used as the source of a config, rather than the control dir. This matches the behavior documented in the git-worktree documentation for [details on configuration files.](https://git-scm.com/docs/git-worktree#_details) A test case is also added to ensure the behavior is as expected.

**Test Plan:**
[x] Added test case
[x] `make build && sudo make install` to build patched version, run with test case script from #926 bug report
[x] `make check` tests all pass other than skipped/expected failures