### PR TITLE
Reformat Source Code & Add `ruff format --check` to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON = python3
-RUFF ?= $(PYTHON) -m ruff 
+RUFF ?= $(PYTHON) -m ruff
 SETUP = $(PYTHON) setup.py
 TESTRUNNER ?= unittest
 RUNTEST = PYTHONHASHSEED=random PYTHONPATH=$(shell pwd)$(if $(PYTHONPATH),:$(PYTHONPATH),) $(PYTHON) -m $(TESTRUNNER) $(TEST_OPTIONS)
@@ -53,6 +53,7 @@ clean::
 
 style:
 	$(RUFF) check .
+	$(RUFF) format --check .
 
 coverage:
 	$(COVERAGE) run -m unittest tests.test_suite dulwich.contrib.test_suite

--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,10 @@ apidocs:
 	pydoctor --intersphinx http://urllib3.readthedocs.org/en/latest/objects.inv --intersphinx http://docs.python.org/3/objects.inv --docformat=google dulwich --project-url=https://www.dulwich.io/ --project-name=dulwich
 
 fix:
-	ruff check --fix .
+	$(RUFF) check --fix .
 
 reformat:
-	ruff format .
+	$(RUFF) format .
 
 .PHONY: codespell
 

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -175,12 +175,12 @@ class Config:
         raise NotImplementedError(self.get_multivar)
 
     @overload
-    def get_boolean(
-        self, section: SectionLike, name: NameLike, default: bool
-    ) -> bool: ...
+    def get_boolean(self, section: SectionLike, name: NameLike, default: bool) -> bool:
+        ...
 
     @overload
-    def get_boolean(self, section: SectionLike, name: NameLike) -> Optional[bool]: ...
+    def get_boolean(self, section: SectionLike, name: NameLike) -> Optional[bool]:
+        ...
 
     def get_boolean(
         self, section: SectionLike, name: NameLike, default: Optional[bool] = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -772,9 +772,9 @@ class SSHGitClientTests(TestCase):
         )
 
     def test_alternative_command_path_spaces(self):
-        self.client.alternative_paths[b"upload-pack"] = (
-            b"/usr/lib/git/git-upload-pack -ibla"
-        )
+        self.client.alternative_paths[
+            b"upload-pack"
+        ] = b"/usr/lib/git/git-upload-pack -ibla"
         self.assertEqual(
             b"/usr/lib/git/git-upload-pack -ibla",
             self.client._get_cmd_path(b"upload-pack"),

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -316,9 +316,9 @@ class RefsContainerTests:
         self.assertNotIn(b"refs/tags/refs-0.2", self._refs)
 
     def test_import_refs_name(self):
-        self._refs[b"refs/remotes/origin/other"] = (
-            b"48d01bd4b77fed026b154d16493e5deab78f02ec"
-        )
+        self._refs[
+            b"refs/remotes/origin/other"
+        ] = b"48d01bd4b77fed026b154d16493e5deab78f02ec"
         self._refs.import_refs(
             b"refs/remotes/origin",
             {b"master": b"42d06bd4b77fed026b154d16493e5deab78f02ec"},
@@ -333,9 +333,9 @@ class RefsContainerTests:
         )
 
     def test_import_refs_name_prune(self):
-        self._refs[b"refs/remotes/origin/other"] = (
-            b"48d01bd4b77fed026b154d16493e5deab78f02ec"
-        )
+        self._refs[
+            b"refs/remotes/origin/other"
+        ] = b"48d01bd4b77fed026b154d16493e5deab78f02ec"
         self._refs.import_refs(
             b"refs/remotes/origin",
             {b"master": b"42d06bd4b77fed026b154d16493e5deab78f02ec"},


### PR DESCRIPTION
This is a follow-up to PR #1312 which missed a few files. This PR:

- Reformats the remaining unformatted files with `ruff format`.
- Adds `ruff format --check .` to code style check in the Makefile.
- Updates the `fix` and `reformat` Makefile targets to use `$(RUFF)` instead of `ruff` directly, making it consistent with the `style` make target, and the other targets in
the Makefile.