### PR TITLE
Remove shebang from graph.py

### DIFF
--- a/dulwich/graph.py
+++ b/dulwich/graph.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # vim:ts=4:sw=4:softtabstop=4:smarttab:expandtab
 # Copyright (c) 2020 Kevin B. Hendricks, Stratford Ontario Canada
 #


### PR DESCRIPTION
The shebang is useless in the `graph.py` file:
```
$ chmod +x dulwich/graph.py
$ PYTHONPATH=. dulwich/graph.py
Traceback (most recent call last):
  File "/tmp/dulwich/dulwich/graph.py", line 25, in <module>
    from .lru_cache import LRUCache
ImportError: attempted relative import with no known parent package
$
```
So let's remove it.

See also #1230.