### PR TITLE
allow for reuse of existing deltas while creating pack files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@
 
 0.20.50	2022-10-30
 
+ * Add --deltify option to ``dulwich pack-objects`` which enables
+   deltification, and add initial support for reusing suitable
+   deltas found in an existing pack file.
+   (Stefan Sperling)
+
  * Fix Repo.reset_index.
    Previously, it instead took the union with the given tree.
    (Christian Sattler, #1072)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -523,12 +523,18 @@ class cmd_ls_tree(Command):
 
 class cmd_pack_objects(Command):
     def run(self, args):
-        opts, args = getopt(args, "", ["stdout"])
+        deltify = False
+        reuse_deltas = True
+        opts, args = getopt(args, "", ["stdout", "deltify", "no-reuse-deltas"])
         opts = dict(opts)
         if len(args) < 1 and "--stdout" not in opts.keys():
             print("Usage: dulwich pack-objects basename")
             sys.exit(1)
         object_ids = [line.strip() for line in sys.stdin.readlines()]
+        if "--deltify" in opts.keys():
+            deltify = True
+        if "--no-reuse-deltas" in opts.keys():
+            reuse_deltas = False
         if "--stdout" in opts.keys():
             packf = getattr(sys.stdout, "buffer", sys.stdout)
             idxf = None
@@ -538,7 +544,13 @@ class cmd_pack_objects(Command):
             packf = open(basename + ".pack", "wb")
             idxf = open(basename + ".idx", "wb")
             close = [packf, idxf]
-        porcelain.pack_objects(".", object_ids, packf, idxf)
+        porcelain.pack_objects(
+            ".",
+            object_ids,
+            packf,
+            idxf,
+            deltify=deltify,
+            reuse_deltas=reuse_deltas)
         for f in close:
             f.close()
 


### PR DESCRIPTION
This feature allows the ``dulwich pack-objects`` command to complete in a somewhat reasonable amount of time on small repositories, provided a pack file which can provide deltas already exists.

Reusing deltas from an existing pack file avoids deltification overhead while creating a new pack file. This optimization is especially important when serving clones and fetches from a server.

For testing purposes, add two options to ``dulwich pack-objects``:
  --deltify: enables deltification and delta-reuse
  --no-reuse-deltas: disables delta-reuse during deltification

The write_pack_objects() now accepts an optional Pack file object argument which enables reuse of deltas.

If deltification is enabled and delta-reuse is not explicitly disabled, the pack_objects() routine in porcelain.py picks a suitable pack file for reuse, which is the pack file which contains the largest amount of objects. A delta found in this pack file can be reused if its delta-base will also be part of the generated pack file.

There are some limitations which should be lifted eventually:

Reused deltas are stored as ref-deltas only. There is no logic yet to figure out where the base of a reused offset-delta has been placed in the new pack file.

We decompress deltas for reuse and compress them again when writing them to the new pack file. More code refactoring would be needed to support direct copying from the source pack file in order to avoid re-compression overhead.