### PR TITLE
Lowercase `CaseInsensitiveOrderedMultiDict.items()` keys

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -89,7 +89,7 @@ class CaseInsensitiveOrderedMultiDict(MutableMapping):
         return self._keyed.keys()
 
     def items(self):
-        return iter(self._real)
+        return ((lower_key(name), value) for name, value in self._real)
 
     def __iter__(self):
         return self._keyed.__iter__()

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1142,6 +1142,22 @@ class BuildRepoRootTests(TestCase):
         cs = r.get_config_stack()
         self.assertEqual(cs.get(("user",), "name"), b"Jelmer")
 
+def test_worktreeconfig_extension_case(self):
+        """Test that worktree code does not error for alternate case format."""
+        r = self._repo
+        c = r.get_config()
+        c.set(("core",), "repositoryformatversion", "1")
+        # Capitalize "Config"
+        c.set(("extensions",), "worktreeConfig", True)
+        c.write_to_path()
+        c = r.get_worktree_config()
+        c.set(("user",), "repositoryformatversion", "1")
+        c.set((b"user",), b"name", b"Jelmer")
+        c.write_to_path()
+        # The following line errored before
+        # https://github.com/jelmer/dulwich/issues/1285 was addressed
+        Repo(self._repo_dir)
+
     def test_repositoryformatversion_1_extension(self):
         r = self._repo
         c = r.get_config()


### PR DESCRIPTION
> _The variable names are case-insensitive._ [...] _Section names are case-insensitive._ ([Git documentation](https://www.git-scm.com/docs/git-config/2.14.6#_configuration_file))

Could close https://github.com/jelmer/dulwich/issues/1285.