### PR TITLE
Catch SymrefLoop in set_if_equals

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -835,7 +835,7 @@ class DiskRefsContainer(RefsContainer):
         try:
             realnames, _ = self.follow(name)
             realname = realnames[-1]
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, SymrefLoop):
             realname = name
         filename = self.refpath(realname)
 


### PR DESCRIPTION
Previously `self.follow(name)` raised `KeyError` which was handled, but now it raises `SymrefLoop` the exception is passed up to the caller. With this patch the old behaviour is restored.