### PR TITLE
client: Fix NameError 'urllib3' is not defined

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2229,10 +2229,12 @@ class AbstractHttpGitClient(GitClient):
 
 
 def _wrap_urllib3_exceptions(func):
+    from urllib3.exceptions import ProtocolError
+
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except urllib3.exceptions.ProtocolError as error:
+        except ProtocolError as error:
             raise GitProtocolError(str(error)) from error
 
     return wrapper


### PR DESCRIPTION
Fix regression introduced in a5cc324 and add test to cover the `urllib3.exceptions.ProtocolError` wrapping.