### PR TITLE
Fix empty message serialization

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -728,8 +728,8 @@ def _format_message(headers, body):
         yield git_line(field, lines[0])
         for line in lines[1:]:
             yield b" " + line + b"\n"
+    yield b"\n"  # There must be a new line after the headers
     if body:
-        yield b"\n"  # There must be a new line after the headers
         yield body
 
 

--- a/tests/compat/test_porcelain.py
+++ b/tests/compat/test_porcelain.py
@@ -126,9 +126,32 @@ class CommitCreateSignTestCase(PorcelainGpgTestCase, CompatTestCase):
                 "commit",
                 "--allow-empty",
                 "-S" + PorcelainGpgTestCase.DEFAULT_KEY_ID,
-                "--allow-empty-message",
                 "-m",
                 "foo",
+            ],
+            env={
+                "GNUPGHOME": os.environ["GNUPGHOME"],
+                "GIT_COMMITTER_NAME": "Joe Example",
+                "GIT_COMMITTER_EMAIL": "joe@example.com",
+            },
+        )
+        commit = self.repo[b"HEAD"]
+        self.assertNotEqual(commit.gpgsig, None)
+        commit.verify()
+
+    def test_verify_with_empty_message(self):
+        # Test that CGit signatures can be verified by dulwich
+        self.import_default_key()
+
+        run_git_or_fail(
+            [
+                f"--git-dir={self.repo.controldir()}",
+                "commit",
+                "--allow-empty",
+                "-S" + PorcelainGpgTestCase.DEFAULT_KEY_ID,
+                "--allow-empty-message",
+                "-m",
+                "",
             ],
             env={
                 "GNUPGHOME": os.environ["GNUPGHOME"],

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1066,7 +1066,7 @@ class TagSerializeTests(TestCase):
                 b"type blob\n"
                 b"tag 0.1\n"
                 b"tagger Jelmer Vernooij <jelmer@samba.org> "
-                b"423423423 +0000\n"
+                b"423423423 +0000\n\n"
             ),
             x.as_raw_string(),
         )


### PR DESCRIPTION
Fixes #1429, incorrect signature verification for commits with an empty message, as encoded by CGit.

