### PR TITLE
Implement timezone offset detection

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,7 +44,7 @@ jobs:
         if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
       - name: Install mypy
         run: |
-          pip install -U mypy types-paramiko types-certifi types-requests types-python-dateutil
+          pip install -U mypy types-paramiko types-certifi types-requests
         if: "matrix.python-version != 'pypy3'"
       - name: Style checks
         run: |

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,7 +44,7 @@ jobs:
         if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
       - name: Install mypy
         run: |
-          pip install -U mypy types-paramiko types-certifi types-requests
+          pip install -U mypy types-paramiko types-certifi types-requests types-python-dateutil
         if: "matrix.python-version != 'pypy3'"
       - name: Style checks
         run: |

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -266,7 +266,7 @@ def parse_timezone_format(tz_str):
     raise TimezoneFormatError(tz_str)
 
 
-def get_user_timezone():
+def get_user_timezones():
     """Retrieve local timezone as described in
     https://raw.githubusercontent.com/git/git/v2.3.0/Documentation/date-formats.txt
     Returns: A tuple containing author timezone, committer timezone

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -401,7 +401,9 @@ def commit(
     repo=".",
     message=None,
     author=None,
+    author_timezone=None,
     committer=None,
+    commit_timezone=None,
     encoding=None,
     no_verify=False,
     signoff=False,
@@ -412,7 +414,9 @@ def commit(
       repo: Path to repository
       message: Optional commit message
       author: Optional author name and email
+      author_timezone: Author timestamp timezone
       committer: Optional committer name and email
+      commit_timezone: Commit timestamp timezone
       no_verify: Skip pre-commit and commit-msg hooks
       signoff: GPG Sign the commit (bool, defaults to False,
         pass True to use default GPG key,
@@ -426,7 +430,11 @@ def commit(
         author = author.encode(encoding or DEFAULT_ENCODING)
     if getattr(committer, "encode", None):
         committer = committer.encode(encoding or DEFAULT_ENCODING)
-    author_timezone, commit_timezone = get_user_timezones()
+    local_timezone = get_user_timezones()
+    if author_timezone is None:
+        author_timezone = local_timezone[0]
+    if commit_timezone is None:
+        commit_timezone = local_timezone[1]
     with open_repo_closing(repo) as r:
         return r.do_commit(
             message=message,

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -448,7 +448,7 @@ def commit(
         author = author.encode(encoding or DEFAULT_ENCODING)
     if getattr(committer, "encode", None):
         committer = committer.encode(encoding or DEFAULT_ENCODING)
-    author_timezone, commit_timezone = get_user_timezone()
+    author_timezone, commit_timezone = get_user_timezones()
     with open_repo_closing(repo) as r:
         return r.do_commit(
             message=message,
@@ -1056,7 +1056,7 @@ def tag_create(
                 tag_time = int(time.time())
             tag_obj.tag_time = tag_time
             if tag_timezone is None:
-                tag_timezone = get_user_timezone()[1]
+                tag_timezone = get_user_timezones()[1]
             elif isinstance(tag_timezone, str):
                 tag_timezone = parse_timezone(tag_timezone)
             tag_obj.tag_timezone = tag_timezone

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -191,6 +191,87 @@ class RemoteExists(Error):
     """Raised when the remote already exists."""
 
 
+def _parse_timezone_format(tz_str):
+    """Parse given string and attempt to return a timezone offset.
+    Different formats are considered in the following order:
+        - Git internal format: <unix timestamp> <timezone offset>
+        - RFC 2822: e.g. Mon, 20 Nov 1995 19:12:08 -0500
+        - ISO 8601: e.g. 1995-11-20T19:12:08-0500
+            - uses regex if dateutil is not available
+    Will default to UTC if timezone cannot be determined.
+    Args:
+      tz_str: datetime string
+    Returns: Timezone offset as integer
+    """
+    import re
+
+    # Git internal format
+    internal_format_pattern = re.compile("^[0-9]+ [+-][0-9]{,4}$")
+    if re.match(internal_format_pattern, tz_str):
+        try:
+            tz_internal = parse_timezone(tz_str.split(" ")[1].encode(DEFAULT_ENCODING))
+            return tz_internal[0]
+        except ValueError:
+            pass
+
+    # RFC 2822
+    import email.utils
+    rfc_2822 = email.utils.parsedate_tz(tz_str)
+    if rfc_2822:
+        return rfc_2822[9]
+
+    # ISO 8601
+    try:
+        from dateutil.parser import isoparse
+        try:
+            iso_8601 = isoparse(tz_str)
+            delta = iso_8601.tzinfo._offset
+            if delta:
+                # From dateutil doc:
+                # `The time zone offset in seconds, or (since version 2.6.0, represented as a datetime.timedelta object).`
+                if isinstance(delta, int):
+                    return delta
+                return int(delta.total_seconds())
+        except (AttributeError, TypeError, ValueError):
+            pass
+    except (ModuleNotFoundError, ImportError):
+        # Supported offsets:
+        # sHHMM, sHH:MM, sHH
+        iso_8601_pattern = re.compile("[0-9]([+-])([0-9]{2})(?::(?=[0-9]{2}))?([0-9]{2})?$")
+        match = re.search(iso_8601_pattern, tz_str)
+        total_secs = 0
+        if match:
+            sign, hours, minutes = match.groups()
+            total_secs += int(hours) * 3600
+            if minutes:
+                total_secs += int(minutes) * 60
+            total_secs = -total_secs if sign == "-" else total_secs
+            return total_secs
+
+    # YYYY.MM.DD, MM/DD/YYYY, DD.MM.YYYY contain no timezone information
+
+    return 0
+
+
+def get_user_timezone():
+    """Retrieve local timezone as described in
+    https://raw.githubusercontent.com/git/git/v2.3.0/Documentation/date-formats.txt
+    Returns: A tuple containing author timezone, committer timezone
+    """
+    local_timezone = time.localtime().tm_gmtoff
+
+    if os.environ.get("GIT_AUTHOR_DATE"):
+        author_timezone = _parse_timezone_format(os.environ["GIT_AUTHOR_DATE"])
+    else:
+        author_timezone = local_timezone
+    if os.environ.get("GIT_COMMITTER_DATE"):
+        commit_timezone = _parse_timezone_format(os.environ["GIT_COMMITTER_DATE"])
+    else:
+        commit_timezone = local_timezone
+
+    return author_timezone, commit_timezone
+
+
 def open_repo(path_or_repo):
     """Open an argument that can be a repository or a path for a repository."""
     if isinstance(path_or_repo, BaseRepo):
@@ -354,11 +435,14 @@ def commit(
         author = author.encode(encoding or DEFAULT_ENCODING)
     if getattr(committer, "encode", None):
         committer = committer.encode(encoding or DEFAULT_ENCODING)
+    author_timezone, commit_timezone = get_user_timezone()
     with open_repo_closing(repo) as r:
         return r.do_commit(
             message=message,
             author=author,
+            author_timezone=author_timezone,
             committer=committer,
+            commit_timezone=commit_timezone,
             encoding=encoding,
             no_verify=no_verify,
             sign=signoff if isinstance(signoff, (str, bool)) else None,
@@ -959,8 +1043,7 @@ def tag_create(
                 tag_time = int(time.time())
             tag_obj.tag_time = tag_time
             if tag_timezone is None:
-                # TODO(jelmer) Use current user timezone rather than UTC
-                tag_timezone = 0
+                tag_timezone = get_user_timezone()[1]
             elif isinstance(tag_timezone, str):
                 tag_timezone = parse_timezone(tag_timezone)
             tag_obj.tag_timezone = tag_timezone

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -201,7 +201,6 @@ def parse_timezone_format(tz_str):
         - Git internal format: <unix timestamp> <timezone offset>
         - RFC 2822: e.g. Mon, 20 Nov 1995 19:12:08 -0500
         - ISO 8601: e.g. 1995-11-20T19:12:08-0500
-            - uses regex if dateutil is not available
     Args:
       tz_str: datetime string
     Returns: Timezone offset as integer
@@ -226,40 +225,19 @@ def parse_timezone_format(tz_str):
         return rfc_2822[9]
 
     # ISO 8601
-    try:
-        from dateutil.parser import isoparse, parse
 
-        try:
-            iso_8601 = isoparse(tz_str)
-            delta = iso_8601.tzinfo._offset
-        except (AttributeError, TypeError, ValueError):
-            try:
-                # 2006-07-03 17:18:44 +0200
-                iso_8601 = parse(tz_str)
-                delta = iso_8601.tzinfo._offset
-            except (AttributeError, TypeError, ValueError):
-                delta = None
-
-        if delta:
-            # From dateutil doc:
-            # `The time zone offset in seconds, or (since version 2.6.0, represented as a datetime.timedelta object).`
-            if isinstance(delta, int):
-                return delta
-            return int(delta.total_seconds())
-
-    except (ModuleNotFoundError, ImportError):
-        # Supported offsets:
-        # sHHMM, sHH:MM, sHH
-        iso_8601_pattern = re.compile("[0-9] ?([+-])([0-9]{2})(?::(?=[0-9]{2}))?([0-9]{2})?$")
-        match = re.search(iso_8601_pattern, tz_str)
-        total_secs = 0
-        if match:
-            sign, hours, minutes = match.groups()
-            total_secs += int(hours) * 3600
-            if minutes:
-                total_secs += int(minutes) * 60
-            total_secs = -total_secs if sign == "-" else total_secs
-            return total_secs
+    # Supported offsets:
+    # sHHMM, sHH:MM, sHH
+    iso_8601_pattern = re.compile("[0-9] ?([+-])([0-9]{2})(?::(?=[0-9]{2}))?([0-9]{2})?$")
+    match = re.search(iso_8601_pattern, tz_str)
+    total_secs = 0
+    if match:
+        sign, hours, minutes = match.groups()
+        total_secs += int(hours) * 3600
+        if minutes:
+            total_secs += int(minutes) * 60
+        total_secs = -total_secs if sign == "-" else total_secs
+        return total_secs
 
     # YYYY.MM.DD, MM/DD/YYYY, DD.MM.YYYY contain no timezone information
 

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -516,6 +516,10 @@ class TimezoneTests(PorcelainTestCase):
         self.put_envs("1995-11-20 19:12:08-05")
         self.assertTupleEqual((-18000, -18000), porcelain.get_user_timezone())
 
+        # https://github.com/git/git/blob/96b2d4fa927c5055adc5b1d08f10a5d7352e2989/t/t6300-for-each-ref.sh#L128
+        self.put_envs("2006-07-03 17:18:44 +0200")
+        self.assertTupleEqual((7200, 7200), porcelain.get_user_timezone())
+
     def test_missing_or_malformed(self):
         # TODO: add more here
         self.fallback("0 + 0500")

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -493,35 +493,35 @@ class TimezoneTests(PorcelainTestCase):
 
     def fallback(self, value):
         self.put_envs(value)
-        self.assertRaises(porcelain.TimezoneFormatError, porcelain.get_user_timezone)
+        self.assertRaises(porcelain.TimezoneFormatError, porcelain.get_user_timezones)
 
     def test_internal_format(self):
         self.put_envs("0 +0500")
-        self.assertTupleEqual((18000, 18000), porcelain.get_user_timezone())
+        self.assertTupleEqual((18000, 18000), porcelain.get_user_timezones())
 
     def test_rfc_2822(self):
         self.put_envs("Mon, 20 Nov 1995 19:12:08 -0500")
-        self.assertTupleEqual((-18000, -18000), porcelain.get_user_timezone())
+        self.assertTupleEqual((-18000, -18000), porcelain.get_user_timezones())
 
         self.put_envs("Mon, 20 Nov 1995 19:12:08")
-        self.assertTupleEqual((0, 0), porcelain.get_user_timezone())
+        self.assertTupleEqual((0, 0), porcelain.get_user_timezones())
 
     def test_iso8601(self):
         self.put_envs("1995-11-20T19:12:08-0501")
-        self.assertTupleEqual((-18060, -18060), porcelain.get_user_timezone())
+        self.assertTupleEqual((-18060, -18060), porcelain.get_user_timezones())
 
         self.put_envs("1995-11-20T19:12:08+0501")
-        self.assertTupleEqual((18060, 18060), porcelain.get_user_timezone())
+        self.assertTupleEqual((18060, 18060), porcelain.get_user_timezones())
 
         self.put_envs("1995-11-20T19:12:08-05:01")
-        self.assertTupleEqual((-18060, -18060), porcelain.get_user_timezone())
+        self.assertTupleEqual((-18060, -18060), porcelain.get_user_timezones())
 
         self.put_envs("1995-11-20 19:12:08-05")
-        self.assertTupleEqual((-18000, -18000), porcelain.get_user_timezone())
+        self.assertTupleEqual((-18000, -18000), porcelain.get_user_timezones())
 
         # https://github.com/git/git/blob/96b2d4fa927c5055adc5b1d08f10a5d7352e2989/t/t6300-for-each-ref.sh#L128
         self.put_envs("2006-07-03 17:18:44 +0200")
-        self.assertTupleEqual((7200, 7200), porcelain.get_user_timezone())
+        self.assertTupleEqual((7200, 7200), porcelain.get_user_timezones())
 
     def test_missing_or_malformed(self):
         # TODO: add more here
@@ -538,25 +538,25 @@ class TimezoneTests(PorcelainTestCase):
     def test_different_envs(self):
         os.environ["GIT_AUTHOR_DATE"] = "0 +0500"
         os.environ["GIT_COMMITTER_DATE"] = "0 +0501"
-        self.assertTupleEqual((18000, 18060), porcelain.get_user_timezone())
+        self.assertTupleEqual((18000, 18060), porcelain.get_user_timezones())
 
     def test_no_envs(self):
         local_timezone = time.localtime().tm_gmtoff
 
         self.put_envs("0 +0500")
-        self.assertTupleEqual((18000, 18000), porcelain.get_user_timezone())
+        self.assertTupleEqual((18000, 18000), porcelain.get_user_timezones())
 
         del os.environ["GIT_COMMITTER_DATE"]
-        self.assertTupleEqual((18000, local_timezone), porcelain.get_user_timezone())
+        self.assertTupleEqual((18000, local_timezone), porcelain.get_user_timezones())
 
         self.put_envs("0 +0500")
         del os.environ["GIT_AUTHOR_DATE"]
-        self.assertTupleEqual((local_timezone, 18000), porcelain.get_user_timezone())
+        self.assertTupleEqual((local_timezone, 18000), porcelain.get_user_timezones())
 
         self.put_envs("0 +0500")
         del os.environ["GIT_AUTHOR_DATE"]
         del os.environ["GIT_COMMITTER_DATE"]
-        self.assertTupleEqual((local_timezone, local_timezone), porcelain.get_user_timezone())
+        self.assertTupleEqual((local_timezone, local_timezone), porcelain.get_user_timezones())
 
 
 class CleanTests(PorcelainTestCase):

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -421,6 +421,58 @@ class CommitTests(PorcelainTestCase):
         self.assertIsInstance(sha, bytes)
         self.assertEqual(len(sha), 40)
 
+    def test_timezone(self):
+        c1, c2, c3 = build_commit_graph(
+            self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
+        )
+        self.repo.refs[b"refs/heads/foo"] = c3.id
+        sha = porcelain.commit(
+            self.repo.path,
+            message="Some message",
+            author="Joe <joe@example.com>",
+            author_timezone=18000,
+            committer="Bob <bob@example.com>",
+            commit_timezone=18000,
+        )
+        self.assertIsInstance(sha, bytes)
+        self.assertEqual(len(sha), 40)
+
+        commit = self.repo.get_object(sha)
+        self.assertEqual(commit._author_timezone, 18000)
+        self.assertEqual(commit._commit_timezone, 18000)
+
+        os.environ["GIT_AUTHOR_DATE"] = os.environ["GIT_COMMITTER_DATE"] = "1995-11-20T19:12:08-0501"
+
+        sha = porcelain.commit(
+            self.repo.path,
+            message="Some message",
+            author="Joe <joe@example.com>",
+            committer="Bob <bob@example.com>",
+        )
+        self.assertIsInstance(sha, bytes)
+        self.assertEqual(len(sha), 40)
+
+        commit = self.repo.get_object(sha)
+        self.assertEqual(commit._author_timezone, -18060)
+        self.assertEqual(commit._commit_timezone, -18060)
+
+        del os.environ["GIT_AUTHOR_DATE"]
+        del os.environ["GIT_COMMITTER_DATE"]
+        local_timezone = time.localtime().tm_gmtoff
+
+        sha = porcelain.commit(
+            self.repo.path,
+            message="Some message",
+            author="Joe <joe@example.com>",
+            committer="Bob <bob@example.com>",
+        )
+        self.assertIsInstance(sha, bytes)
+        self.assertEqual(len(sha), 40)
+
+        commit = self.repo.get_object(sha)
+        self.assertEqual(commit._author_timezone, local_timezone)
+        self.assertEqual(commit._commit_timezone, local_timezone)
+
 
 @skipIf(platform.python_implementation() == "PyPy" or sys.platform == "win32", "gpgme not easily available or supported on Windows and PyPy")
 class CommitSignTests(PorcelainGpgTestCase):

--- a/dulwich/tests/test_porcelain.py
+++ b/dulwich/tests/test_porcelain.py
@@ -493,7 +493,7 @@ class TimezoneTests(PorcelainTestCase):
 
     def fallback(self, value):
         self.put_envs(value)
-        self.assertTupleEqual((0, 0), porcelain.get_user_timezone())
+        self.assertRaises(porcelain.TimezoneFormatError, porcelain.get_user_timezone)
 
     def test_internal_format(self):
         self.put_envs("0 +0500")
@@ -502,6 +502,9 @@ class TimezoneTests(PorcelainTestCase):
     def test_rfc_2822(self):
         self.put_envs("Mon, 20 Nov 1995 19:12:08 -0500")
         self.assertTupleEqual((-18000, -18000), porcelain.get_user_timezone())
+
+        self.put_envs("Mon, 20 Nov 1995 19:12:08")
+        self.assertTupleEqual((0, 0), porcelain.get_user_timezone())
 
     def test_iso8601(self):
         self.put_envs("1995-11-20T19:12:08-0501")
@@ -524,8 +527,6 @@ class TimezoneTests(PorcelainTestCase):
         # TODO: add more here
         self.fallback("0 + 0500")
         self.fallback("a +0500")
-
-        self.fallback("Mon, 20 Nov 1995 19:12:08")
 
         self.fallback("1995-11-20T19:12:08")
         self.fallback("1995-11-20T19:12:08-05:")


### PR DESCRIPTION
This PR adds functionality to detect local timezone offsets to porcelain.
[date-formats.txt](https://raw.githubusercontent.com/git/git/v2.3.0/Documentation/date-formats.txt).
~~The implementation optionally supports [```python-dateutil```](https://github.com/dateutil/dateutil) to parse ISO 8601 formatted strings.~~

RFC on some details:
- move ```parse_timezone_format()``` out of porcelain?
- different ordering of formats?
- use author date instead of committer date in ```tag_create()```? (currently works like C git)

IMO, only porcelain should support timezone detection. All "internal/low-level" functions should just default to 0.