### PR TITLE
Add Python 3.9 into tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
-envlist = py35, py35-noext, py36, py36-noext, py37, py37-noext, py38, py38-noext
+envlist = py36, py36-noext, py37, py37-noext, py38, py38-noext, py39, py39-noext
 
 [testenv]
 
@@ -11,9 +11,6 @@ whitelist_externals = make
 [testenv:pypy-noext]
 commands = make check-noextensions
 
-[testenv:py35-noext]
-commands = make check-noextensions
-
 [testenv:py36-noext]
 commands = make check-noextensions
 
@@ -21,4 +18,7 @@ commands = make check-noextensions
 commands = make check-noextensions
 
 [testenv:py38-noext]
+commands = make check-noextensions
+
+[testenv:py39-noext]
 commands = make check-noextensions


### PR DESCRIPTION
Latest Debian stable has this and adding it makes development easier. Also looks like this no longer supports Python 3.5 so removing