### PR TITLE
detect and reject ref-deltas which use an object as its own delta base

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2655,6 +2655,8 @@ class Pack:
                 assert isinstance(basename, bytes) and len(basename) == 20
                 base_offset, base_type, base_obj = get_ref(basename)
                 assert isinstance(base_type, int)
+                if base_offset == prev_offset:  # object is based on itself
+                    raise UnresolvedDeltas(sha_to_hex(basename))
             delta_stack.append((prev_offset, base_type, delta))
 
         # Now grab the base object (mustn't be a delta) and apply the


### PR DESCRIPTION
Dulwich could be driven into an infinite loop by creating a pack file which contains a ref-delta that refers to the deltified object itself as the delta's base, indexing this pack file as a thin-pack, and then trying to access the packed object.

Fix this problem and add a test case which triggers the issue if the fix is reverted (caution: the test will loop forever).

Found via a bug in the Software Heritage Git Loader test suite which created such a pack file:
https://gitlab.softwareheritage.org/swh/devel/swh-loader-git/-/merge_requests/184/