### PR TITLE
refs: optimise writing unchanged refs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,11 @@
 
  * Add ``reflog`` command in porcelain. (Jelmer Vernooĳ)
 
+ * Optimize writing unchanged refs by avoiding unnecessary fsync
+   when ref already has the desired value. File locking behavior
+   is preserved to ensure proper concurrency control.
+   (Dan Villiom Podlaski Christiansen, Jelmer Vernooĳ, #1120)
+
 0.23.2	2025-07-07
 
  * Print deprecations on usage, not import.


### PR DESCRIPTION
This is inspired by [an issue filed in hg-git](https://foss.heptapod.net/mercurial/hg-git/-/issues/401); essentially, writing a _lot_ of unchanged references is quite slow, due to the `fsync()` implied in re-writing the file. Although we could fix this within hg-git, it seems to me that the general optimisation might apply to other users of Dulwich, so this PR makes it so that it avoids acquiring the lock to a ref if that ref already matches the expected update.