### PR TITLE
miscellaneous typechecking

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -27,6 +27,8 @@ import os
 import stat
 import sys
 
+from typing import Callable, Dict, List, Optional, Tuple
+
 from dulwich.diff_tree import (
     tree_changes,
     walk_trees,
@@ -79,7 +81,11 @@ PACK_MODE = 0o444 if sys.platform != "win32" else 0o644
 class BaseObjectStore(object):
     """Object store interface."""
 
-    def determine_wants_all(self, refs, depth=None):
+    def determine_wants_all(
+        self,
+        refs: Dict[bytes, bytes],
+        depth: Optional[int] = None
+    ) -> List[bytes]:
         def _want_deepen(sha):
             if not depth:
                 return False
@@ -141,6 +147,12 @@ class BaseObjectStore(object):
     def __iter__(self):
         """Iterate over the SHAs that are present in this store."""
         raise NotImplementedError(self.__iter__)
+
+    def add_pack(
+        self
+    ) -> Tuple[BytesIO, Callable[[], None], Callable[[], None]]:
+        """Add a new pack to this object store."""
+        raise NotImplementedError(self.add_pack)
 
     def add_object(self, obj):
         """Add a single object to this object store."""

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1002,6 +1002,7 @@ def get_remote_repo(
     if config.has_section(section):
         remote_name = encoded_location.decode()
         url = config.get(section, "url")
+        assert url is not None
         encoded_location = url
     else:
         remote_name = None
@@ -1614,7 +1615,7 @@ def ls_tree(
         list_tree(r.object_store, tree.id, "")
 
 
-def remote_add(repo, name, url):
+def remote_add(repo: Repo, name: Union[bytes, str], url: Union[bytes, str]):
     """Add a remote.
 
     Args:

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -158,13 +158,13 @@ class RefsContainer(object):
 
     def import_refs(
         self,
-        base,
-        other,
-        committer=None,
-        timestamp=None,
-        timezone=None,
-        message=None,
-        prune=False,
+        base: bytes,
+        other: Dict[bytes, bytes],
+        committer: Optional[bytes] = None,
+        timestamp: Optional[bytes] = None,
+        timezone: Optional[bytes] = None,
+        message: Optional[bytes] = None,
+        prune: bool = False,
     ):
         if prune:
             to_delete = set(self.subkeys(base))

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1057,7 +1057,12 @@ class Repo(BaseRepo):
       bare (bool): Whether this is a bare repository
     """
 
-    def __init__(self, root, object_store=None, bare=None):
+    def __init__(
+        self,
+        root: str,
+        object_store: Optional[BaseObjectStore] = None,
+        bare: Optional[bool] = None
+    ) -> None:
         hidden_path = os.path.join(root, CONTROLDIR)
         if bare is None:
             if (os.path.isfile(hidden_path) or
@@ -1093,9 +1098,18 @@ class Repo(BaseRepo):
         self.path = root
         config = self.get_config()
         try:
-            format_version = int(config.get("core", "repositoryformatversion"))
+            repository_format_version = config.get(
+                "core",
+                "repositoryformatversion"
+            )
+            format_version = (
+                0
+                if repository_format_version is None
+                else int(repository_format_version)
+            )
         except KeyError:
             format_version = 0
+
         if format_version != 0:
             raise UnsupportedVersion(format_version)
         if object_store is None:
@@ -1485,7 +1499,7 @@ class Repo(BaseRepo):
             raise
         return target
 
-    def reset_index(self, tree=None):
+    def reset_index(self, tree: Optional[Tree] = None):
         """Reset the index back to a specific tree.
 
         Args:
@@ -1569,7 +1583,7 @@ class Repo(BaseRepo):
         return ret
 
     @classmethod
-    def init(cls, path, mkdir=False):
+    def init(cls, path: str, mkdir: bool = False) -> "Repo":
         """Create a new repository.
 
         Args:


### PR DESCRIPTION
Some miscellaneous typechecking additions.

I'm afraid this is rather un-systematic, I'm not keen to volunteer to sort out the typing in this project in its entirety!  But it is kind of annoying that dulwich has  a `py.typed` declaring that it is typed; and that most of its interface does not actually have type annotations...

So I have added annotations only on the parts of the interface that I am using in the project that is currently of interest to me, so that I can get _that_ to typecheck cleanly - and also just enough internal annotations to satisfy mypy here.

This is very far from completing the typing: but I think it's going in the right direction - and if others were to do the same for the parts of the interface that they cared about then we'd get all the way to done, one step at a time.