### PR TITLE
client: Fix content type check in AbstractHttpGitClient._smart_request

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2007,7 +2007,7 @@ class AbstractHttpGitClient(GitClient):
         if isinstance(data, bytes):
             headers["Content-Length"] = str(len(data))
         resp, read = self._http_request(url, headers, data)
-        if resp.content_type != result_content_type:
+        if not resp.content_type.startswith(result_content_type):
             raise GitProtocolError(
                 "Invalid content-type from server: %s" % resp.content_type
             )


### PR DESCRIPTION
Some git servers can send a `Content-Type` header containing a `charset` directive. 

```shell
$ echo -e "0079want 034350e047bbb1892a917c51f065f2e8125a6bf7 multi_ack multi_ack_detailed ofs-delta shallow side-band-64k thin-pack\n0032want 034350e047bbb1892a917c51f065f2e8125a6bf7\n0032want 67106b8421ca9e5fe77e46766e754e29390abb89\n00000009done\n" | curl -i -X POST --data-binary @- -H "Content-Type: application/x-git-upload-pack-request" https://hacktivis.me/git/blog.git/git-upload-pack
HTTP/2 200 
server: nginx/1.23.3
date: Wed, 05 Jul 2023 10:41:01 GMT
content-type: application/x-git-upload-pack-result; charset=utf-8
expires: Fri, 01 Jan 1980 00:00:00 GMT
pragma: no-cache
cache-control: no-cache, max-age=0, must-revalidate
x-frame-options: sameorigin
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
referrer-policy: no-referrer
strict-transport-security: max-age=63072000; includeSubDomains; preload
content-security-policy: default-src 'none'

Warning: Binary output can mess up your terminal. Use "--output -" to tell 
Warning: curl to output it to your terminal anyway, or consider "--output 
Warning: <FILE>" to save to a file.
```

Official git client can successfully clone repositories hosted on such server but `dulwich`
was raising a `GitProtocolError` as the code to check the header value was not expecting 
a directive to be present in it.

```shell
$ git clone https://hacktivis.me/git/blog.git
Cloning into 'blog'...
remote: Enumerating objects: 6287, done.
remote: Total 6287 (delta 0), reused 0 (delta 0), pack-reused 6287
Receiving objects: 100% (6287/6287), 10.01 MiB | 4.63 MiB/s, done.
Resolving deltas: 100% (4279/4279), done.

$ python
Python 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dulwich.porcelain import clone
>>> clone("https://hacktivis.me/git/blog.git")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/anlambert/dev/dulwich/dulwich/porcelain.py", line 542, in clone
    return client.clone(
           ^^^^^^^^^^^^^
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 735, in clone
    result = self.fetch(path, target, progress=progress, depth=depth)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 813, in fetch
    result = self.fetch_pack(
             ^^^^^^^^^^^^^^^^
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 2133, in fetch_pack
    resp, read = self._smart_request(
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/dev/dulwich/dulwich/client.py", line 2011, in _smart_request
    raise GitProtocolError(
dulwich.errors.GitProtocolError: Invalid content-type from server: application/x-git-upload-pack-result; charset=utf-8
```

The issue was spotted by the [Software Heritage git loader](https://sentry.softwareheritage.org/share/issue/64a2a6d0190043a894f6a404d67b1f90/).