### PR TITLE
Fix wheels uploads: don't upload wheels with unsupported platform tag

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -2,7 +2,6 @@ name: Python tests
 
 on:
   push:
-  pull_request:
   schedule:
     - cron: "0 6 * * *" # Daily 6AM UTC build
 

--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -1,4 +1,4 @@
-name: Python package
+name: Python tests
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     - cron: "0 6 * * *" # Daily 6AM UTC build
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -2,7 +2,6 @@ name: Build Python Wheels
 
 on:
   push:
-  pull_request:
   schedule:
     - cron: "0 6 * * *" # Daily 6AM UTC build
 

--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -69,12 +69,12 @@ jobs:
         if: "matrix.os == 'ubuntu-latest'"
       - name: Upload wheels (Linux)
         uses: actions/upload-artifact@v2
-        # Only include *manylinux* wheels; the other wheels files are built but
-        # rejected by pip.
+        # Only include *-manylinux* wheels; the other wheels files are built but
+        # rejected by pip (unsupported platform tag)
         if: "matrix.os == 'ubuntu-latest'"
         with:
           name: dist
-          path: dist/*manylinux*.whl
+          path: dist/*-manylinux*.whl
       - name: Upload wheels (non-Linux)
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Fix wheels uploads: don't upload wheels with unsupported platform tag.

This was down to a missing dash, *manylinux*.whl matches 6 extra wheels with
platform tag linux_aarch64; *-manylinux*.whl doesn't.

Fixes #1034
