### PR TITLE
Raise GitProtocolError on unexpected pkt

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -413,7 +413,10 @@ def _read_shallow_updates(pkt_seq):
     new_shallow = set()
     new_unshallow = set()
     for pkt in pkt_seq:
-        cmd, sha = pkt.split(b" ", 1)
+        try:
+            cmd, sha = pkt.split(b" ", 1)
+        except ValueError:
+            raise GitProtocolError("unknown command %s" % pkt)
         if cmd == COMMAND_SHALLOW:
             new_shallow.add(sha.strip())
         elif cmd == COMMAND_UNSHALLOW:


### PR DESCRIPTION
There are some packets (like NAK) which have no sha. This does not change them to be handled but you get in exception always the command that failed to be unpacked instead of strange exception about there not being enough values to unpack.