### PR TITLE
empty proxy environment variables are now ignored

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1833,7 +1833,7 @@ def default_urllib3_manager(   # noqa: C901
     if proxy_server is None:
         for proxyname in ("https_proxy", "http_proxy", "all_proxy"):
             proxy_server = os.environ.get(proxyname)
-            if proxy_server is not None and proxy_server != "":
+            if proxy_server:
                 break
 
     if config is not None:

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1833,7 +1833,7 @@ def default_urllib3_manager(   # noqa: C901
     if proxy_server is None:
         for proxyname in ("https_proxy", "http_proxy", "all_proxy"):
             proxy_server = os.environ.get(proxyname)
-            if proxy_server is not None:
+            if proxy_server is not None and proxy_server != "":
                 break
 
     if config is not None:

--- a/dulwich/tests/test_client.py
+++ b/dulwich/tests/test_client.py
@@ -1238,6 +1238,16 @@ class DefaultUrllib3ManagerTest(TestCase):
         self.assertEqual(manager.proxy.port, 8080)
         del os.environ["http_proxy"]
 
+    def test_environment_empty_proxy(self):
+        import urllib3
+
+        config = ConfigDict()
+        os.environ["http_proxy"] = ""
+        manager = default_urllib3_manager(config=config)
+        self.assertNotIsInstance(manager, urllib3.ProxyManager)
+        self.assertIsInstance(manager, urllib3.PoolManager)
+        del os.environ["http_proxy"]
+
     def test_config_proxy_custom_cls(self):
         import urllib3
 


### PR DESCRIPTION
This small change would allow the usage of
`http_proxy='' command`
as for example in
`http_proxy='' dvc list ...`
in bash scripts to temporary overwrite a proxy configuration by environment variables.