### PR TITLE
recognize Git protocol-v2 delim-pkt message separators

### DIFF
--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -206,7 +206,7 @@ class Protocol(object):
         This method may read from the readahead buffer; see unread_pkt_line.
 
         Returns: The next string from the stream, without the length prefix, or
-            None for a flush-pkt ('0000').
+            None for a flush-pkt ('0000') or delim-pkt ('0001').
         """
         if self._readahead is None:
             read = self.read
@@ -219,7 +219,7 @@ class Protocol(object):
             if not sizestr:
                 raise HangupException()
             size = int(sizestr, 16)
-            if size == 0:
+            if size == 0 or size == 1:  # flush-pkt or delim-pkt
                 if self.report_activity:
                     self.report_activity(4, "read")
                 return None


### PR DESCRIPTION
Version 2 of the Git protocol adds a new message delimiter which is distinct from the flush packet. Recognize such delimiters in the read_pkt_line() method of the Protocol class, such that pkt-lines will still be split as expected when reading protocol-v2 messages.