### PR TITLE
Test symrefs handling for git protocol v2

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2609,9 +2609,11 @@ class AbstractHttpGitClient(GitClient):
         )
         (
             negotiated_capabilities,
-            symrefs,
+            capa_symrefs,
             agent,
         ) = self._negotiate_upload_pack_capabilities(server_capabilities)
+        if not symrefs and capa_symrefs:
+            symrefs = capa_symrefs
         if depth is not None:
             wants = determine_wants(refs, depth=depth)
         else:

--- a/tests/compat/test_client.py
+++ b/tests/compat/test_client.py
@@ -226,6 +226,10 @@ class DulwichClientTestBase:
         c = self._client()
         with repo.Repo(os.path.join(self.gitroot, "dest")) as dest:
             result = c.fetch(self._build_path("/server_new.export"), dest)
+            self.assertEqual(
+                {b"HEAD": b"refs/heads/master"},
+                result.symrefs,
+            )
             for r in result.refs.items():
                 dest.refs.set_if_equals(r[0], None, r[1])
             self.assertDestEqualsSrc()

--- a/tests/compat/test_client.py
+++ b/tests/compat/test_client.py
@@ -234,6 +234,21 @@ class DulwichClientTestBase:
                 dest.refs.set_if_equals(r[0], None, r[1])
             self.assertDestEqualsSrc()
 
+    def test_fetch_pack_with_nondefault_symref(self):
+        c = self._client()
+        src = repo.Repo(os.path.join(self.gitroot, "server_new.export"))
+        src.refs.add_if_new(b"refs/heads/main", src.refs[b"refs/heads/master"])
+        src.refs.set_symbolic_ref(b"HEAD", b"refs/heads/main")
+        with repo.Repo(os.path.join(self.gitroot, "dest")) as dest:
+            result = c.fetch(self._build_path("/server_new.export"), dest)
+            self.assertEqual(
+                {b"HEAD": b"refs/heads/main"},
+                result.symrefs,
+            )
+            for r in result.refs.items():
+                dest.refs.set_if_equals(r[0], None, r[1])
+            self.assertDestEqualsSrc()
+
     def test_fetch_pack_depth(self):
         c = self._client()
         with repo.Repo(os.path.join(self.gitroot, "dest")) as dest:


### PR DESCRIPTION
This adds missing compat tests for symref handling in git protocol v2 and fixes a bug in the HTTP client implementation uncovered by the tests. 