### PR TITLE
On Windows, provide a hint about developer mode when creating symlinks fails due to a permission error

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 0.20.47	UNRELEASED
 
+ * On Windows, provide a hint about developer mode
+   when creating symlinks fails due to a permission
+   error. (Jelmer Vernooĳ, #1005)
+
  * Support repository format version 1.
    (Jelmer Vernooĳ, #1056)
 

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1875,7 +1875,8 @@ def update_head(repo, target, detached=False, new_branch=None):
             r.refs.set_symbolic_ref(b"HEAD", to_set)
 
 
-def reset_file(repo, file_path: str, target: bytes = b'HEAD'):
+def reset_file(repo, file_path: str, target: bytes = b'HEAD',
+               symlink_fn=None):
     """Reset the file to specific commit or branch.
 
     Args:
@@ -1890,7 +1891,7 @@ def reset_file(repo, file_path: str, target: bytes = b'HEAD'):
     full_path = os.path.join(repo.path.encode(), file_path)
     blob = repo.object_store[file_entry[1]]
     mode = file_entry[0]
-    build_file_from_blob(blob, mode, full_path)
+    build_file_from_blob(blob, mode, full_path, symlink_fn=symlink_fn)
 
 
 def check_mailmap(repo, contact):

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -337,6 +337,9 @@ class ParentsProvider(object):
 class BaseRepo(object):
     """Base class for a git repository.
 
+    This base class is meant to be used for Repository implementations that e.g.
+    work on top of a different transport than a standard filesystem path.
+
     Attributes:
       object_store: Dictionary-like object for accessing
         the objects
@@ -1095,6 +1098,7 @@ class Repo(BaseRepo):
         object_store: Optional[BaseObjectStore] = None,
         bare: Optional[bool] = None
     ) -> None:
+        self.symlink_fn = None
         hidden_path = os.path.join(root, CONTROLDIR)
         if bare is None:
             if (os.path.isfile(hidden_path)
@@ -1568,6 +1572,7 @@ class Repo(BaseRepo):
             tree,
             honor_filemode=honor_filemode,
             validate_path_element=validate_path_element,
+            symlink_fn=self.symlink_fn,
         )
 
     def get_config(self) -> "ConfigFile":

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -71,10 +71,6 @@ def can_symlink():
         # Platforms other than Windows should allow symlinks without issues.
         return True
 
-    if not hasattr(os, "symlink"):
-        # Older Python versions do not have `os.symlink` on Windows.
-        return False
-
     test_source = tempfile.mkdtemp()
     test_target = test_source + "can_symlink"
     try:


### PR DESCRIPTION
On Windows, provide a hint about developer mode when creating symlinks fails due to a permission error

Fixes #1005
