### PR TITLE
initialize pack entry count to 0 in pack.PackStreamCopier.verify()

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1059,6 +1059,7 @@ class PackStreamCopier(PackStreamReader):
         See PackStreamReader.iterobjects for a list of exceptions this may
         throw.
         """
+        i = 0  # default count of entries if read_objects() is empty
         for i, unpacked in enumerate(self.read_objects()):
             if self._delta_iter:
                 self._delta_iter.record(unpacked)


### PR DESCRIPTION
I have encountered

```
UnboundLocalError: local variable 'i' referenced before assignment
```

on this line

https://github.com/jelmer/dulwich/blob/df1660cb6e65b4a211b8f5c8f547293ec65664d0/dulwich/pack.py#L1068

in `dulwich==0.21.3`, presumably because this function depends on `self.read_objects()` being non-empty. I encounter this deterministically when I do encounter it, but I don't know the exact conditions to reproduce yet. I think it's related to cache situations when reading from the same repo more than once in the same script, but it seems to only happen for certain files. For context, I am a DVC user and have encountered it with `dvc.api.open()` and also when calling `dvc import` from the CLI.

This PR adds `i = 0` above the for loop, which fixes the bug for me (then when `self.read_objects()` is empty, the for loop doesn't run but `i` is 0 and the progress reports "copied 0 pack entries" which seems reasonable if they were all in some cache and didn't need to be copied).