### PR TITLE
add easy type hints to some function returns

### DIFF
--- a/dulwich/diff_tree.py
+++ b/dulwich/diff_tree.py
@@ -24,7 +24,7 @@ import stat
 from collections import defaultdict, namedtuple
 from io import BytesIO
 from itertools import chain
-from typing import Optional, Tuple
+from typing import Optional
 
 from .object_store import BaseObjectStore
 from .objects import S_ISGITLINK, ObjectID, ShaFile, Tree, TreeEntry
@@ -70,7 +70,7 @@ def _tree_entries(path: bytes, tree: Tree) -> list[TreeEntry]:
 
 def _merge_entries(
     path: bytes, tree1: Tree, tree2: Tree
-) -> list[Tuple[TreeEntry, TreeEntry]]:
+) -> list[tuple[TreeEntry, TreeEntry]]:
     """Merge the entries of two trees.
 
     Args:

--- a/dulwich/diff_tree.py
+++ b/dulwich/diff_tree.py
@@ -24,7 +24,7 @@ import stat
 from collections import defaultdict, namedtuple
 from io import BytesIO
 from itertools import chain
-from typing import Optional
+from typing import Optional, Tuple
 
 from .object_store import BaseObjectStore
 from .objects import S_ISGITLINK, ObjectID, ShaFile, Tree, TreeEntry
@@ -59,7 +59,7 @@ class TreeChange(namedtuple("TreeChange", ["type", "old", "new"])):
         return cls(CHANGE_DELETE, old, _NULL_ENTRY)
 
 
-def _tree_entries(path: str, tree: Tree) -> list[TreeEntry]:
+def _tree_entries(path: bytes, tree: Tree) -> list[TreeEntry]:
     result: list[TreeEntry] = []
     if not tree:
         return result
@@ -68,7 +68,9 @@ def _tree_entries(path: str, tree: Tree) -> list[TreeEntry]:
     return result
 
 
-def _merge_entries(path, tree1, tree2):
+def _merge_entries(
+    path: bytes, tree1: Tree, tree2: Tree
+) -> list[Tuple[TreeEntry, TreeEntry]]:
     """Merge the entries of two trees.
 
     Args:

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -352,7 +352,7 @@ class ShaFile:
         """Return raw string serialization of this object."""
         return self.as_raw_string()
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Return unique hash for this object."""
         return hash(self.id)
 
@@ -531,7 +531,7 @@ class ShaFile:
         """Returns the length of the raw string of this object."""
         return sum(map(len, self.as_raw_chunks()))
 
-    def sha(self):
+    def sha(self) -> "HASH":
         """The SHA1 object that is the name of this object."""
         if self._sha is None or self._needs_serialization:
             # this is a local because as_raw_chunks() overwrites self._sha
@@ -557,21 +557,21 @@ class ShaFile:
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__} {self.id}>"
 
-    def __ne__(self, other):
+    def __ne__(self, other) -> bool:
         """Check whether this object does not match the other."""
         return not isinstance(other, ShaFile) or self.id != other.id
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         """Return True if the SHAs of the two objects match."""
         return isinstance(other, ShaFile) and self.id == other.id
 
-    def __lt__(self, other):
+    def __lt__(self, other) -> bool:
         """Return whether SHA of this object is less than the other."""
         if not isinstance(other, ShaFile):
             raise TypeError
         return self.id < other.id
 
-    def __le__(self, other):
+    def __le__(self, other) -> bool:
         """Check whether SHA of this object is less than or equal to the other."""
         if not isinstance(other, ShaFile):
             raise TypeError
@@ -1128,7 +1128,7 @@ class Tree(ShaFile):
         self._entries[name] = mode, hexsha
         self._needs_serialization = True
 
-    def iteritems(self, name_order=False):
+    def iteritems(self, name_order=False) -> Iterator[TreeEntry]:
         """Iterate over entries.
 
         Args:
@@ -1138,7 +1138,7 @@ class Tree(ShaFile):
         """
         return sorted_tree_items(self._entries, name_order)
 
-    def items(self):
+    def items(self) -> list[TreeEntry]:
         """Return the sorted entries in this tree.
 
         Returns: List with (name, mode, sha) tuples

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1128,7 +1128,7 @@ class Tree(ShaFile):
         self._entries[name] = mode, hexsha
         self._needs_serialization = True
 
-    def iteritems(self, name_order=False):
+    def iteritems(self, name_order=False) -> Iterator[TreeEntry]:
         """Iterate over entries.
 
         Args:
@@ -1138,7 +1138,7 @@ class Tree(ShaFile):
         """
         return sorted_tree_items(self._entries, name_order)
 
-    def items(self):
+    def items(self) -> list[TreeEntry]:
         """Return the sorted entries in this tree.
 
         Returns: List with (name, mode, sha) tuples

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1128,7 +1128,7 @@ class Tree(ShaFile):
         self._entries[name] = mode, hexsha
         self._needs_serialization = True
 
-    def iteritems(self, name_order=False) -> Iterator[TreeEntry]:
+    def iteritems(self, name_order=False):
         """Iterate over entries.
 
         Args:
@@ -1138,7 +1138,7 @@ class Tree(ShaFile):
         """
         return sorted_tree_items(self._entries, name_order)
 
-    def items(self) -> list[TreeEntry]:
+    def items(self):
         """Return the sorted entries in this tree.
 
         Returns: List with (name, mode, sha) tuples

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -233,7 +233,7 @@ class RefsContainer:
                 keys.add(refname[base_len:])
         return keys
 
-    def as_dict(self, base=None):
+    def as_dict(self, base=None) -> dict[bytes, bytes]:
         """Return the contents of this container as a dictionary."""
         ret = {}
         keys = self.keys(base)
@@ -316,7 +316,7 @@ class RefsContainer:
             return True
         return False
 
-    def __getitem__(self, name):
+    def __getitem__(self, name) -> bytes:
         """Get the SHA1 for a reference name.
 
         This method follows all symbolic references.

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -233,7 +233,7 @@ class RefsContainer:
                 keys.add(refname[base_len:])
         return keys
 
-    def as_dict(self, base=None) -> dict[bytes, bytes]:
+    def as_dict(self, base=None) -> dict[Ref, ObjectID]:
         """Return the contents of this container as a dictionary."""
         ret = {}
         keys = self.keys(base)
@@ -316,7 +316,7 @@ class RefsContainer:
             return True
         return False
 
-    def __getitem__(self, name) -> bytes:
+    def __getitem__(self, name) -> ObjectID:
         """Get the SHA1 for a reference name.
 
         This method follows all symbolic references.


### PR DESCRIPTION
In the process of stating to use Dulwich (for https://gitlab.com/perm.pub/hidos/-/commits/sshsig), I added the following type hints to get mypy to pass with strict setting (in hidos).

Seems like a very safe merge.

I'll probably have some more type hints in the next few days. I'll ping you when I think  I don't have any more type hints to add this week.