### PR TITLE
Simplify tox setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 downloadcache = {toxworkdir}/cache/
-envlist = py36, py36-noext, py37, py37-noext, py38, py38-noext, py39, py39-noext
 
 [testenv]
 
@@ -8,17 +7,5 @@ commands = make check
 recreate = True
 whitelist_externals = make
 
-[testenv:pypy-noext]
-commands = make check-noextensions
-
-[testenv:py36-noext]
-commands = make check-noextensions
-
-[testenv:py37-noext]
-commands = make check-noextensions
-
-[testenv:py38-noext]
-commands = make check-noextensions
-
-[testenv:py39-noext]
+[testenv:noext]
 commands = make check-noextensions


### PR DESCRIPTION
Since upstream doesn't predominantly use tox, just remove all extra boilerplate so tox will work out of the box with whatever Python is.