### PR TITLE
build: respect the "pure" argument at metadata generation time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.2", "setuptools-rust"]
+requires = ["setuptools>=61.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 from setuptools import setup
-from setuptools_rust import Binding, RustExtension
 
 if sys.platform == "darwin" and os.path.exists("/usr/bin/xcodebuild"):
     # XCode 4.0 dropped support for ppc architecture, which is hardcoded in
@@ -35,38 +34,45 @@ if "__pypy__" not in sys.modules and sys.platform != "win32":
 
 optional = os.environ.get("CIBUILDWHEEL", "0") != "1"
 
-rust_extensions = [
-    RustExtension(
-        "dulwich._objects",
-        "crates/objects/Cargo.toml",
-        binding=Binding.PyO3,
-        optional=optional,
-    ),
-    RustExtension(
-        "dulwich._pack",
-        "crates/pack/Cargo.toml",
-        binding=Binding.PyO3,
-        optional=optional,
-    ),
-    RustExtension(
-        "dulwich._diff_tree",
-        "crates/diff-tree/Cargo.toml",
-        binding=Binding.PyO3,
-        optional=optional,
-    ),
-]
-
 # Ideally, setuptools would just provide a way to do this
-if "--pure" in sys.argv:
-    sys.argv.remove("--pure")
+if "PURE" in os.environ or "--pure" in sys.argv:
+    if "--pure" in sys.argv:
+        sys.argv.remove("--pure")
+    setup_requires = []
     rust_extensions = []
+else:
+    setup_requires = ["setuptools_rust"]
+    # We check for egg_info since that indicates we are running prepare_metadata_for_build_*
+    if "egg_info" in sys.argv:
+        rust_extensions = []
+    else:
+        from setuptools_rust import Binding, RustExtension
 
-if "PURE" in os.environ:
-    rust_extensions = []
+        rust_extensions = [
+            RustExtension(
+                "dulwich._objects",
+                "crates/objects/Cargo.toml",
+                binding=Binding.PyO3,
+                optional=optional,
+            ),
+            RustExtension(
+                "dulwich._pack",
+                "crates/pack/Cargo.toml",
+                binding=Binding.PyO3,
+                optional=optional,
+            ),
+            RustExtension(
+                "dulwich._diff_tree",
+                "crates/diff-tree/Cargo.toml",
+                binding=Binding.PyO3,
+                optional=optional,
+            ),
+        ]
 
 
 setup(
     package_data={"": ["py.typed"]},
     rust_extensions=rust_extensions,
+    setup_requires=setup_requires,
     tests_require=tests_require,
 )


### PR DESCRIPTION
When a pure build is requested, no compiled extensions are produced. The setuptools_rust dependency ends up imported-but-not-used. Teach setuptools to avoid build-requiring it in this case.

Closes: https://github.com/jelmer/dulwich/issues/1405