### PR TITLE
Added flush before fsync

### DIFF
--- a/dulwich/file.py
+++ b/dulwich/file.py
@@ -189,6 +189,7 @@ class _GitFile(object):
         """
         if self._closed:
             return
+        self._file.flush()
         os.fsync(self._file.fileno())
         self._file.close()
         try:


### PR DESCRIPTION
Improves file system integrity.

This modification should minimize the possibility of corrupted files for (Windows) systems without UPS and the possibility for incomplete shutdowns, power failure or hard reset.
The positive effect shows, if one of the above incidents happens after a completed writing git access (e.g. commit)

Without fsync when the system (Windows) is not shutdown properly, files may have proper length but contain only '0' bytes.