### PR TITLE
gha: publish: don't forget to install paramiko

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine fastimport
+        pip install setuptools wheel twine fastimport paramiko
     - name: Install gpg on supported platforms
       run: pip install -U gpg
       if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"


### PR DESCRIPTION
Was missed in https://github.com/jelmer/dulwich/commit/94a68a899b6139c35c8a10e683218ee2ba755105, which resulted in failed wheel builds https://github.com/jelmer/dulwich/runs/6442441328?check_suite_focus=true.