### PR TITLE
more typechecking

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2285,6 +2285,7 @@ def iter_instead_of(config: Config, push: bool = False) -> Iterable[Tuple[str, s
             except KeyError:
                 pass
         for needle in needles:
+            assert isinstance(needle, bytes)
             yield needle.decode('utf-8'), replacement.decode('utf-8')
 
 

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -286,7 +286,9 @@ def default_user_ignore_filter_path(config: Config) -> str:
       Path to a global ignore file
     """
     try:
-        return config.get((b"core",), b"excludesFile")
+        value = config.get((b"core",), b"excludesFile")
+        assert isinstance(value, bytes)
+        return value.decode(encoding="utf-8")
     except KeyError:
         pass
 

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -195,12 +195,16 @@ def get_user_identity(config: "StackedConfig", kind: Optional[str] = None) -> by
             email = email_uc.encode("utf-8")
     if user is None:
         try:
-            user = config.get(("user",), "name")
+            config_value = config.get(("user",), "name")
+            assert isinstance(config_value, bytes)
+            user = config_value
         except KeyError:
             user = None
     if email is None:
         try:
-            email = config.get(("user",), "email")
+            config_value = config.get(("user",), "email")
+            assert isinstance(config_value, bytes)
+            email = config_value
         except KeyError:
             email = None
     default_user, default_email = _get_default_identity()


### PR DESCRIPTION
Continuing to add type annotations to config-related classes.

That there are places in the code that put booleans into the configuration remains a wart, and its influence grows as the types pass that fact along.  It might be a worthwhile clean up to have [this code](https://github.com/jelmer/dulwich/blob/bbf100b63fb00ebb4a1d0ca698b1abe337611bae/dulwich/repo.py#L368-L374) use the strings "true" and "false" and remove `bool` from `Value` and `ValueLike`...