### PR TITLE
Disable pypi uploads in disperse; this is now down by the GitHub actions workflow

### DIFF
--- a/disperse.conf
+++ b/disperse.conf
@@ -10,3 +10,5 @@ update_version {
 }
 # Dulwich' CI builds wheels, which is really slow
 ci_timeout: 7200
+# We have a GitHub action that uploads to PyPI, so we don't need to do it here.
+skip_twine_upload: true


### PR DESCRIPTION
Disable pypi uploads in disperse; this is now down by the GitHub actions workflow
