### PR TITLE
Fix typos

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -993,7 +993,7 @@
     probing the filesystem for trustable permissions.
     (Koen Martens)
 
-  * Fix ``porcelain.reset`` to respect the comittish argument.
+  * Fix ``porcelain.reset`` to respect the committish argument.
     (Koen Martens)
 
   * Fix dulwich.porcelain.ls_remote() on Python 3.
@@ -2030,7 +2030,7 @@ FEATURES
 
   * Provide strnlen() on mingw32 which doesn't have it. (Hans Kolek)
 
-  * Set bare=true in the configuratin for bare repositories. (Dirk Neumann)
+  * Set bare=true in the configuration for bare repositories. (Dirk Neumann)
 
  FEATURES
 
@@ -2114,7 +2114,7 @@ FEATURES
 
  FEATURES
 
-  * Move named file initilization to BaseRepo. (Dave Borowitz)
+  * Move named file initialization to BaseRepo. (Dave Borowitz)
 
   * Add logging utilities and git/HTTP server logging. (Dave Borowitz)
 
@@ -2195,7 +2195,7 @@ note: This list is most likely incomplete for 0.6.0.
   * Fix RefsContainer.add_if_new to support dangling symrefs.
     (Dave Borowitz)
 
-  * Non-existant index files in non-bare repositories are now treated as 
+  * Non-existent index files in non-bare repositories are now treated as 
     empty. (Dave Borowitz)
 
   * Always update ShaFile.id when the contents of the object get changed. 

--- a/README.swift.rst
+++ b/README.swift.rst
@@ -46,7 +46,7 @@ be used as template::
 
 
 Note that for now we use the same tenant to perform the requests
-against Swift. Therefor there is only one Swift account used
+against Swift. Therefore there is only one Swift account used
 for storing repositories. Each repository will be contained in
 a Swift container.
 
@@ -118,7 +118,7 @@ The other Git commands can be used the way you do usually against
 a regular repository.
 
 Note the daemon subcommands starts a Git server listening for the
-Git protocol. Therefor there is no authentication or encryption
+Git protocol. Therefore there is no authentication or encryption
 at all between the cGIT client and the GIT server (Dulwich).
 
 Note on the .info file for pack object

--- a/docs/tutorial/encoding.txt
+++ b/docs/tutorial/encoding.txt
@@ -12,7 +12,7 @@ and commit messages.
 .. _C git: https://github.com/git/git/blob/master/Documentation/i18n.txt
 
 The library should be able to read *all* existing git repositories,
-irregardless of what encoding they use. This is the main reason why Dulwich
+regardless of what encoding they use. This is the main reason why Dulwich
 does not convert paths to unicode strings.
 
 A further consideration is that converting back and forth to unicode

--- a/dulwich/archive.py
+++ b/dulwich/archive.py
@@ -90,7 +90,7 @@ def tar_stream(store, tree, mtime, prefix=b"", format=""):
         if format == "gz":
             # Manually correct the gzip header file modification time so that
             # archives created from the same Git tree are always identical.
-            # The gzip header file modification time is not currenctly
+            # The gzip header file modification time is not currently
             # accessible from the tarfile API, see:
             # https://bugs.python.org/issue31526
             buf.seek(0)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -507,7 +507,7 @@ class cmd_ls_tree(Command):
             "-r",
             "--recursive",
             action="store_true",
-            help="Recusively list tree contents.",
+            help="Recursively list tree contents.",
         )
         parser.add_option("--name-only", action="store_true", help="Only display name.")
         options, args = parser.parse_args(args)

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1786,7 +1786,7 @@ class SSHGitClient(TraditionalGitClient):
             kwargs["password"] = self.password
         if self.key_filename is not None:
             kwargs["key_filename"] = self.key_filename
-        # GIT_SSH_COMMAND takes precendence over GIT_SSH
+        # GIT_SSH_COMMAND takes precedence over GIT_SSH
         if self.ssh_command is not None:
             kwargs["ssh_command"] = self.ssh_command
         con = self.ssh_vendor.run_command(

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -44,7 +44,7 @@ from typing import (
 from dulwich.file import GitFile
 
 
-SENTINAL = object()
+SENTINEL = object()
 
 
 def lower_key(key):
@@ -111,13 +111,13 @@ class CaseInsensitiveOrderedMultiDict(MutableMapping):
     def __getitem__(self, item):
         return self._keyed[lower_key(item)]
 
-    def get(self, key, default=SENTINAL):
+    def get(self, key, default=SENTINEL):
         try:
             return self[key]
         except KeyError:
             pass
 
-        if default is SENTINAL:
+        if default is SENTINEL:
             return type(self)()
 
         return default
@@ -128,7 +128,7 @@ class CaseInsensitiveOrderedMultiDict(MutableMapping):
             if lower_key(actual) == key:
                 yield value
 
-    def setdefault(self, key, default=SENTINAL):
+    def setdefault(self, key, default=SENTINEL):
         try:
             return self[key]
         except KeyError:

--- a/dulwich/contrib/diffstat.py
+++ b/dulwich/contrib/diffstat.py
@@ -184,7 +184,7 @@ def diffstat(lines, max_width=80):
 
 def main():
     argv = sys.argv
-    # allow diffstat.py to also be used from the comand line
+    # allow diffstat.py to also be used from the command line
     if len(sys.argv) > 1:
         diffpath = argv[1]
         data = b""
@@ -197,7 +197,7 @@ def main():
 
     # if no path argument to a diff file is passed in, run
     # a self test. The test case includes tricky things like
-    # a diff of diff, binary files, renames with futher changes
+    # a diff of diff, binary files, renames with further changes
     # added files and removed files.
     # All extracted from Sigil-Ebook/Sigil's github repo with
     # full permission to use under this license.

--- a/dulwich/contrib/release_robot.py
+++ b/dulwich/contrib/release_robot.py
@@ -29,7 +29,7 @@ Copy the following into the package ``__init__.py`` module::
     __version__ = get_current_version()
 
 This example assumes the tags have a leading "v" like "v0.3", and that the
-``.git`` folder is in a project folder that containts the package folder.
+``.git`` folder is in a project folder that contains the package folder.
 
 EG::
 

--- a/dulwich/contrib/swift.py
+++ b/dulwich/contrib/swift.py
@@ -504,9 +504,9 @@ class SwiftPackReader(object):
     """A SwiftPackReader that mimic read and sync method
 
     The reader allows to read a specified amount of bytes from
-    a given offset of a Swift object. A read offset is kept internaly.
+    a given offset of a Swift object. A read offset is kept internally.
     The reader will read from Swift a specified amount of data to complete
-    its internal buffer. chunk_length specifiy the amount of data
+    its internal buffer. chunk_length specify the amount of data
     to read from Swift.
     """
 

--- a/dulwich/contrib/test_paramiko_vendor.py
+++ b/dulwich/contrib/test_paramiko_vendor.py
@@ -131,7 +131,7 @@ class ParamikoSSHVendorTests(TestCase):
     def setUp(self):
         import paramiko.transport
 
-        # reenable server functionality for tests
+        # re-enable server functionality for tests
         if hasattr(paramiko.transport, "SERVER_DISABLED_BY_GENTOO"):
             paramiko.transport.SERVER_DISABLED_BY_GENTOO = False
 

--- a/dulwich/contrib/test_swift_smoke.py
+++ b/dulwich/contrib/test_swift_smoke.py
@@ -123,7 +123,7 @@ class SwiftRepoSmokeTest(unittest.TestCase):
         swift.SwiftRepo.init_bare(self.scon, self.conf)
         tcp_client = client.TCPGitClient(self.server_address, port=self.port)
         remote_refs = tcp_client.fetch(self.fakerepo, local_repo)
-        # The remote repo is empty (no refs retreived)
+        # The remote repo is empty (no refs retrieved)
         self.assertEqual(remote_refs, None)
 
     def test_push_commit(self):

--- a/dulwich/graph.py
+++ b/dulwich/graph.py
@@ -74,7 +74,7 @@ def _find_lcas(lookup_parents, c1, c2s):
                     cstates[pcmt] = flags
                 wlst.append(pcmt)
 
-    # walk final candidates removing any superceded by _DNC by later lower LCAs
+    # walk final candidates removing any superseded by _DNC by later lower LCAs
     results = []
     for cmt in cands:
         if not (cstates[cmt] & _DNC):

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -886,7 +886,7 @@ def index_entry_from_path(path, object_store=None):
 
     This returns an index value for files, symlinks
     and tree references. for directories and
-    non-existant files it returns None
+    non-existent files it returns None
 
     Args:
       path: Path to create an index entry for
@@ -929,7 +929,7 @@ def iter_fresh_entries(
 
 
 def iter_fresh_objects(paths, root_path, include_deleted=False, object_store=None):
-    """Iterate over versions of objecs on disk referenced by index.
+    """Iterate over versions of objects on disk referenced by index.
 
     Args:
       root_path: Root path to access from

--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -202,7 +202,7 @@ def write_object_diff(f, store, old_file, new_file, diff_binary=False):
       diff_binary: Whether to diff files even if they
         are considered binary files by is_binary().
 
-    Note: the tuple elements should be None for nonexistant files
+    Note: the tuple elements should be None for nonexistent files
     """
     (old_path, old_mode, old_id) = old_file
     (new_path, new_mode, new_id) = new_file

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -303,7 +303,7 @@ def _set_filesystem_hidden(path):
         if not SetFileAttributesW(path, FILE_ATTRIBUTE_HIDDEN):
             pass  # Could raise or log `ctypes.WinError()` here
 
-    # Could implement other platform specific filesytem hiding here
+    # Could implement other platform specific filesystem hiding here
 
 
 class ParentsProvider(object):
@@ -399,7 +399,7 @@ class BaseRepo(object):
         raise NotImplementedError(self._put_named_file)
 
     def _del_named_file(self, path):
-        """Delete a file in the contrl directory with the given name."""
+        """Delete a file in the control directory with the given name."""
         raise NotImplementedError(self._del_named_file)
 
     def open_index(self):
@@ -1053,7 +1053,7 @@ class UnsupportedVersion(Exception):
 class Repo(BaseRepo):
     """A git repository backed by local disk.
 
-    To open an existing repository, call the contructor with
+    To open an existing repository, call the constructor with
     the path of the repository.
 
     To create a new repository, use the Repo.init class method.
@@ -1390,7 +1390,7 @@ class Repo(BaseRepo):
                 tree_entry = self.object_store[tree_id].lookup_path(
                     self.object_store.__getitem__, tree_path)
             except KeyError:
-                # if tree_entry didnt exist, this file was being added, so
+                # if tree_entry didn't exist, this file was being added, so
                 # remove index entry
                 try:
                     del index[tree_path]

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -1068,7 +1068,7 @@ class ReceivePackHandler(PackHandler):
         client_refs = []
         ref = self.proto.read_pkt_line()
 
-        # if ref is none then client doesnt want to send us anything..
+        # if ref is none then client doesn't want to send us anything..
         if ref is None:
             return
 

--- a/dulwich/tests/__init__.py
+++ b/dulwich/tests/__init__.py
@@ -50,7 +50,7 @@ class TestCase(_TestCase):
     def setUp(self):
         super(TestCase, self).setUp()
         self._old_home = os.environ.get("HOME")
-        os.environ["HOME"] = "/nonexistant"
+        os.environ["HOME"] = "/nonexistent"
         os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
 
     def tearDown(self):

--- a/dulwich/tests/compat/test_client.py
+++ b/dulwich/tests/compat/test_client.py
@@ -1,4 +1,4 @@
-# test_client.py -- Compatibilty tests for git client.
+# test_client.py -- Compatibility tests for git client.
 # Copyright (C) 2010 Google, Inc.
 #
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
@@ -18,7 +18,7 @@
 # License, Version 2.0.
 #
 
-"""Compatibilty tests between the Dulwich client and the cgit server."""
+"""Compatibility tests between the Dulwich client and the cgit server."""
 
 import copy
 from io import BytesIO

--- a/dulwich/tests/compat/utils.py
+++ b/dulwich/tests/compat/utils.py
@@ -84,7 +84,7 @@ def require_git_version(required_version, git_path=_DEFAULT_GIT):
 
     Args:
       required_version: A tuple of ints of the form (major, minor, point,
-        sub-point); ommitted components default to 0.
+        sub-point); omitted components default to 0.
       git_path: Path to the git executable; defaults to the version in
         the system path.
     Raises:

--- a/dulwich/tests/test_config.py
+++ b/dulwich/tests/test_config.py
@@ -301,7 +301,7 @@ class StackedConfigTests(TestCase):
     def test_default_backends(self):
         StackedConfig.default_backends()
 
-    @skipIf(sys.platform != "win32", "Windows specfic config location.")
+    @skipIf(sys.platform != "win32", "Windows specific config location.")
     def test_windows_config_from_path(self):
         from dulwich.config import get_win_system_paths
 
@@ -317,7 +317,7 @@ class StackedConfigTests(TestCase):
             paths,
         )
 
-    @skipIf(sys.platform != "win32", "Windows specfic config location.")
+    @skipIf(sys.platform != "win32", "Windows specific config location.")
     def test_windows_config_from_reg(self):
         import winreg
 

--- a/dulwich/tests/test_greenthreads.py
+++ b/dulwich/tests/test_greenthreads.py
@@ -130,6 +130,6 @@ class TestGreenThreadsMissingObjectFinder(TestCase):
         finder = GreenThreadsMissingObjectFinder(
             self.store, wants[0 : int(self.cmt_amount / 2)], wants
         )
-        # sha_done will contains commit id and sha of blob refered in tree
+        # sha_done will contains commit id and sha of blob referred in tree
         self.assertEqual(len(finder.sha_done), (self.cmt_amount / 2) * 2)
         self.assertEqual(len(finder.objects_to_send), self.cmt_amount / 2)

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -717,7 +717,7 @@ class CloneTests(PorcelainTestCase):
         with tempfile.TemporaryDirectory() as parent:
             target_path = os.path.join(parent, "target")
             self.assertRaises(
-                Exception, porcelain.clone, "/nonexistant/repo", target_path
+                Exception, porcelain.clone, "/nonexistent/repo", target_path
             )
             self.assertFalse(os.path.exists(target_path))
 

--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -247,9 +247,9 @@ class RefsContainerTests(object):
         self.assertEqual(nines, self._refs[b"refs/heads/master"])
 
         self.assertTrue(
-            self._refs.set_if_equals(b"refs/heads/nonexistant", ZERO_SHA, nines)
+            self._refs.set_if_equals(b"refs/heads/nonexistent", ZERO_SHA, nines)
         )
-        self.assertEqual(nines, self._refs[b"refs/heads/nonexistant"])
+        self.assertEqual(nines, self._refs[b"refs/heads/nonexistent"])
 
     def test_add_if_new(self):
         nines = b"9" * 40
@@ -623,7 +623,7 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
             b"42d06bd4b77fed026b154d16493e5deab78f02ec",
             self._refs.read_ref(b"refs/heads/packed"),
         )
-        self.assertEqual(None, self._refs.read_ref(b"nonexistant"))
+        self.assertEqual(None, self._refs.read_ref(b"nonexistent"))
 
     def test_read_loose_ref(self):
         self._refs[b"refs/heads/foo"] = b"df6800012397fb85c56e7418dd4eb9405dee075c"


### PR DESCRIPTION
Found via `codespell -L te,ue,nd,feld,fpr,fo,claus,bu`