### PR TITLE
Abort deltify() calls when reaching max size limit

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1645,9 +1645,14 @@ def deltify_pack_objects(objects, window_size=None):
         for base_id, base_type_num, base in possible_bases:
             if base_type_num != type_num:
                 continue
-            delta = list(create_delta(base, raw))
-            delta_len = sum(map(len, delta))
-            if delta_len < winner_len:
+            delta_len = 0
+            delta = []
+            for chunk in create_delta(base, raw):
+                delta_len += len(chunk)
+                if delta_len >= winner_len:
+                    break
+                delta.append(chunk)
+            else:
                 winner_base = base_id
                 winner = delta
                 winner_len = sum(map(len, winner))

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1645,7 +1645,7 @@ def deltify_pack_objects(objects, window_size=None):
         for base_id, base_type_num, base in possible_bases:
             if base_type_num != type_num:
                 continue
-            delta = create_delta(base, raw)
+            delta = list(create_delta(base, raw))
             delta_len = sum(map(len, delta))
             if delta_len < winner_len:
                 winner_base = base_id
@@ -1871,10 +1871,9 @@ def create_delta(base_buf, target_buf):
         target_buf = b''.join(target_buf)
     assert isinstance(base_buf, bytes)
     assert isinstance(target_buf, bytes)
-    out_buf = []
     # write delta header
-    out_buf.append(_delta_encode_size(len(base_buf)))
-    out_buf.append(_delta_encode_size(len(target_buf)))
+    yield _delta_encode_size(len(base_buf))
+    yield _delta_encode_size(len(target_buf))
     # write out delta opcodes
     seq = SequenceMatcher(isjunk=None, a=base_buf, b=target_buf)
     for opcode, i1, i2, j1, j2 in seq.get_opcodes():
@@ -1888,7 +1887,7 @@ def create_delta(base_buf, target_buf):
             copy_len = i2 - i1
             while copy_len > 0:
                 to_copy = min(copy_len, _MAX_COPY_LEN)
-                out_buf.append(_encode_copy_operation(copy_start, to_copy))
+                yield _encode_copy_operation(copy_start, to_copy)
                 copy_start += to_copy
                 copy_len -= to_copy
         if opcode == "replace" or opcode == "insert":
@@ -1897,13 +1896,12 @@ def create_delta(base_buf, target_buf):
             s = j2 - j1
             o = j1
             while s > 127:
-                out_buf.append(bytes([127]))
-                out_buf.append(memoryview(target_buf)[o:o + 127])
+                yield bytes([127])
+                yield memoryview(target_buf)[o:o + 127]
                 s -= 127
                 o += 127
-            out_buf.append(bytes([s]))
-            out_buf.append(memoryview(target_buf)[o:o + s])
-    return out_buf
+            yield bytes([s])
+            yield memoryview(target_buf)[o:o + s]
 
 
 def apply_delta(src_buf, delta):

--- a/dulwich/tests/test_pack.py
+++ b/dulwich/tests/test_pack.py
@@ -186,7 +186,8 @@ class TestPackDeltas(TestCase):
 
     def _test_roundtrip(self, base, target):
         self.assertEqual(
-            target, b"".join(apply_delta(base, create_delta(base, target)))
+            target,
+            b"".join(apply_delta(base, list(create_delta(base, target))))
         )
 
     def test_nochange(self):
@@ -880,7 +881,7 @@ class DeltifyTests(TestCase):
     def test_simple_delta(self):
         b1 = Blob.from_string(b"a" * 101)
         b2 = Blob.from_string(b"a" * 100)
-        delta = create_delta(b1.as_raw_chunks(), b2.as_raw_chunks())
+        delta = list(create_delta(b1.as_raw_chunks(), b2.as_raw_chunks()))
         self.assertEqual(
             [
                 (b1.type_num, b1.sha().digest(), None, b1.as_raw_chunks()),

--- a/dulwich/tests/utils.py
+++ b/dulwich/tests/utils.py
@@ -260,7 +260,7 @@ def build_pack(f, objects_spec, store=None):
             base_index, data = obj
             base = offset - offsets[base_index]
             _, base_data, _ = full_objects[base_index]
-            obj = (base, create_delta(base_data, data))
+            obj = (base, list(create_delta(base_data, data)))
         elif type_num == REF_DELTA:
             base_ref, data = obj
             if isinstance(base_ref, int):
@@ -268,7 +268,7 @@ def build_pack(f, objects_spec, store=None):
             else:
                 base_type_num, base_data = store.get_raw(base_ref)
                 base = obj_sha(base_type_num, base_data)
-            obj = (base, create_delta(base_data, data))
+            obj = (base, list(create_delta(base_data, data)))
 
         crc32 = write_pack_object(sf.write, type_num, obj)
         offsets[i] = offset


### PR DESCRIPTION
Abort deltify() calls when reaching max size limit.
