### PR TITLE
tweak doc-strings in LocalGitClient for clarity

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1403,7 +1403,7 @@ class SubprocessGitClient(TraditionalGitClient):
 
 
 class LocalGitClient(GitClient):
-    """Git Client that just uses a local Repo."""
+    """Git Client that just uses a local on-disk repository."""
 
     def __init__(
         self, thin_packs=True, report_activity=None, config: Optional[Config] = None
@@ -1432,7 +1432,7 @@ class LocalGitClient(GitClient):
         return closing(Repo(path))
 
     def send_pack(self, path, update_refs, generate_pack_data, progress=None):
-        """Upload a pack to a remote repository.
+        """Upload a pack to a local on-disk repository.
 
         Args:
           path: Repository path (as bytestring)
@@ -1525,7 +1525,7 @@ class LocalGitClient(GitClient):
         progress=None,
         depth=None,
     ) -> FetchPackResult:
-        """Retrieve a pack from a git smart server.
+        """Retrieve a pack from a local on-disk repository.
 
         Args:
           path: Remote path to fetch from
@@ -1560,7 +1560,7 @@ class LocalGitClient(GitClient):
             return FetchPackResult(r.get_refs(), symrefs, agent)
 
     def get_refs(self, path):
-        """Retrieve the current refs from a git smart server."""
+        """Retrieve the current refs from a local on-disk repository."""
         with self._open_repo(path) as target:
             return target.get_refs()
 


### PR DESCRIPTION
Some doc-strings were talking about smart Git servers which do not come into the picture when the transfer protocol is just local disk access.