### PR TITLE
Update docs regarding building dulwich without c bindings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,13 @@ If you don't want to install the C bindings, specify the --pure argument to setu
 
 or if you are installing from pip::
 
-    $ pip install dulwich --global-option="--pure"
+    $ pip install --no-binary dulwich dulwich --config-settings "--build-option=--pure"
 
-Note that you can also specify --global-option in a
-`requirements.txt <https://pip.pypa.io/en/stable/reference/pip_install/#requirement-specifiers>`_
+Note that you can also specify --build-option in a
+`requirements.txt <https://pip.pypa.io/en/stable/reference/requirement-specifiers/>`_
 file, e.g. like this::
 
-    dulwich --global-option=--pure
+    dulwich --config-settings "--build-option=--pure"
 
 Getting started
 ---------------


### PR DESCRIPTION
See: #1093.

Currently, both `--global-option=--pure` and `--build-option=--pure` work (when set in `--config-settings`).  However, using `--global-option` in this way is considered deprecated:

https://setuptools.pypa.io/en/latest/history.html#id139
https://github.com/pypa/setuptools/pull/3380

`--no-binary dulwich` is needed to prevent pip installing the pre-built wheel from pypi.org.

(Unlike when this was discussed in the issue, setting config-settings in requirements.txt now works.)

<hr/>

Thanks again for the very useful python library (and sorry for bothering you about annoying python packaging), but hopefully this will save somebody time in the future.

