### PR TITLE
_pack: Fix some big left-shifts of unsigned char 

### DIFF
--- a/dulwich/_pack.c
+++ b/dulwich/_pack.c
@@ -41,7 +41,7 @@ static size_t get_delta_header_size(uint8_t *delta, size_t *index, size_t length
 	size_t size = 0;
 	size_t i = 0;
 	while ((*index) < length) {
-		uint8_t cmd = delta[*index];
+		size_t cmd = delta[*index];
 		(*index)++;
 		size |= (cmd & ~0x80) << i;
 		i += 7;
@@ -130,14 +130,14 @@ static PyObject *py_apply_delta(PyObject *self, PyObject *args)
 			int i;
 			for (i = 0; i < 4; i++) {
 				if (cmd & (1 << i)) {
-					uint8_t x = delta[index];
+					unsigned x = delta[index];
 					index++;
 					cp_off |= x << (i * 8);
 				}
 			}
 			for (i = 0; i < 3; i++) {
 				if (cmd & (1 << (4+i))) {
-					uint8_t x = delta[index];
+					unsigned x = delta[index];
 					index++;
 					cp_size |= x << (i * 8);
 				}


### PR DESCRIPTION
The git loader used by Software Heritage recently reported the following error while processing the following repository: https://github.com/BlockSocUNSW/Blocksoc_Net.

```
ApplyDeltaError: Unexpected source buffer size: 18446744072185159680 vs 2770575360
  File "swh/loader/core/loader.py", line 441, in load
    self.store_data()
  File "swh/loader/git/base.py", line 80, in store_data
    for obj in self.get_contents():
  File "swh/loader/git/loader.py", line 505, in get_contents
    for raw_obj in self.iter_objects(b"blob"):
  File "swh/loader/git/loader.py", line 490, in iter_objects
    for obj in PackInflater.for_pack_data(
  File "dulwich/pack.py", line 1440, in _walk_all_chains
    yield from self._follow_chain(offset, type_num, None)
  File "dulwich/pack.py", line 1495, in _follow_chain
    unpacked = self._resolve_object(offset, obj_type_num, base_chunks)
  File "dulwich/pack.py", line 1486, in _resolve_object
    unpacked.obj_chunks = apply_delta(base_chunks, unpacked.decomp_chunks)
```
This is really an edge case as it is the first time we observed that issue.

The error is raised by the C implementation of `apply_delta` function that can be found in the `_pack.c` file.

Nevertheless, official git client can successfully clone the repository as well as dulwich when using the Python implementation of the `apply_delta` function.

```
$ git clone https://github.com/BlockSocUNSW/Blocksoc_Net
Cloning into 'Blocksoc_Net'...
remote: Enumerating objects: 40832, done.
remote: Total 40832 (delta 0), reused 0 (delta 0), pack-reused 40832
Receiving objects: 100% (40832/40832), 3.20 GiB | 3.51 MiB/s, done.
Resolving deltas: 100% (15014/15014), done.
Updating files: 100% (12197/12197), done.
```

Looking at the `ApplyDeltaError` exception message this made me think to a kind-of integer overflow issue. I compared the C implementation used by git to process deltas against the one in dulwich and noticed git was doing some integer computations using `unsigned` or `unsigned long` types while dulwich is using `unsigned char` instead (see [delta.h](https://github.com/git/git/blob/d0e8084c65cbf949038ae4cc344ac2c2efd77415/delta.h#L93-L99) and [patch-delta.c](https://github.com/git/git/blob/d0e8084c65cbf949038ae4cc344ac2c2efd77415/patch-delta.c#L47) from git source tree and this [commit](https://github.com/git/git/commit/48fb7deb5bbd87933e7d314b73d7c1b52667f80f) fixing the same issue in git).

Aligning dulwich C implementation of `apply_delta` with the git one effectively fixes the issue.

```
$ python
Python 3.11.2 (main, Mar 13 2023, 12:18:29) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from dulwich.porcelain import clone
>>> clone("https://github.com/BlockSocUNSW/Blocksoc_Net")
Enumerating objects: 40832, done.
Total 40832 (delta 0), reused 0 (delta 0), pack-reused 40832
generating index: 40832/40832
<Repo at 'Blocksoc_Net'>
>>> 
```

I do not really know how to write a test for this though.