### PR TITLE
compat tests: honour PATH environment variable in run_git()

### DIFF
--- a/dulwich/tests/compat/utils.py
+++ b/dulwich/tests/compat/utils.py
@@ -139,6 +139,7 @@ def run_git(
 
     env = popen_kwargs.pop("env", {})
     env["LC_ALL"] = env["LANG"] = "C"
+    env["PATH"] = os.getenv("PATH")
 
     args = [git_path] + args
     popen_kwargs["stdin"] = subprocess.PIPE


### PR DESCRIPTION
Copy PATH into the environment used by subprocess.Popen().

This makes it possible to use Git binaries installed in non-standard
locations, such as ~/bin. And it allows running compat tests on OpenBSD,
where "git" sits in /usr/local/bin by default, and where /usr/local/bin
is not in the default PATH of the shell.