### PR TITLE
Define a stricter return type for _parse_message

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -651,7 +651,7 @@ class Blob(ShaFile):
         return ret
 
 
-def _parse_message(chunks: Iterable[bytes]) -> Iterator[Tuple[Optional[bytes], Optional[bytes]]]:
+def _parse_message(chunks: Iterable[bytes]) -> Iterator[Union[Tuple[None, None], Tuple[Optional[bytes], bytes]]]:
     """Parse a message with a list of fields and a body.
 
     Args:


### PR DESCRIPTION
If the first item of the tuple is not None, then the second item is guaranteed not to be None either.

This is motivated by Software Heritage calling this function and getting the value for three (non-None) keys:

* https://gitlab.softwareheritage.org/swh/devel/swh-loader-git/-/blob/5cbe435407a14726c3e1c353eeee3681d8a2c2ac/swh/loader/git/converters.py#L189
* https://gitlab.softwareheritage.org/swh/devel/swh-loader-git/-/blob/5cbe435407a14726c3e1c353eeee3681d8a2c2ac/swh/loader/git/converters.py#L279

so mypy complained. Not a big deal though; I can work around it with assertions: https://gitlab.softwareheritage.org/swh/devel/swh-loader-git/-/merge_requests/153/diffs