### PR TITLE
Add 32 bit architecture wheels for windows

### DIFF
--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -13,10 +13,14 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc - 3.11"]
+        architecture: ["x64", "x86"]
         include:
           - os: ubuntu-latest
             python-version: "3.x"
           # path encoding
+        exclude:
+          - os: macos-latest
+            architecture: "x86"
       fail-fast: true
 
     steps:
@@ -25,6 +29,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
       - name: Install native dependencies (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y libgpgme-dev libgpg-error-dev
         if: "matrix.os == 'ubuntu-latest'"


### PR DESCRIPTION
This enhances the Github Actions configuration to create wheels for 32-bit Windows.

As win32 is still a valid platform for python, this helps using dulwich on this python versions, as no compiler/compilation is required on package installation.