### PR TITLE
Strip pkt-line when negotiating Git protocol v2

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -260,7 +260,7 @@ class ReportStatusParser:
 
 def negotiate_protocol_version(proto):
     pkt = proto.read_pkt_line()
-    if pkt == b"version 2\n":
+    if pkt is not None and pkt.strip() == b"version 2":
         return 2
     proto.unread_pkt_line(pkt)
     return 0


### PR DESCRIPTION
This makes it so both "version 2" and "version 2\n" (and any alternatives with more whitespace) are accepted as a successful v2 response.

Fixes #1423