### PR TITLE
Handle alternate case for worktreeconfig setting

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1191,7 +1191,7 @@ class Repo(BaseRepo):
             raise UnsupportedVersion(format_version)
 
         for extension, _value in config.items((b"extensions",)):
-            if extension not in (b"worktreeconfig",):
+            if extension.lower() not in (b"worktreeconfig",):
                 raise UnsupportedExtension(extension)
 
         if object_store is None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1143,7 +1143,7 @@ class BuildRepoRootTests(TestCase):
         self.assertEqual(cs.get(("user",), "name"), b"Jelmer")
 
     def test_worktreeconfig_extension_case(self):
-        """Test that worktree code does not error for alternate case format"""
+        """Test that worktree code does not error for alternate case format."""
         r = self._repo
         c = r.get_config()
         c.set(("core",), "repositoryformatversion", "1")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1142,6 +1142,22 @@ class BuildRepoRootTests(TestCase):
         cs = r.get_config_stack()
         self.assertEqual(cs.get(("user",), "name"), b"Jelmer")
 
+    def test_worktreeconfig_extension_case(self):
+        """Test that worktree code does not error for alternate case format"""
+        r = self._repo
+        c = r.get_config()
+        c.set(("core",), "repositoryformatversion", "1")
+        # Capitalize "Config"
+        c.set(("extensions",), "worktreeConfig", True)
+        c.write_to_path()
+        c = r.get_worktree_config()
+        c.set(("user",), "repositoryformatversion", "1")
+        c.set((b"user",), b"name", b"Jelmer")
+        c.write_to_path()
+        # The following line errored before
+        # https://github.com/jelmer/dulwich/issues/1285 was addressed
+        Repo(self._repo_dir)
+
     def test_repositoryformatversion_1_extension(self):
         r = self._repo
         c = r.get_config()


### PR DESCRIPTION
`extensions.worktreeconfig` was checked in a way that was not case-insensitive, but git config settings should be case insensitive. This behavior led to problems since the documentation describes the setting as `worktreeConfig` and GitHub Actions started setting the option with this casing.

Fixes https://github.com/jelmer/dulwich/issues/1285