### PR TITLE
publish sdist from github

### DIFF
--- a/.github/workflows/python-distributions.yml
+++ b/.github/workflows/python-distributions.yml
@@ -1,4 +1,4 @@
-name: Build Python Wheels
+name: Build Python distributions
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
     - cron: "0 6 * * *" # Daily 6AM UTC build
 
 jobs:
-  build:
+  build-wheels:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -45,22 +45,36 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
 
-  publish:
+  build-sdist:
     runs-on: ubuntu-latest
-
-    needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dulwich-')
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
-
-      - name: Install twine
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install twine
-      - name: Download wheels
+          pip install build
+      - name: Build sdist
+        run: python -m build --sdist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v3
+        with:
+          path: ./dist/*.tar.gz
+
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - build-wheels
+      - build-sdist
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dulwich-')
+    steps:
+      - name: Download distributions
         uses: actions/download-artifact@v2
-      - name: Publish wheels
+        with:
+          name: artifact
+          path: dist
+      - name: Publish distributions
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: twine upload artifact/*.whl
+        run: twine upload dist/*


### PR DESCRIPTION
cf #975

Comments:
- for obvious reasons, it's hard for me to test this end-to-end
- the build process here respects your `MANIFEST.IN` in a way that whatever you are currently doing seems not to
  - the most conspicuous difference is the omission of `testdata`, maybe you want to add `graft testdata`

