### PR TITLE
Catch SymrefLoop in set_if_equals

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 0.20.47	UNRELEASED
 
+ * Fix handling of SymrefLoop in RefsContainer.__setitem__.
+   (Dominic Davis-Foster, Jelmer Vernooĳ)
+
 0.20.46	2022-09-06
 
  * Apply insteadOf to rsync-style location strings

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -835,7 +835,7 @@ class DiskRefsContainer(RefsContainer):
         try:
             realnames, _ = self.follow(name)
             realname = realnames[-1]
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, SymrefLoop):
             realname = name
         filename = self.refpath(realname)
 

--- a/dulwich/tests/test_refs.py
+++ b/dulwich/tests/test_refs.py
@@ -521,6 +521,14 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
         )
         self.assertRaises(SymrefLoop, self._refs.follow, b"refs/heads/loop")
 
+    def test_set_overwrite_loop(self):
+        self.assertRaises(SymrefLoop, self._refs.follow, b"refs/heads/loop")
+        self._refs[b'refs/heads/loop'] = (
+            b"42d06bd4b77fed026b154d16493e5deab78f02ec")
+        self.assertEqual(
+            ([b'refs/heads/loop'], b'42d06bd4b77fed026b154d16493e5deab78f02ec'),
+            self._refs.follow(b"refs/heads/loop"))
+
     def test_delitem(self):
         RefsContainerTests.test_delitem(self)
         ref_file = os.path.join(self._refs.path, b"refs", b"heads", b"master")


### PR DESCRIPTION
Catch SymrefLoop in set_if_equals.

(Dominic's change in https://github.com/jelmer/dulwich/pull/1042 + tests)

Fixes #1042
