### PR TITLE
display stderr output from git programs run by the test suite

### DIFF
--- a/dulwich/tests/compat/test_utils.py
+++ b/dulwich/tests/compat/test_utils.py
@@ -35,7 +35,7 @@ class GitVersionTests(TestCase):
 
         def run_git(args, **unused_kwargs):
             self.assertEqual(["--version"], args)
-            return 0, self._version_str
+            return 0, self._version_str, ''
 
         utils.run_git = run_git
 


### PR DESCRIPTION
This makes it easier to determine why a Git command failed. In my case, while exploring Git-protocol-v2 support, it is very helpful to see what git-http-backend complains about when my WIP implementation sends an invalid request.