### PR TITLE
clone: fix cloning repo with detached head

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -711,17 +711,18 @@ class GitClient:
             if origin_sha and not origin_head:
                 # set detached HEAD
                 target.refs[b"HEAD"] = origin_sha
-
-            _set_origin_head(target.refs, origin.encode('utf-8'), origin_head)
-            head_ref = _set_default_branch(
-                target.refs, origin.encode('utf-8'), origin_head, branch, ref_message
-            )
-
-            # Update target head
-            if head_ref:
-                head = _set_head(target.refs, head_ref, ref_message)
+                head = origin_sha
             else:
-                head = None
+                _set_origin_head(target.refs, origin.encode('utf-8'), origin_head)
+                head_ref = _set_default_branch(
+                    target.refs, origin.encode('utf-8'), origin_head, branch, ref_message
+                )
+
+                # Update target head
+                if head_ref:
+                    head = _set_head(target.refs, head_ref, ref_message)
+                else:
+                    head = None
 
             if checkout and head is not None:
                 target.reset_index()

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1485,17 +1485,17 @@ class Repo(BaseRepo):
             if origin_sha and not origin_head:
                 # set detached HEAD
                 target.refs[b"HEAD"] = origin_sha
-
-            _set_origin_head(target.refs, origin, origin_head)
-            head_ref = _set_default_branch(
-                target.refs, origin, origin_head, branch, ref_message
-            )
-
-            # Update target head
-            if head_ref:
-                head = _set_head(target.refs, head_ref, ref_message)
             else:
-                head = None
+                _set_origin_head(target.refs, origin, origin_head)
+                head_ref = _set_default_branch(
+                    target.refs, origin, origin_head, branch, ref_message
+                )
+
+                # Update target head
+                if head_ref:
+                    head = _set_head(target.refs, head_ref, ref_message)
+                else:
+                    head = None
 
             if checkout and head is not None:
                 target.reset_index()


### PR DESCRIPTION
When cloning a repo with detached head we do not need to do anything w/setting default branches or trying to match the origin's HEAD

This makes dulwich clone consistent with CGit, where cloning a source repo with detached head makes the resulting dest repo also have a detached head (with no default or upstream tracking branches set)

```
$ git clone src-repo dst-repo
Cloning into 'dst-repo'...
done.
Note: switching to 'dbfb510657c332184640b3b1329979194fb3bead'.

You are in 'detached HEAD' state.
...
$ cd dst-repo
$ git status
Not currently on any branch.
nothing to commit, working tree clean
$ cat .git/HEAD
dbfb510657c332184640b3b1329979194fb3bead
$ cat .git/config
[core]
        ...
[remote "origin"]
        url = /Users/pmrowla/git/scratch/test-detached-clone/src-repo
        fetch = +refs/heads/*:refs/remotes/origin/*
```

related: https://github.com/iterative/dvc/issues/9262