### PR TITLE
gha: don't forget to install twine

### DIFF
--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine fastimport paramiko
+        pip install setuptools wheel fastimport paramiko
     - name: Install gpg on supported platforms
       run: pip install -U gpg
       if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
@@ -79,6 +79,10 @@ jobs:
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dulwich-')
     steps:
+    - name: Install twine
+      run: |
+        python -m pip install --upgrade pip
+        pip install twine
     - name: Publish (Linux)
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
changes introduced in `f473b9f1..02ac0dc9` moved the twine upload step to a separate job, which is missing the `pip install twine` step

fixes #968 