### PR TITLE
Remove shebang from cli.py

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python3 -u
 #
 # dulwich - Simple command-line interface to Dulwich
 # Copyright (C) 2008-2011 Jelmer Vernooij <jelmer@jelmer.uk>


### PR DESCRIPTION
The shebang is useless in the `cli.py` file:
```
$ PYTHONPATH=. dulwich/cli.py 
Traceback (most recent call last):
  File "/tmp/dulwich/dulwich/cli.py", line 41, in <module>
    from .client import GitProtocolError, get_transport_and_path
ImportError: attempted relative import with no known parent package
$
```
So let's remove it.