### PR TITLE
client: fix basic auth with empty password

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2181,7 +2181,7 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
         if username is not None:
             # No escaping needed: ":" is not allowed in username:
             # https://tools.ietf.org/html/rfc2617#section-2
-            credentials = "%s:%s" % (username, password)
+            credentials = f"{username}:{password or ''}"
             import urllib3.util
 
             basic_auth = urllib3.util.make_headers(basic_auth=credentials)


### PR DESCRIPTION
When authenticating using basic auth and only providing username (no password) the default value of `None` was cast to string, resulting in an attempt to authenticate using `<username>:None` instead of providing an empty password.
This broke authentication when providing an auth token as username (`https://token@github.com/...`)
 
Also see https://github.com/iterative/dvc/issues/7898#issuecomment-1157564615
