### PR TITLE
dulwich does not depend on setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "urllib3>=1.25",
-    'setuptools ; python_version >= "3.12"',
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
the build depends on setuptools: but it also depends on setuptools-rust - and those things are correctly declared as build requirements in pyproject.toml