### PR TITLE
Update pyproject.toml - urllib3>=1.25,<=2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "urllib3>=1.25",
+    "urllib3>=1.25,<=2.1.0",
     'typing_extensions;python_version<="3.7"',
 ]
 dynamic = ["version"]


### PR DESCRIPTION
restrict 2.2.0 urllib3 for mypy errors during gh-actions

[2.2.0 was released](https://github.com/urllib3/urllib3/releases/tag/2.2.0) 3 days ago and I think that's the cause of the failed builds

Apologies if I missed something during this drive-by PR, I was evaluating Dulwich and saw the build errors, and wanted to know why it was failing and I think this is the root cause.