### PR TITLE
Support non-ascii characters in filenames in tar streams

### DIFF
--- a/dulwich/archive.py
+++ b/dulwich/archive.py
@@ -110,7 +110,7 @@ def tar_stream(store, tree, mtime, prefix=b"", format=""):
 
             info = tarfile.TarInfo()
             # tarfile only works with ascii.
-            info.name = entry_abspath.decode("ascii")
+            info.name = entry_abspath.decode('utf-8', 'surrogateescape')
             info.size = blob.raw_length()
             info.mode = entry.mode
             info.mtime = mtime

--- a/dulwich/tests/test_archive.py
+++ b/dulwich/tests/test_archive.py
@@ -73,6 +73,19 @@ class ArchiveTests(TestCase):
         self.addCleanup(tf.close)
         self.assertEqual(["somename"], tf.getnames())
 
+    def test_unicode(self):
+        store = MemoryObjectStore()
+        b1 = Blob.from_string(b"somedata")
+        store.add_object(b1)
+        t1 = Tree()
+        t1.add("ő".encode('utf-8'), 0o100644, b1.id)
+        store.add_object(t1)
+        stream = b"".join(tar_stream(store, t1, mtime=0))
+        BytesIO(stream)
+        tf = tarfile.TarFile(fileobj=stream)
+        self.addCleanup(tf.close)
+        self.assertEqual(["ő"], tf.getnames())
+
     def test_prefix(self):
         stream = self._get_example_tar_stream(mtime=0, prefix=b"blah")
         tf = tarfile.TarFile(fileobj=stream)

--- a/dulwich/tests/test_archive.py
+++ b/dulwich/tests/test_archive.py
@@ -81,8 +81,7 @@ class ArchiveTests(TestCase):
         t1.add("ő".encode('utf-8'), 0o100644, b1.id)
         store.add_object(t1)
         stream = b"".join(tar_stream(store, t1, mtime=0))
-        BytesIO(stream)
-        tf = tarfile.TarFile(fileobj=stream)
+        tf = tarfile.TarFile(fileobj=BytesIO(stream))
         self.addCleanup(tf.close)
         self.assertEqual(["ő"], tf.getnames())
 


### PR DESCRIPTION
Support non-ascii characters in filenames in tar streams.
