### PR TITLE
Explicitly reenable paramiko server on Gentoo for tests

### DIFF
--- a/dulwich/contrib/test_paramiko_vendor.py
+++ b/dulwich/contrib/test_paramiko_vendor.py
@@ -122,6 +122,12 @@ class Server(paramiko.ServerInterface):
 class ParamikoSSHVendorTests(TestCase):
 
     def setUp(self):
+        import paramiko.transport
+
+        # reenable server functionality for tests
+        if hasattr(paramiko.transport, "SERVER_DISABLED_BY_GENTOO"):
+            paramiko.transport.SERVER_DISABLED_BY_GENTOO = False
+
         self.commands = []
         socket.setdefaulttimeout(10)
         self.addCleanup(socket.setdefaulttimeout, None)


### PR DESCRIPTION
Gentoo patches out server support from paramiko for security reasons.
Since dulwich uses it only for testing, use the knob to explicitly
reenable it.