### PR TITLE
Deprecation notice about urllib3[secure]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-urllib3[secure]>=1.23
+urllib3>=1.23

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ scripts = ['bin/dul-receive-pack', 'bin/dul-upload-pack']
 if has_setuptools:
     setup_kwargs['extras_require'] = {
         'fastimport': ['fastimport'],
-        'https': ['urllib3[secure]>=1.24.1'],
+        'https': ['urllib3>=1.24.1'],
         'pgp': ['gpg'],
         'paramiko': ['paramiko'],
         }


### PR DESCRIPTION
### Description
pyOpenSSL and urllib3[secure] are deprecated in the upcoming release (1.26.12)
https://github.com/urllib3/urllib3/issues/2680