### PR TITLE
fix for windows usage as "username getpass.getuser" is not available

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -139,11 +139,11 @@ class InvalidUserIdentity(Exception):
 def _get_default_identity() -> Tuple[str, str]:
     import getpass
     import socket
-
-    username = getpass.getuser()
     try:
+        username = getpass.getuser()
         import pwd
     except ImportError:
+        username = os.getlogin()
         fullname = None
     else:
         try:


### PR DESCRIPTION
fix for windows usage as "username getpass.getuser" is not available
Added os.getlogin() for windows usage