### PR TITLE
status: return posix-style untracked paths instead of nt-style paths on win32

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1218,7 +1218,12 @@ def status(repo=".", ignored=False, untracked_files="all"):
             exclude_ignored=not ignored,
             untracked_files=untracked_files,
         )
-        untracked_changes = list(untracked_paths)
+        if sys.platform == "win32":
+            untracked_changes = [
+                path.replace(os.path.sep, "/") for path in untracked_paths
+            ]
+        else:
+            untracked_changes = list(untracked_paths)
 
         return GitStatus(tracked_changes, unstaged_changes, untracked_changes)
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -1919,6 +1919,16 @@ class StatusTests(PorcelainTestCase):
         with self.assertRaises(ValueError):
             porcelain.status(self.repo.path, untracked_files="antani")
 
+    def test_status_untracked_path(self):
+        untracked_dir = os.path.join(self.repo_path, "untracked_dir")
+        os.mkdir(untracked_dir)
+        untracked_file = os.path.join(untracked_dir, "untracked_file")
+        with open(untracked_file, "w") as fh:
+            fh.write("untracked")
+
+        _, _, untracked = porcelain.status(self.repo.path, untracked_files="all")
+        self.assertEqual(untracked, ["untracked_dir/untracked_file"])
+
     def test_status_crlf_mismatch(self):
         # First make a commit as if the file has been added on a Linux system
         # or with core.autocrlf=True


### PR DESCRIPTION
For consistency with CLI git (and with other porcelain.status paths), we should be returning posix-style paths instead of nt-style paths for untracked paths.