### PR TITLE
gha: don't forget to upload wheels

### DIFF
--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -63,23 +63,28 @@ jobs:
         # https://github.com/RalfG/python-wheels-manylinux-build/issues/26
         LD_LIBRARY_PATH: /usr/local/lib:${{ env.LD_LIBRARY_PATH }}
       if: "matrix.os == 'ubuntu-latest'"
+    - name: Upload wheels (Linux)
+      uses: actions/upload-artifact@v2
+      # Only include *manylinux* wheels; the other wheels files are built but
+      # rejected by pip.
+      if: "matrix.os == 'ubuntu-latest'"
+      with:
+        name: dist
+        path: dist/*manylinux*.whl
+    - name: Upload wheels (non-Linux)
+      uses: actions/upload-artifact@v2
+      with:
+        name: dist
+        path: dist/*.whl
+      if: "matrix.os != 'ubuntu-latest'"
 
   publish:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        include:
-          - os: ubuntu-latest
-            python-version: '3.x'
-          # path encoding
-      fail-fast: false
+    runs-on: ubuntu-latest
 
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dulwich-')
     steps:
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: "3.x"
@@ -87,19 +92,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install twine
-    - name: Publish (Linux)
+    - name: Download wheels
+      uses: actions/download-artifact@v2
+    - name: Publish wheels
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        # Only include *manylinux* wheels; the other wheels files are built but
-        # rejected by pip.
-        twine upload dist/*manylinux*.whl
-      if: "matrix.os == 'ubuntu-latest'"
-    - name: Publish (non-Linux)
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        twine upload dist/*.whl
-      if: "matrix.os != 'ubuntu-latest'"
+      run: twine upload dist/*.whl


### PR DESCRIPTION
Unfortunately wheel publishing got broken in https://github.com/jelmer/dulwich/commit/978cd0115bf16eaeca510e55028d12fc5d9344ba

We now upload built wheels into one `dist` artifact and then publish them all at once in one job, saving on workers.

Related to #963