### PR TITLE
porcelain: rename walk_untracked kwarg to untracked_file

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1156,16 +1156,12 @@ def pull(
             _import_remote_refs(r.refs, remote_name, fetch_result.refs)
 
 
-def status(repo=".", ignored=False, walk_untracked=True):
+def status(repo=".", ignored=False):
     """Returns staged, unstaged, and untracked changes relative to the HEAD.
 
     Args:
       repo: Path to repository or repository object
       ignored: Whether to include ignored files in untracked
-      walk_untracked: Whether to walk untracked directories
-            When True, behaves like `git status -uall`.
-            When False, behaves like to `git status -unormal` (git default).
-
     Returns: GitStatus tuple,
         staged -  dict with lists of staged paths (diff index/HEAD)
         unstaged -  list of unstaged paths (diff index/working-tree)
@@ -1181,7 +1177,7 @@ def status(repo=".", ignored=False, walk_untracked=True):
         unstaged_changes = list(get_unstaged_changes(index, r.path, filter_callback))
 
         untracked_paths = get_untracked_paths(
-            r.path, r.path, index, exclude_ignored=not ignored, walk=walk_untracked
+            r.path, r.path, index, exclude_ignored=not ignored
         )
         untracked_changes = list(untracked_paths)
 
@@ -1220,13 +1216,7 @@ def _walk_working_dir_paths(frompath, basepath, prune_dirnames=None):
             dirnames[:] = prune_dirnames(dirpath, dirnames)
 
 
-def get_untracked_paths(
-    frompath,
-    basepath,
-    index,
-    exclude_ignored=False,
-    walk=True,
-):
+def get_untracked_paths(frompath, basepath, index, exclude_ignored=False):
     """Get untracked paths.
 
     Args:
@@ -1234,7 +1224,6 @@ def get_untracked_paths(
       basepath: Path to compare to
       index: Index to check against
       exclude_ignored: Whether to exclude ignored paths
-      walk: Whether to walk untracked paths.
 
     Note: ignored directories will never be walked for performance reasons.
       If exclude_ignored is False, only the path to an ignored directory will
@@ -1244,7 +1233,6 @@ def get_untracked_paths(
         ignore_manager = IgnoreFilterManager.from_repo(r)
 
     ignored_dirs = []
-    untracked_dirs = []
 
     def prune_dirnames(dirpath, dirnames):
         for i in range(len(dirnames) - 1, -1, -1):
@@ -1256,15 +1244,6 @@ def get_untracked_paths(
                         os.path.join(os.path.relpath(path, frompath), "")
                     )
                 del dirnames[i]
-            elif not walk:
-                if not any(
-                    os.fsdecode(index_path).startswith(dirnames[i])
-                    for index_path, _, in index.items()
-                ):
-                    untracked_dirs.append(
-                        os.path.join(os.path.relpath(path, frompath)) + os.sep
-                    )
-                    del dirnames[i]
         return dirnames
 
     for ap, is_dir in _walk_working_dir_paths(
@@ -1273,13 +1252,15 @@ def get_untracked_paths(
         if not is_dir:
             ip = path_to_tree_path(basepath, ap)
             if ip not in index:
-                if not exclude_ignored or not ignore_manager.is_ignored(
-                    os.path.relpath(ap, basepath)
+                if (
+                    not exclude_ignored
+                    or not ignore_manager.is_ignored(
+                        os.path.relpath(ap, basepath)
+                    )
                 ):
                     yield os.path.relpath(ap, frompath)
 
     yield from ignored_dirs
-    yield from untracked_dirs
 
 
 def get_tree_changes(repo):

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1874,7 +1874,12 @@ class StatusTests(PorcelainTestCase):
             results.staged,
         )
         self.assertListEqual(results.unstaged, [b"blye"])
-        self.assertListEqual(results.untracked, ["blyat"])
+        results_no_untracked = porcelain.status(self.repo.path, untracked_files="no")
+        self.assertListEqual(results_no_untracked.untracked, [])
+
+    def test_status_wrong_untracked_files_value(self):
+        with self.assertRaises(ValueError):
+            porcelain.status(self.repo.path, untracked_files="antani")
 
     def test_status_crlf_mismatch(self):
         # First make a commit as if the file has been added on a Linux system
@@ -2170,6 +2175,22 @@ class StatusTests(PorcelainTestCase):
             )
         )
 
+    def test_get_untracked_paths_invalid_untracked_files(self):
+        with self.assertRaises(ValueError):
+            list(
+                porcelain.get_untracked_paths(
+                    self.repo.path,
+                    self.repo.path,
+                    self.repo.open_index(),
+                    untracked_files="invalid_value",
+                )
+            )
+
+    def test_get_untracked_paths_normal(self):
+        with self.assertRaises(NotImplementedError):
+            _, _, _ = porcelain.status(
+                repo=self.repo.path, untracked_files="normal"
+            )
 
 # TODO(jelmer): Add test for dulwich.porcelain.daemon
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1880,13 +1880,11 @@ class StatusTests(PorcelainTestCase):
         )
         self.assertListEqual(results.unstaged, [b"blye"])
         self.assertListEqual(
-            results.untracked, [
-                "untracked_file", os.path.join("untracked_dir", "file")]
+            results.untracked, ["untracked_file", "untracked_dir/file"]
         )
         results_no_walk = porcelain.status(self.repo.path, walk_untracked=False)
         self.assertListEqual(
-            results_no_walk.untracked,
-            ["untracked_file", "untracked_dir" + os.path.sep]
+            results_no_walk.untracked, ["untracked_file", "untracked_dir/"]
         )
 
     def test_status_crlf_mismatch(self):
@@ -2192,7 +2190,7 @@ class StatusTests(PorcelainTestCase):
             f.write("foo")
 
         self.assertEqual(
-            {"dir" + os.path.sep},
+            {"dir/"},
             set(
                 porcelain.get_untracked_paths(
                     self.repo.path, self.repo.path, self.repo.open_index(), walk=False
@@ -2200,8 +2198,7 @@ class StatusTests(PorcelainTestCase):
             ),
         )
         self.assertEqual(
-            set([os.path.join("dir", "file"),
-                 os.path.join("dir", "subdir", "subfile")]),
+            set(["dir/file", "dir/subdir/subfile"]),
             set(
                 porcelain.get_untracked_paths(
                     self.repo.path, self.repo.path, self.repo.open_index(), walk=True

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1842,17 +1842,12 @@ class StatusTests(PorcelainTestCase):
         mod_path = os.path.join(self.repo.path, "bar")
         add_path = os.path.join(self.repo.path, "baz")
         us_path = os.path.join(self.repo.path, "blye")
-        ut_path = os.path.join(self.repo.path, "untracked_file")
-        os.mkdir(os.path.join(self.repo.path, "untracked_dir"))
-        ut_subfile_path = os.path.join(self.repo.path, "untracked_dir/file")
-
+        ut_path = os.path.join(self.repo.path, "blyat")
         with open(del_path, "w") as f:
             f.write("origstuff")
         with open(mod_path, "w") as f:
             f.write("origstuff")
         with open(us_path, "w") as f:
-            f.write("origstuff")
-        with open(ut_subfile_path, "w") as f:
             f.write("origstuff")
         porcelain.add(repo=self.repo.path, paths=[del_path, mod_path, us_path])
         porcelain.commit(
@@ -1879,13 +1874,7 @@ class StatusTests(PorcelainTestCase):
             results.staged,
         )
         self.assertListEqual(results.unstaged, [b"blye"])
-        self.assertListEqual(
-            results.untracked, ["untracked_file", "untracked_dir/file"]
-        )
-        results_no_walk = porcelain.status(self.repo.path, walk_untracked=False)
-        self.assertListEqual(
-            results_no_walk.untracked, ["untracked_file", "untracked_dir/"]
-        )
+        self.assertListEqual(results.untracked, ["blyat"])
 
     def test_status_crlf_mismatch(self):
         # First make a commit as if the file has been added on a Linux system
@@ -2178,32 +2167,7 @@ class StatusTests(PorcelainTestCase):
                     self.repo.open_index(),
                     exclude_ignored=True,
                 )
-            ),
-        )
-
-    def test_get_untracked_paths_walk(self):
-        os.mkdir(os.path.join(self.repo.path, "dir"))
-        os.mkdir(os.path.join(self.repo.path, "dir/subdir"))
-        with open(os.path.join(self.repo.path, "dir", "file"), "w") as f:
-            f.write("foo")
-        with open(os.path.join(self.repo.path, "dir/subdir/subfile"), "w") as f:
-            f.write("foo")
-
-        self.assertEqual(
-            {"dir/"},
-            set(
-                porcelain.get_untracked_paths(
-                    self.repo.path, self.repo.path, self.repo.open_index(), walk=False
-                )
-            ),
-        )
-        self.assertEqual(
-            set(["dir/file", "dir/subdir/subfile"]),
-            set(
-                porcelain.get_untracked_paths(
-                    self.repo.path, self.repo.path, self.repo.open_index(), walk=True
-                )
-            ),
+            )
         )
 
 


### PR DESCRIPTION
The idea is to more closely match `git`'s `-u/--untracked-file` flag and behaviour:
    - `untracked_files="no"` returns no untracked files
    - `untracked_files="all"` (dulwich default) returns all untracked files
    - `untracked_files="normal"` (git default) is not implemented (see discussion at https://github.com/jelmer/dulwich/pull/956)
    

