### PR TITLE
Add tests for pushing to the embedded server

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1139,13 +1139,14 @@ def pull(
             path, r, progress=errstream.write, determine_wants=determine_wants
         )
         for (lh, rh, force_ref) in selected_refs:
-            try:
-                check_diverged(r, r.refs[rh], fetch_result.refs[lh])
-            except DivergedBranches:
-                if fast_forward:
-                    raise
-                else:
-                    raise NotImplementedError("merge is not yet supported")
+            if not force_ref and rh in r.refs:
+                try:
+                    check_diverged(r, r.refs.get(rh), fetch_result.refs[lh])
+                except DivergedBranches:
+                    if fast_forward:
+                        raise
+                    else:
+                        raise NotImplementedError("merge is not yet supported")
             r.refs[rh] = fetch_result.refs[lh]
         if selected_refs:
             r[b"HEAD"] = fetch_result.refs[selected_refs[0][1]]

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -20,6 +20,7 @@
 
 """Tests for dulwich.porcelain."""
 
+import contextlib
 from io import BytesIO, StringIO
 import os
 import platform
@@ -30,6 +31,7 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+import threading
 import time
 from unittest import skipIf
 
@@ -48,6 +50,7 @@ from dulwich.repo import (
     NoIndexPresent,
     Repo,
 )
+from dulwich import server
 from dulwich.tests import (
     TestCase,
 )
@@ -55,6 +58,10 @@ from dulwich.tests.utils import (
     build_commit_graph,
     make_commit,
     make_object,
+)
+from dulwich.web import (
+    make_server,
+    make_wsgi_chain,
 )
 
 
@@ -2867,3 +2874,35 @@ class FindUniqueAbbrevTests(PorcelainTestCase):
         self.assertEqual(
             c1.id.decode('ascii')[:7],
             porcelain.find_unique_abbrev(self.repo.object_store, c1.id))
+
+
+class ServerTests(PorcelainTestCase):
+    @contextlib.contextmanager
+    def _serving(self):
+        with make_server('localhost', 0, self.app) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+
+            try:
+                yield f"http://localhost:{server.server_port}"
+
+            finally:
+                server.shutdown()
+                thread.join(10)
+
+    def setUp(self):
+        super().setUp()
+
+        self.served_repo_path = os.path.join(self.test_dir, "served_repo.git")
+        self.served_repo = Repo.init_bare(self.served_repo_path, mkdir=True)
+        self.addCleanup(self.served_repo.close)
+
+        backend = DictBackend({"/": self.served_repo})
+        self.app = make_wsgi_chain(backend)
+
+    def test_pull(self):
+        c1, = build_commit_graph(self.served_repo.object_store, [[1]])
+        self.served_repo.refs[b"refs/heads/master"] = c1.id
+
+        with self._serving() as url:
+            porcelain.pull(self.repo, url, "master")

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -50,7 +50,9 @@ from dulwich.repo import (
     NoIndexPresent,
     Repo,
 )
-from dulwich import server
+from dulwich.server import (
+    DictBackend,
+)
 from dulwich.tests import (
     TestCase,
 )
@@ -2906,3 +2908,10 @@ class ServerTests(PorcelainTestCase):
 
         with self._serving() as url:
             porcelain.pull(self.repo, url, "master")
+
+    def test_push(self):
+        c1, = build_commit_graph(self.repo.object_store, [[1]])
+        self.repo.refs[b"refs/heads/master"] = c1.id
+
+        with self._serving() as url:
+            porcelain.push(self.repo, url, "master")


### PR DESCRIPTION
This PR adds a test that pushes to Dulwich itself. The main motivation is to reproduce #977 without relying on outside infrastructure.

While at it, I added a small test for pulling into an empty repository, only to discover that it failed. So I fixed that :slightly_smiling_face: 