### PR TITLE
client: Handle absolute path as redirect location in HTTP client

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1947,7 +1947,7 @@ class AbstractHttpGitClient(GitClient):
                     "Redirected from URL %s to URL %s without %s"
                     % (url, resp.redirect_location, tail)
                 )
-            base_url = resp.redirect_location[: -len(tail)]
+            base_url = urljoin(url, resp.redirect_location[: -len(tail)])
 
         try:
             self.dumb = (


### PR DESCRIPTION
Some git servers can redirect a repository URL using an absolute-path URI reference as value of the `Location` HTTP header as allowed by [RFC 7231 Section 7.1.2](https://www.rfc-editor.org/rfc/rfc7231#section-7.1.2).

```console
$ curl -I https://codeberg.org/ashwinvis/radicale-sh.git
HTTP/2 307 
cache-control: no-store, no-transform
content-type: text/html; charset=utf-8
location: /ashwinvis/radicale-auth-sh
set-cookie: i_like_gitea=7b9a4d2494e520a3; Path=/; HttpOnly; SameSite=Lax; Secure; SameSite=Lax
set-cookie: _csrf=rcOoJeB1NS-JKRoc8ve8til2uVs6MTY3ODc0MDA0NTE0MzgwMzI1MQ; Path=/; Expires=Tue, 14 Mar 2023 20:40:45 GMT; HttpOnly; SameSite=Lax; Secure; SameSite=Lax
set-cookie: macaron_flash=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax; Secure; SameSite=Lax
date: Mon, 13 Mar 2023 20:40:45 GMT
strict-transport-security: max-age=63072000; includeSubDomains; preload
permissions-policy: interest-cohort=()
x-frame-options: sameorigin
x-content-type-options: nosniff
content-security-policy-report-only: default-src data: 'self' https://*.codeberg.org https://codeberg.org; script-src 'self' https://*.codeberg.org https://codeberg.org; style-src data: 'self' 'unsafe-inline' https://*.codeberg.org https://codeberg.org; img-src *; media-src *; object-src 'none'; report-uri https://codeberg.org/.well-known/csp-report

$ git clone https://codeberg.org/ashwinvis/radicale-sh.git
Cloning into 'radicale-sh'...
warning: redirecting to https://codeberg.org/ashwinvis/radicale-auth-sh/
remote: Enumerating objects: 54, done.
remote: Total 54 (delta 0), reused 0 (delta 0), pack-reused 54
Receiving objects: 100% (54/54), 11.06 KiB | 707.00 KiB/s, done.
Resolving deltas: 100% (20/20), done.
```

That edge case was causing `dulwich` to raise `urllib3.exceptions.LocationValueError` when attempting to clone such repository as the redirection URL was missing the scheme and the net location.

```console
$ swh loader run git https://codeberg.org/ashwinvis/radicale-sh.git
WARNING:swh.loader.cli:No storage configuration detected, using an in-memory storage instead.
INFO:swh.loader.git.loader.GitLoader:Load origin 'https://codeberg.org/ashwinvis/radicale-sh.git' with type 'git'
INFO:urllib3.poolmanager:Redirecting https://codeberg.org/ashwinvis/radicale-sh.git/info/refs?service=git-upload-pack -> https://codeberg.org/ashwinvis/radicale-auth-sh/info/refs?service=git-upload-pack
ERROR:swh.loader.git.loader.GitLoader:Loading failure, updating to `failed` status
Traceback (most recent call last):
  File "/home/anlambert/swh/swh-environment/swh-loader-core/swh/loader/core/loader.py", line 417, in load
    more_data_to_fetch = self.fetch_data()
  File "/home/anlambert/swh/swh-environment/swh-loader-git/swh/loader/git/loader.py", line 319, in fetch_data
    fetch_info = self.fetch_pack_from_origin(
  File "/home/anlambert/swh/swh-environment/swh-loader-git/swh/loader/git/loader.py", line 237, in fetch_pack_from_origin
    pack_result = client.fetch_pack(
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 2113, in fetch_pack
    resp, read = self._smart_request(
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 1989, in _smart_request
    resp, read = self._http_request(url, headers, data)
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 2212, in _http_request
    resp = self.pool_manager.request(
  File "/home/anlambert/.virtualenvs/swh/lib/python3.9/site-packages/urllib3/request.py", line 78, in request
    return self.request_encode_body(
  File "/home/anlambert/.virtualenvs/swh/lib/python3.9/site-packages/urllib3/request.py", line 170, in request_encode_body
    return self.urlopen(method, url, **extra_kw)
  File "/home/anlambert/.virtualenvs/swh/lib/python3.9/site-packages/urllib3/poolmanager.py", line 365, in urlopen
    conn = self.connection_from_host(u.host, port=u.port, scheme=u.scheme)
  File "/home/anlambert/.virtualenvs/swh/lib/python3.9/site-packages/urllib3/poolmanager.py", line 237, in connection_from_host
    raise LocationValueError("No host specified.")
urllib3.exceptions.LocationValueError: No host specified.
{'status': 'failed'} for origin 'https://codeberg.org/ashwinvis/radicale-sh.git'
```

Fix the issue by restoring scheme and net location to the redirection URL using those from the original request URL.