### PR TITLE
Add ObjectStore.iter_prefix

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,8 @@
  * Fix handling of symrefs with protocol v2.
    (Jelmer Vernooĳ, #1389)
 
+ * Add ``ObjectStore.iter_prefix``.  (Jelmer Vernooĳ)
+
 0.22.3	2024-10-15
 
  * Improve wheel building in CI, so we can upload wheels for the next release.

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -22,6 +22,7 @@
 
 """Git object store interfaces and implementation."""
 
+import binascii
 import os
 import stat
 import sys
@@ -357,6 +358,17 @@ class BaseObjectStore:
     def close(self):
         """Close any files opened by this object store."""
         # Default implementation is a NO-OP
+
+    def iter_prefix(self, prefix: bytes) -> Iterator[ObjectID]:
+        """Iterate over all SHA1s that start with a given prefix.
+
+        The default implementation is a naive iteration over all objects.
+        However, subclasses may override this method with more efficient
+        implementations.
+        """
+        for sha in self:
+            if sha.startswith(prefix):
+                yield sha
 
 
 class PackBasedObjectStore(BaseObjectStore):
@@ -1026,6 +1038,32 @@ class DiskObjectStore(PackBasedObjectStore):
         os.mkdir(os.path.join(path, "info"))
         os.mkdir(os.path.join(path, PACKDIR))
         return cls(path)
+
+    def iter_prefix(self, prefix):
+        if len(prefix) < 2:
+            return super().iter_prefix(prefix)
+        seen = set()
+        dir = prefix[:2].decode()
+        rest = prefix[2:].decode()
+        for name in os.listdir(os.path.join(self.path, dir)):
+            if name.startswith(rest):
+                sha = os.fsencode(dir + name)
+                if sha not in seen:
+                    seen.add(sha)
+                    yield sha
+
+        for p in self.packs:
+            bin_prefix = binascii.unhexlify(prefix) if len(prefix) % 2 == 0 else binascii.unhexlify(prefix[:-1])
+            for sha in p.index.iter_prefix(bin_prefix):
+                sha = sha_to_hex(sha)
+                if sha.startswith(prefix) and sha not in seen:
+                    seen.add(sha)
+                    yield sha
+        for alternate in self.alternates:
+            for sha in alternate.iter_prefix(prefix):
+                if sha not in seen:
+                    seen.add(sha)
+                    yield sha
 
 
 class MemoryObjectStore(BaseObjectStore):

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -1041,7 +1041,8 @@ class DiskObjectStore(PackBasedObjectStore):
 
     def iter_prefix(self, prefix):
         if len(prefix) < 2:
-            return super().iter_prefix(prefix)
+            yield from super().iter_prefix(prefix)
+            return
         seen = set()
         dir = prefix[:2].decode()
         rest = prefix[2:].decode()
@@ -1053,7 +1054,11 @@ class DiskObjectStore(PackBasedObjectStore):
                     yield sha
 
         for p in self.packs:
-            bin_prefix = binascii.unhexlify(prefix) if len(prefix) % 2 == 0 else binascii.unhexlify(prefix[:-1])
+            bin_prefix = (
+                binascii.unhexlify(prefix)
+                if len(prefix) % 2 == 0
+                else binascii.unhexlify(prefix[:-1])
+            )
             for sha in p.index.iter_prefix(bin_prefix):
                 sha = sha_to_hex(sha)
                 if sha.startswith(prefix) and sha not in seen:

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -746,6 +746,28 @@ class FilePackIndex(PackIndex):
             raise KeyError(sha)
         return self._unpack_offset(i)
 
+    def iter_prefix(self, prefix: bytes) -> Iterator[bytes]:
+        """Iterate over all SHA1s with the given prefix."""
+        start = ord(prefix[:1])
+        if start == 0:
+            start = 0
+        else:
+            start = self._fan_out_table[start - 1]
+        end = ord(prefix[:1]) + 1
+        if end == 0x100:
+            end = len(self)
+        else:
+            end = self._fan_out_table[end]
+        assert start <= end
+        started = False
+        for i in range(start, end):
+            name = self._unpack_name(i)
+            if name.startswith(prefix):
+                yield name
+                started = True
+            elif started:
+                break
+
 
 class PackIndex1(FilePackIndex):
     """Version 1 Pack Index file."""

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -236,6 +236,11 @@ class ObjectStoreTests:
         self.store.add_object(testobject)
         self.store.close()
 
+    def test_iter_prefix(self):
+        self.store.add_object(testobject)
+        self.assertEqual([testobject.id], list(self.store.iter_prefix(b"")))
+        self.assertEqual([testobject.id], list(self.store.iter_prefix(testobject.id[:10])))
+
 
 class PackBasedObjectStoreTests(ObjectStoreTests):
     def tearDown(self):

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -238,8 +238,14 @@ class ObjectStoreTests:
 
     def test_iter_prefix(self):
         self.store.add_object(testobject)
+        self.assertEqual([testobject.id], list(self.store.iter_prefix(testobject.id)))
+        self.assertEqual(
+            [testobject.id], list(self.store.iter_prefix(testobject.id[:10]))
+        )
+        self.assertEqual(
+            [testobject.id], list(self.store.iter_prefix(testobject.id[:4]))
+        )
         self.assertEqual([testobject.id], list(self.store.iter_prefix(b"")))
-        self.assertEqual([testobject.id], list(self.store.iter_prefix(testobject.id[:10])))
 
 
 class PackBasedObjectStoreTests(ObjectStoreTests):

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -124,6 +124,12 @@ class PackIndexTests(PackTests):
         self.assertEqual(p.object_sha1(138), hex_to_sha(tree_sha))
         self.assertEqual(p.object_sha1(12), hex_to_sha(commit_sha))
 
+    def test_iter_prefix(self):
+        p = self.get_pack_index(pack1_sha)
+        self.assertEqual([p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha))))
+        self.assertEqual([p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha)[:5])))
+        self.assertEqual([p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha)[:2])))
+
     def test_index_len(self):
         p = self.get_pack_index(pack1_sha)
         self.assertEqual(3, len(p))

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -127,8 +127,12 @@ class PackIndexTests(PackTests):
     def test_iter_prefix(self):
         p = self.get_pack_index(pack1_sha)
         self.assertEqual([p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha))))
-        self.assertEqual([p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha)[:5])))
-        self.assertEqual([p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha)[:2])))
+        self.assertEqual(
+            [p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha)[:5]))
+        )
+        self.assertEqual(
+            [p.object_sha1(178)], list(p.iter_prefix(hex_to_sha(a_sha)[:2]))
+        )
 
     def test_index_len(self):
         p = self.get_pack_index(pack1_sha)


### PR DESCRIPTION
This allow scanning an object store for a specific SHA prefix. The default implementation is naive and scans the entire key space, but specific implementations have more efficient approaches, improving performance.,