### PR TITLE
Document authentication with porcelain.clone

### DIFF
--- a/docs/tutorial/porcelain.txt
+++ b/docs/tutorial/porcelain.txt
@@ -24,6 +24,10 @@ Clone a repository
 ------------------
 
   >>> porcelain.clone("git://github.com/jelmer/dulwich", "dulwich-clone")
+  
+Authentication works using the ``username`` and ``password`` parameters:
+
+  >>> porcelain.clone("https://example.com/a-private-repo.git", "a-private-repo-clone", username="user", password="password")
 
 Commit changes
 --------------

--- a/docs/tutorial/porcelain.txt
+++ b/docs/tutorial/porcelain.txt
@@ -25,7 +25,7 @@ Clone a repository
 
   >>> porcelain.clone("git://github.com/jelmer/dulwich", "dulwich-clone")
   
-Basic uthentication works using the ``username`` and ``password`` parameters:
+Basic authentication works using the ``username`` and ``password`` parameters:
 
   >>> porcelain.clone(
       "https://example.com/a-private-repo.git",

--- a/docs/tutorial/porcelain.txt
+++ b/docs/tutorial/porcelain.txt
@@ -25,9 +25,12 @@ Clone a repository
 
   >>> porcelain.clone("git://github.com/jelmer/dulwich", "dulwich-clone")
   
-Authentication works using the ``username`` and ``password`` parameters:
+Basic uthentication works using the ``username`` and ``password`` parameters:
 
-  >>> porcelain.clone("https://example.com/a-private-repo.git", "a-private-repo-clone", username="user", password="password")
+  >>> porcelain.clone(
+      "https://example.com/a-private-repo.git",
+      "a-private-repo-clone",
+      username="user", password="password")
 
 Commit changes
 --------------


### PR DESCRIPTION
Currently, the porcelain documentation does not mention that `porcelain.clone` supports authentication using the `username` and `password` parameters.

I think it would be nice to mention this especially for new users of the library like me, who go straight to the porcelain section of the documentation because they just want to clone a repository in Python. It took me a while to figure out that authentication is possible, so I'd like to ease that burden for all future new users of Dulwich by explicitly stating that possibility :)