### PR TITLE
Make `CaseInsensitiveOrderedMultiDict.items()` keys case insensitive

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -59,6 +59,21 @@ def lower_key(key):
     return key
 
 
+def case_insensitive_key(key):
+    if isinstance(key, (bytes, str)):
+        class CaseInsensitiveNameLike(type(key)):
+            def __eq__(self, other: object) -> bool:
+                return self.lower() == other.lower()
+            def __hash__(self) -> int:
+                return hash(self.lower())
+        return CaseInsensitiveNameLike(key)
+
+    if isinstance(key, Iterable):
+        return type(key)(map(case_insensitive_key, key))  # type: ignore
+
+    return key
+
+
 class CaseInsensitiveOrderedMultiDict(MutableMapping):
     def __init__(self) -> None:
         self._real: List[Any] = []
@@ -89,7 +104,7 @@ class CaseInsensitiveOrderedMultiDict(MutableMapping):
         return self._keyed.keys()
 
     def items(self):
-        return iter(self._real)
+        return ((case_insensitive_key(key), value) for key, value in self._real)
 
     def __iter__(self):
         return self._keyed.__iter__()

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -63,9 +63,9 @@ def case_insensitive_key(key):
     if isinstance(key, (bytes, str)):
         class CaseInsensitiveNameLike(type(key)):
             def __eq__(self, other: object) -> bool:
-                return self.lower() == other.lower()
+                return lower_key(self) == lower_key(other)
             def __hash__(self) -> int:
-                return hash(self.lower())
+                return hash(lower_key(self))
         return CaseInsensitiveNameLike(key)
 
     if isinstance(key, Iterable):

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1191,7 +1191,7 @@ class Repo(BaseRepo):
             raise UnsupportedVersion(format_version)
 
         for extension, _value in config.items((b"extensions",)):
-            if extension.lower() not in (b"worktreeconfig",):
+            if extension not in (b"worktreeconfig",):
                 raise UnsupportedExtension(extension)
 
         if object_store is None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1142,6 +1142,22 @@ class BuildRepoRootTests(TestCase):
         cs = r.get_config_stack()
         self.assertEqual(cs.get(("user",), "name"), b"Jelmer")
 
+def test_worktreeconfig_extension_case(self):
+        """Test that worktree code does not error for alternate case format."""
+        r = self._repo
+        c = r.get_config()
+        c.set(("core",), "repositoryformatversion", "1")
+        # Capitalize "Config"
+        c.set(("extensions",), "worktreeConfig", True)
+        c.write_to_path()
+        c = r.get_worktree_config()
+        c.set(("user",), "repositoryformatversion", "1")
+        c.set((b"user",), b"name", b"Jelmer")
+        c.write_to_path()
+        # The following line errored before
+        # https://github.com/jelmer/dulwich/issues/1285 was addressed
+        Repo(self._repo_dir)
+
     def test_repositoryformatversion_1_extension(self):
         r = self._repo
         c = r.get_config()


### PR DESCRIPTION
Variant of https://github.com/jelmer/dulwich/issues/1288 addressing https://github.com/jelmer/dulwich/pull/1288#pullrequestreview-2016417146.

Could close #1285.