### PR TITLE
Drop use of certifi to find ca certificate path

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -44,7 +44,7 @@ jobs:
         if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
       - name: Install mypy
         run: |
-          pip install -U mypy types-paramiko types-certifi types-requests
+          pip install -U mypy types-paramiko types-requests
         if: "matrix.python-version != 'pypy3'"
       - name: Style checks
         run: |

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1863,7 +1863,9 @@ def default_urllib3_manager(   # noqa: C901
 
     headers = {"User-agent": user_agent}
 
-    kwargs = {}
+    kwargs = {
+        "ca_certs" : ca_certs,
+    }
     if ssl_verify is True:
         kwargs["cert_reqs"] = "CERT_REQUIRED"
     elif ssl_verify is False:
@@ -1872,18 +1874,7 @@ def default_urllib3_manager(   # noqa: C901
         # Default to SSL verification
         kwargs["cert_reqs"] = "CERT_REQUIRED"
 
-    if ca_certs is not None:
-        kwargs["ca_certs"] = ca_certs
     kwargs.update(override_kwargs)
-
-    # Try really hard to find a SSL certificate path
-    if "ca_certs" not in kwargs and kwargs.get("cert_reqs") != "CERT_NONE":
-        try:
-            import certifi
-        except ImportError:
-            pass
-        else:
-            kwargs["ca_certs"] = certifi.where()
 
     import urllib3
 

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ setup(name='dulwich',
       ext_modules=ext_modules,
       zip_safe=False,
       distclass=DulwichDistribution,  # type: ignore
-      install_requires=['urllib3>=1.24.1', 'certifi'],
+      install_requires=['urllib3>=1.25'],
       include_package_data=True,
       test_suite='dulwich.tests.test_suite',
       tests_require=tests_require,


### PR DESCRIPTION
Drop use of certifi to find ca certificate path.
  
This seems to be having adverse affects where we specify an incorrect path in some cases. Fixes #1025
  
Increment minimum urllib3 to >= 1.25 just to be sure; not strictly necessary -
we're already trying to be explicit about whether we want verification.
  
This was originally introduced in 48e2ef8c2f2c65a33ad3276458791c19ef208c1a, but
urllib3 now verifies certificates by default.
See also https://urllib3.readthedocs.io/en/latest/user-guide.html#certificate-verification
  
thanks to @dimbleby  for help with the archeology on this one :)
