### PR TITLE
tidying up the boolean config change

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2285,7 +2285,6 @@ def iter_instead_of(config: Config, push: bool = False) -> Iterable[Tuple[str, s
             except KeyError:
                 pass
         for needle in needles:
-            assert isinstance(needle, bytes)
             yield needle.decode('utf-8'), replacement.decode('utf-8')
 
 

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -199,8 +199,6 @@ class Config(object):
             value = self.get(section, name)
         except KeyError:
             return default
-        if isinstance(value, bool):
-            return value
         if value.lower() == b"true":
             return True
         elif value.lower() == b"false":
@@ -401,7 +399,7 @@ class ConfigDict(Config, MutableMapping[Section, MutableMapping[Name, Value]]):
         return self._values.keys()
 
 
-def _format_string(value):
+def _format_string(value: bytes) -> bytes:
     if (
         value.startswith(b" ")
         or value.startswith(b"\t")
@@ -618,12 +616,7 @@ class ConfigFile(ConfigDict):
             else:
                 f.write(b"[" + section_name + b' "' + subsection_name + b'"]\n')
             for key, value in values.items():
-                if value is True:
-                    value = b"true"
-                elif value is False:
-                    value = b"false"
-                else:
-                    value = _format_string(value)
+                value = _format_string(value)
                 f.write(b"\t" + key + b" = " + value + b"\n")
 
 


### PR DESCRIPTION
Apologies for the stream of MRs, I intend this to be the last!

I realised that after making the `set()` change for booleans in the way that you suggested, the code that I had previously kept for backwards-compatibility can in fact be removed.  So here's one last piece of tidying on that.