### PR TITLE
gha: temporarily pin flake8 to 4.0.1

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U pip coverage flake8 fastimport paramiko urllib3
+        pip install -U pip coverage flake8==4.0.1 fastimport paramiko urllib3
     - name: Install gpg on supported platforms
       run: pip install -U gpg
       if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"


### PR DESCRIPTION
5.x started reporting new issues which were making CI fail.

