### PR TITLE
fix fallback ref-prefix used by porcelain.clone()

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -488,7 +488,7 @@ def init(path=".", *, bare=False, symlinks: Optional[bool] = None):
 
 def encode_refspecs(refspecs, refspec_encoding):
     if refspecs is None:
-        return [b"HEAD"]
+        return [b"HEAD", b"refs/"]
 
     def encode_refspec(ref):
         if isinstance(ref, bytes):


### PR DESCRIPTION
The porcelain layer fell back on just "HEAD" as the default ref-prefix, exluding all other refs from the cloned repository.

Fixes issue #1389