### PR TITLE
Clarify that Index.__getitem__ returns a Index or ConflictedIndexEntry

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -455,8 +455,8 @@ class Index:
     def __getitem__(self, key: bytes) -> Union[IndexEntry, ConflictedIndexEntry]:
         """Retrieve entry by relative path and stage.
 
-        Returns: tuple with (ctime, mtime, dev, ino, mode, uid, gid, size, sha,
-            flags)
+        Returns: Either a IndexEntry or a ConflictedIndexEntry
+        Raises KeyError: if the entry does not exist
         """
         return self._byname[key]
 


### PR DESCRIPTION
Clarify that Index.__getitem__ returns a Index or ConflictedIndexEntry

Fixes #1205
