### PR TITLE
config: check both `git/etc` and `git/mingw64/etc` on windows

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -620,9 +620,15 @@ def _find_git_in_win_path():
     for exe in ("git.exe", "git.cmd"):
         for path in os.environ.get("PATH", "").split(";"):
             if os.path.exists(os.path.join(path, exe)):
-                # exe path is .../Git/bin/git.exe or .../Git/cmd/git.exe
+                # in windows native shells (powershell/cmd) exe path is
+                # .../Git/bin/git.exe or .../Git/cmd/git.exe
+                #
+                # in git-bash exe path is .../Git/mingw64/bin/git.exe
                 git_dir, _bin_dir = os.path.split(path)
                 yield git_dir
+                parent_dir, basename = os.path.split(git_dir)
+                if basename == "mingw32" or basename == "mingw64":
+                    yield parent_dir
                 break
 
 


### PR DESCRIPTION
Current windows Git installations include separate git exe's in `Git/cmd/git.exe` and `Git/mingw64/bin/git.exe`. The mingw64 build will be in the PATH when the user is in git-bash, and the native `cmd/git.exe` build will be in the PATH in native windows shells (cmd.exe or powershell).

The system level gitconfig that gets used by either `git.exe` is located in `Git/etc/gitconfig`, but the existing windows gitconfig lookup behavior only searches `Git/mingw64/etc/gitconfig`