### PR TITLE
Start building using cibuildwheel

### DIFF
--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -33,6 +33,10 @@ jobs:
         run: python -m unittest dulwich.tests.test_suite
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+          CIBW_ARCHS_WINDOWS: AMD64
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -31,12 +31,15 @@ jobs:
         if: "matrix.os != 'windows-latest'"
       - name: Run test suite
         run: python -m unittest dulwich.tests.test_suite
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        if: "matrix.os == 'ubuntu-latest'"
       - name: Build wheels
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS_WINDOWS: AMD64 x86
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pythonwheels.yml
+++ b/.github/workflows/pythonwheels.yml
@@ -10,25 +10,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-rc - 3.11"]
-        architecture: ["x64", "x86"]
-        include:
-          - os: ubuntu-latest
-            python-version: "3.x"
-          # path encoding
-        exclude:
-          - os: macos-latest
-            architecture: "x86"
+        os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: true
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
       - name: Install native dependencies (Ubuntu)
         run: sudo apt-get update && sudo apt-get install -y libgpgme-dev libgpg-error-dev
         if: "matrix.os == 'ubuntu-latest'"
@@ -38,48 +25,18 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel fastimport paramiko urllib3
+          pip install setuptools wheel fastimport paramiko urllib3 cibuildwheel==2.9.0
       - name: Install gpg on supported platforms
         run: pip install -U gpg
-        if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"
+        if: "matrix.os != 'windows-latest'"
       - name: Run test suite
-        run: |
-          python -m unittest dulwich.tests.test_suite
-      - name: Build
-        run: |
-          python setup.py sdist bdist_wheel
-        if: "matrix.os != 'ubuntu-latest'"
-      - uses: docker/setup-qemu-action@v1
-        name: Set up QEMU
-        if: "matrix.os == 'ubuntu-latest'"
-      - name: Build (Linux aarch64)
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2014_aarch64
+        run: python -m unittest dulwich.tests.test_suite
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
         with:
-          python-versions: "cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311"
-        if: "matrix.os == 'ubuntu-latest'"
-      - name: Build (Linux)
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0
-        with:
-          python-versions: "cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311"
-        env:
-          # Temporary fix for LD_LIBRARY_PATH issue. See
-          # https://github.com/RalfG/python-wheels-manylinux-build/issues/26
-          LD_LIBRARY_PATH: /usr/local/lib:${{ env.LD_LIBRARY_PATH }}
-        if: "matrix.os == 'ubuntu-latest'"
-      - name: Upload wheels (Linux)
-        uses: actions/upload-artifact@v2
-        # Only include *-manylinux* wheels; the other wheels files are built but
-        # rejected by pip (unsupported platform tag)
-        if: "matrix.os == 'ubuntu-latest'"
-        with:
-          name: dist
-          path: dist/*-manylinux*.whl
-      - name: Upload wheels (non-Linux)
-        uses: actions/upload-artifact@v2
-        with:
-          name: dist
-          path: dist/*.whl
-        if: "matrix.os != 'ubuntu-latest'"
+          path: ./wheelhouse/*.whl
 
   publish:
     runs-on: ubuntu-latest
@@ -87,10 +44,8 @@ jobs:
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dulwich-')
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
+      - uses: actions/setup-python@v3
+
       - name: Install twine
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
Hey there, here's an attempt at building musl wheels using [cibuildwheel](https://github.com/pypa/cibuildwheel) to help with #1007.

Set to build wheels on the following architectures for python versions 3.6-3.11:
```
CIBW_ARCHS_LINUX: x86_64 aarch64
CIBW_ARCHS_MACOS: x86_64 arm64 universal2
CIBW_ARCHS_WINDOWS: AMD64
```
 Go ahead and tweak as wanted according to the `CIBW_ARCHS*` options documented [here](https://cibuildwheel.readthedocs.io/en/stable/options/#archs).

I'm coming from an issue with installing poetry on alpine in https://github.com/nikolaik/docker-python-nodejs, started with https://github.com/python-poetry/poetry/pull/5428 released in poetry [v1.2.0](https://github.com/python-poetry/poetry/releases/tag/1.2.0)

Resulting in the following build artifacts: https://github.com/nikolaik/dulwich/actions/runs/3015967682