### PR TITLE
More refactoring of index

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -82,8 +82,8 @@ class Stage(Enum):
 @dataclass
 class SerializedIndexEntry:
     name: bytes
-    ctime: int | float | Tuple[int, int]
-    mtime: int | float | Tuple[int, int]
+    ctime: Union[int, float, Tuple[int, int]]
+    mtime: Union[int, float, Tuple[int, int]]
     dev: int
     ino: int
     mode: int
@@ -100,8 +100,8 @@ class SerializedIndexEntry:
 
 @dataclass
 class IndexEntry:
-    ctime: int | float | Tuple[int, int]
-    mtime: int | float | Tuple[int, int]
+    ctime: Union[int, float, Tuple[int, int]]
+    mtime: Union[int, float, Tuple[int, int]]
     dev: int
     ino: int
     mode: int
@@ -312,14 +312,14 @@ def read_index(f: BinaryIO) -> Iterator[SerializedIndexEntry]:
         yield read_cache_entry(f, version)
 
 
-def read_index_dict(f) -> Dict[bytes, IndexEntry | ConflictedIndexEntry]:
+def read_index_dict(f) -> Dict[bytes, Union[IndexEntry, ConflictedIndexEntry]]:
     """Read an index file and return it as a dictionary.
        Dict Key is tuple of path and stage number, as
             path alone is not unique
     Args:
       f: File object to read fromls.
     """
-    ret: Dict[bytes, IndexEntry | ConflictedIndexEntry] = {}
+    ret: Dict[bytes, Union[IndexEntry, ConflictedIndexEntry]] = {}
     for entry in read_index(f):
         stage = entry.stage()
         if stage == Stage.NORMAL:
@@ -355,7 +355,7 @@ def write_index(f: BinaryIO, entries: List[SerializedIndexEntry], version: Optio
 
 def write_index_dict(
     f: BinaryIO,
-    entries: Dict[bytes, IndexEntry | ConflictedIndexEntry],
+    entries: Dict[bytes, Union[IndexEntry, ConflictedIndexEntry]],
     version: Optional[int] = None,
 ) -> None:
     """Write an index file based on the contents of a dictionary.
@@ -402,7 +402,7 @@ def cleanup_mode(mode: int) -> int:
 class Index:
     """A Git Index file."""
 
-    _byname: Dict[bytes, IndexEntry | ConflictedIndexEntry]
+    _byname: Dict[bytes, Union[IndexEntry, ConflictedIndexEntry]]
 
     def __init__(self, filename: Union[bytes, str], read=True) -> None:
         """Create an index object associated with the given filename.
@@ -452,7 +452,7 @@ class Index:
         """Number of entries in this index file."""
         return len(self._byname)
 
-    def __getitem__(self, key: bytes) -> IndexEntry | ConflictedIndexEntry:
+    def __getitem__(self, key: bytes) -> Union[IndexEntry, ConflictedIndexEntry]:
         """Retrieve entry by relative path and stage.
 
         Returns: tuple with (ctime, mtime, dev, ino, mode, uid, gid, size, sha,
@@ -499,20 +499,20 @@ class Index:
         """Remove all contents from this index."""
         self._byname = {}
 
-    def __setitem__(self, name: bytes, value: IndexEntry | ConflictedIndexEntry) -> None:
+    def __setitem__(self, name: bytes, value: Union[IndexEntry, ConflictedIndexEntry]) -> None:
         assert isinstance(name, bytes)
         self._byname[name] = value
 
     def __delitem__(self, name: bytes) -> None:
         del self._byname[name]
 
-    def iteritems(self) -> Iterator[Tuple[bytes, IndexEntry | ConflictedIndexEntry]]:
+    def iteritems(self) -> Iterator[Tuple[bytes, Union[IndexEntry, ConflictedIndexEntry]]]:
         return iter(self._byname.items())
 
-    def items(self) -> Iterator[Tuple[bytes, IndexEntry | ConflictedIndexEntry]]:
+    def items(self) -> Iterator[Tuple[bytes, Union[IndexEntry, ConflictedIndexEntry]]]:
         return iter(self._byname.items())
 
-    def update(self, entries: Dict[bytes, IndexEntry | ConflictedIndexEntry]):
+    def update(self, entries: Dict[bytes, Union[IndexEntry, ConflictedIndexEntry]]):
         for key, value in entries.items():
             self[key] = value
 

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -20,7 +20,7 @@
 
 """Parser for the git index file format."""
 
-import collections
+from dataclasses import dataclass
 import os
 import stat
 import struct
@@ -52,23 +52,19 @@ from .objects import (
 )
 from .pack import ObjectContainer, SHA1Reader, SHA1Writer
 
-# TODO(jelmer): Switch to dataclass?
-IndexEntry = collections.namedtuple(
-    "IndexEntry",
-    [
-        "ctime",
-        "mtime",
-        "dev",
-        "ino",
-        "mode",
-        "uid",
-        "gid",
-        "size",
-        "sha",
-        "flags",
-        "extended_flags",
-    ],
-)
+@dataclass
+class IndexEntry:
+    ctime: int | float | Tuple[int, int]
+    mtime: int | float | Tuple[int, int]
+    dev: int
+    ino: int
+    mode: int
+    uid: int
+    gid: int
+    size: int
+    sha: bytes
+    flags: int
+    extended_flags: int
 
 
 class ConflictedIndexEntry:

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1970,7 +1970,7 @@ def checkout_branch(repo, target: Union[bytes, str], force: bool = False):
             blob = repo.object_store[entry.sha]
             ensure_dir_exists(os.path.dirname(full_path))
             st = build_file_from_blob(blob, entry.mode, full_path)
-            repo_index[entry.path] = index_entry_from_stat(st, entry.sha, 0)
+            repo_index[entry.path] = index_entry_from_stat(st, entry.sha)
 
         repo_index.write()
 

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1422,7 +1422,7 @@ class Repo(BaseRepo):
                     blob = blob_from_path_and_stat(full_path, st)
                     blob = blob_normalizer.checkin_normalize(blob, fs_path)
                     self.object_store.add_object(blob)
-                    index[tree_path] = index_entry_from_stat(st, blob.id, 0)
+                    index[tree_path] = index_entry_from_stat(st, blob.id)
         index.write()
 
     def unstage(self, fs_paths: List[str]):
@@ -1478,8 +1478,6 @@ class Repo(BaseRepo):
                 gid=st.st_gid if st else 0,
                 size=len(self[tree_entry[1]].data),
                 sha=tree_entry[1],
-                flags=0,
-                extended_flags=0
             )
 
             index[tree_path] = index_entry

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -43,7 +43,6 @@ from ..index import (
     get_unstaged_changes,
     index_entry_from_stat,
     read_index,
-    read_index_dict,
     validate_path_element_default,
     validate_path_element_ntfs,
     write_cache_time,
@@ -156,39 +155,6 @@ class SimpleIndexWriterTestCase(IndexTestCase):
 
         with open(filename, "rb") as x:
             self.assertEqual(entries, list(read_index(x)))
-
-
-class ReadIndexDictTests(IndexTestCase):
-    def setUp(self):
-        IndexTestCase.setUp(self)
-        self.tempdir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        IndexTestCase.tearDown(self)
-        shutil.rmtree(self.tempdir)
-
-    def test_simple_write(self):
-        entries = {
-            (b"barbla", Stage.NORMAL): IndexEntry(
-                (1230680220, 0),
-                (1230680220, 0),
-                2050,
-                3761020,
-                33188,
-                1000,
-                1000,
-                0,
-                b"e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                0,
-                0,
-            )
-        }
-        filename = os.path.join(self.tempdir, "test-simple-write-index")
-        with open(filename, "wb+") as x:
-            write_index_dict(x, entries)
-
-        with open(filename, "rb") as x:
-            self.assertEqual(entries, read_index_dict(x))
 
 
 class CommitTreeTests(TestCase):

--- a/dulwich/tests/test_index.py
+++ b/dulwich/tests/test_index.py
@@ -92,7 +92,7 @@ class SimpleIndexTestCase(IndexTestCase):
 
     def test_getitem(self):
         self.assertEqual(
-            (
+            IndexEntry(
                 (1230680220, 0),
                 (1230680220, 0),
                 2050,
@@ -298,9 +298,9 @@ class IndexEntryFromStatTests(TestCase):
 
 class BuildIndexTests(TestCase):
     def assertReasonableIndexEntry(self, index_entry, mode, filesize, sha):
-        self.assertEqual(index_entry[4], mode)  # mode
-        self.assertEqual(index_entry[7], filesize)  # filesize
-        self.assertEqual(index_entry[8], sha)  # sha
+        self.assertEqual(index_entry.mode, mode)  # mode
+        self.assertEqual(index_entry.size, filesize)  # filesize
+        self.assertEqual(index_entry.sha, sha)  # sha
 
     def assertFileContents(self, path, contents, symlink=False):
         if symlink:
@@ -573,8 +573,8 @@ class BuildIndexTests(TestCase):
             # dir c
             cpath = os.path.join(repo.path, "c")
             self.assertTrue(os.path.isdir(cpath))
-            self.assertEqual(index[b"c"][4], S_IFGITLINK)  # mode
-            self.assertEqual(index[b"c"][8], c.id)  # sha
+            self.assertEqual(index[b"c"].mode, S_IFGITLINK)  # mode
+            self.assertEqual(index[b"c"].sha, c.id)  # sha
 
     def test_git_submodule_exists(self):
         repo_dir = tempfile.mkdtemp()
@@ -614,8 +614,8 @@ class BuildIndexTests(TestCase):
             # dir c
             cpath = os.path.join(repo.path, "c")
             self.assertTrue(os.path.isdir(cpath))
-            self.assertEqual(index[b"c"][4], S_IFGITLINK)  # mode
-            self.assertEqual(index[b"c"][8], c.id)  # sha
+            self.assertEqual(index[b"c"].mode, S_IFGITLINK)  # mode
+            self.assertEqual(index[b"c"].sha, c.id)  # sha
 
 
 class GetUnstagedChangesTests(TestCase):


### PR DESCRIPTION
More refactoring of index

- Split out SerializedIndexEntry
- Add a ConflictedIndexEntry class that holds references to {ancestor, this, other} entries
