### PR TITLE
Add SPDX license identifier to source files

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,6 +2,8 @@ Dulwich may be used under the conditions of either of two licenses,
 the Apache License (version 2.0 or later) or the GNU General Public License,
 version 2.0 or later.
 
+SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ doesn't call out to git directly but instead uses pure Python.
 
 **License**: Apache License, version 2 or GNU General Public License, version 2 or later.
 
+SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 The project is named after the part of London that Mr. and Mrs. Git live in
 the particular Monty Python sketch.
 

--- a/bin/dul-receive-pack
+++ b/bin/dul-receive-pack
@@ -2,6 +2,7 @@
 # dul-receive-pack - git-receive-pack in python
 # Copyright (C) 2008 John Carr <john.carr@unrouted.co.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/bin/dul-upload-pack
+++ b/bin/dul-upload-pack
@@ -2,6 +2,7 @@
 # dul-upload-pack - git-upload-pack in python
 # Copyright (C) 2008 John Carr <john.carr@unrouted.co.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/bin/dulwich
+++ b/bin/dulwich
@@ -2,6 +2,7 @@
 # command-line interface for Dulwich
 # Copyright (C) 2020 Jelmer Vernooĳ <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/devscripts/PREAMBLE.py
+++ b/devscripts/PREAMBLE.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/devscripts/replace-preamble.sh
+++ b/devscripts/replace-preamble.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/zsh
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 perl -i -p0e "s{\Q$(cat PREAMBLE.py.old)\E}{$(cat devscripts/PREAMBLE.py)}g" dulwich/**/*.py bin/dul*
 perl -i -p0e "s{\Q$(cat PREAMBLE.c.old)\E}{$(cat devscripts/PREAMBLE.c)}g" dulwich/*.c

--- a/dulwich/__init__.py
+++ b/dulwich/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 # Copyright (C) 2008 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/archive.py
+++ b/dulwich/archive.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2015 Jonas Haag <jonas@lophus.org>
 # Copyright (C) 2015 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/bundle.py
+++ b/dulwich/bundle.py
@@ -1,6 +1,7 @@
 # bundle.py -- Bundle format support
 # Copyright (C) 2020 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2008-2011 Jelmer Vernooij <jelmer@jelmer.uk>
 # vim: expandtab
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1,6 +1,7 @@
 # client.py -- Implementation of the client side git protocols
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/cloud/gcs.py
+++ b/dulwich/cloud/gcs.py
@@ -1,6 +1,7 @@
 # object_store.py -- Object store for git objects
 # Copyright (C) 2021 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -1,6 +1,7 @@
 # config.py - Reading and writing Git config files
 # Copyright (C) 2011-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/contrib/__init__.py
+++ b/dulwich/contrib/__init__.py
@@ -1,6 +1,7 @@
 # __init__.py -- Contrib module for Dulwich
 # Copyright (C) 2014 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/contrib/diffstat.py
+++ b/dulwich/contrib/diffstat.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # vim:ts=4:sw=4:softtabstop=4:smarttab:expandtab
 
+# SPDX-License-Identifier: MIT
 # Copyright (c) 2020 Kevin B. Hendricks, Stratford Ontario Canada
 # All rights reserved.
 #

--- a/dulwich/contrib/paramiko_vendor.py
+++ b/dulwich/contrib/paramiko_vendor.py
@@ -1,6 +1,7 @@
 # paramiko_vendor.py -- paramiko implementation of the SSHVendor interface
 # Copyright (C) 2013 Aaron O'Mullan <aaron.omullan@friendco.de>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/contrib/release_robot.py
+++ b/dulwich/contrib/release_robot.py
@@ -1,5 +1,6 @@
 # release_robot.py
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/contrib/requests_vendor.py
+++ b/dulwich/contrib/requests_vendor.py
@@ -1,6 +1,7 @@
 # requests_vendor.py -- requests implementation of the AbstractHttpGitClient interface
 # Copyright (C) 2022 Eden Shalit <epopcop@gmail.com>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/contrib/swift.py
+++ b/dulwich/contrib/swift.py
@@ -3,6 +3,7 @@
 #
 # Author: Fabien Boucher <fabien.boucher@enovance.com>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/credentials.py
+++ b/dulwich/credentials.py
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2022 Daniele Trifirò <daniele@iterative.ai>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/diff_tree.py
+++ b/dulwich/diff_tree.py
@@ -1,6 +1,7 @@
 # diff_tree.py -- Utilities for diffing files and trees.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/errors.py
+++ b/dulwich/errors.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 # Copyright (C) 2009-2012 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/fastexport.py
+++ b/dulwich/fastexport.py
@@ -1,6 +1,7 @@
 # __init__.py -- Fast export/import functionality
 # Copyright (C) 2010-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/file.py
+++ b/dulwich/file.py
@@ -1,6 +1,7 @@
 # file.py -- Safe access to git files
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/graph.py
+++ b/dulwich/graph.py
@@ -1,6 +1,7 @@
 # vim:ts=4:sw=4:softtabstop=4:smarttab:expandtab
 # Copyright (c) 2020 Kevin B. Hendricks, Stratford Ontario Canada
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/greenthreads.py
+++ b/dulwich/greenthreads.py
@@ -3,6 +3,7 @@
 #
 # Author: Fabien Boucher <fabien.boucher@enovance.com>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/hooks.py
+++ b/dulwich/hooks.py
@@ -1,6 +1,7 @@
 # hooks.py -- for dealing with git hooks
 # Copyright (C) 2012-2013 Jelmer Vernooij and others.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2017 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -1,6 +1,7 @@
 # index.py -- File parser/writer for the git index file
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/lfs.py
+++ b/dulwich/lfs.py
@@ -1,6 +1,7 @@
 # lfs.py -- Implementation of the LFS
 # Copyright (C) 2020 Jelmer Vernooij
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -1,6 +1,7 @@
 # line_ending.py -- Line ending conversion functions
 # Copyright (C) 2018-2018 Boris Feld <boris.feld@comet.ml>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/log_utils.py
+++ b/dulwich/log_utils.py
@@ -1,6 +1,7 @@
 # log_utils.py -- Logging utilities for Dulwich
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/lru_cache.py
+++ b/dulwich/lru_cache.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2006, 2008 Canonical Ltd
 # Copyright (C) 2022 Jelmer Vernooĳ <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/mailmap.py
+++ b/dulwich/mailmap.py
@@ -1,6 +1,7 @@
 # mailmap.py -- Mailmap reader
 # Copyright (C) 2018 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #                         and others
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/objectspec.py
+++ b/dulwich/objectspec.py
@@ -1,6 +1,7 @@
 # objectspec.py -- Object specification
 # Copyright (C) 2014 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -1,6 +1,7 @@
 # patch.py -- For dealing with packed-style patches.
 # Copyright (C) 2009-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -1,6 +1,7 @@
 # porcelain.py -- Porcelain-like layer on top of Dulwich
 # Copyright (C) 2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2008 John Carr <john.carr@unrouted.co.uk>
 # Copyright (C) 2008-2012 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/reflog.py
+++ b/dulwich/reflog.py
@@ -1,6 +1,7 @@
 # reflog.py -- Parsing and writing reflog files
 # Copyright (C) 2015 Jelmer Vernooij and others.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -1,6 +1,7 @@
 # refs.py -- For dealing with git refs
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 # Copyright (C) 2008-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2008 John Carr <john.carr@unrouted.co.uk>
 # Copyright(C) 2011-2012 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -1,6 +1,7 @@
 # stash.py
 # Copyright (C) 2018 Jelmer Vernooij <jelmer@samba.org>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/submodule.py
+++ b/dulwich/submodule.py
@@ -1,6 +1,7 @@
 # config.py - Reading and writing Git config files
 # Copyright (C) 2011-2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/tests/__init__.py
+++ b/dulwich/tests/__init__.py
@@ -1,6 +1,7 @@
 # __init__.py -- The tests for dulwich
 # Copyright (C) 2024 Jelmer Vernooĳ <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/tests/test_object_store.py
+++ b/dulwich/tests/test_object_store.py
@@ -1,6 +1,7 @@
 # test_object_store.py -- tests for object_store.py
 # Copyright (C) 2008 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/tests/utils.py
+++ b/dulwich/tests/utils.py
@@ -1,6 +1,7 @@
 # utils.py -- Test utilities for Dulwich.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/walk.py
+++ b/dulwich/walk.py
@@ -1,6 +1,7 @@
 # walk.py -- General implementation of walking commits and their contents.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/dulwich/web.py
+++ b/dulwich/web.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2010 Google, Inc.
 # Copyright (C) 2012 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/examples/clone.py
+++ b/examples/clone.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 """Clone.
 
 This trivial script demonstrates how to clone or lock a remote repository.

--- a/examples/config.py
+++ b/examples/config.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 # Read the config file for a git repository.
 #
 # Example usage:

--- a/examples/diff.py
+++ b/examples/diff.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 # This trivial script demonstrates how to extract the unified diff for a single
 # commit in a local repository.
 #

--- a/examples/gcs.py
+++ b/examples/gcs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 import tempfile
 

--- a/examples/latest_change.py
+++ b/examples/latest_change.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 # Example printing the last author of a specified file
 
 import sys

--- a/examples/memoryrepo.py
+++ b/examples/memoryrepo.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 # This script creates a clone of a remote repository in local memory,
 # then adds a single file and pushes the result back.
 #

--- a/examples/rename-branch.py
+++ b/examples/rename-branch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 import argparse
 

--- a/fuzzing/fuzz-targets/fuzz_bundle.py
+++ b/fuzzing/fuzz-targets/fuzz_bundle.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import sys
 from io import BytesIO
 from typing import Optional

--- a/fuzzing/fuzz-targets/fuzz_configfile.py
+++ b/fuzzing/fuzz-targets/fuzz_configfile.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import sys
 from io import BytesIO
 from typing import Optional

--- a/fuzzing/fuzz-targets/fuzz_object_store.py
+++ b/fuzzing/fuzz-targets/fuzz_object_store.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import stat
 import sys
 from io import BytesIO

--- a/fuzzing/fuzz-targets/fuzz_repo.py
+++ b/fuzzing/fuzz-targets/fuzz_repo.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import os
 import sys
 import tempfile

--- a/fuzzing/fuzz-targets/test_utils.py
+++ b/fuzzing/fuzz-targets/test_utils.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
 import atheris  # pragma: no cover
 
 

--- a/fuzzing/oss-fuzz-scripts/container-environment-bootstrap.sh
+++ b/fuzzing/oss-fuzz-scripts/container-environment-bootstrap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 set -euo pipefail
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # Setup file for dulwich
 # Copyright (C) 2008-2022 Jelmer Vernooĳ <jelmer@jelmer.uk>
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 
 import os
 import sys

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 # __init__.py -- The tests for dulwich
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/__init__.py
+++ b/tests/compat/__init__.py
@@ -1,6 +1,7 @@
 # __init__.py -- Compatibility tests for dulwich
 # Copyright (C) 2010 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/server_utils.py
+++ b/tests/compat/server_utils.py
@@ -1,6 +1,7 @@
 # server_utils.py -- Git server compatibility utilities
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_client.py
+++ b/tests/compat/test_client.py
@@ -1,6 +1,7 @@
 # test_client.py -- Compatibility tests for git client.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_pack.py
+++ b/tests/compat/test_pack.py
@@ -1,6 +1,7 @@
 # test_pack.py -- Compatibility tests for git packs.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_patch.py
+++ b/tests/compat/test_patch.py
@@ -1,6 +1,7 @@
 # test_patch.py -- test patch compatibility with CGit
 # Copyright (C) 2019 Boris Feld <boris@comet.ml>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_porcelain.py
+++ b/tests/compat/test_porcelain.py
@@ -1,6 +1,7 @@
 # test_porcelain .py -- Tests for dulwich.porcelain/CGit compatibility
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_repository.py
+++ b/tests/compat/test_repository.py
@@ -1,6 +1,7 @@
 # test_repo.py -- Git repo compatibility tests
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_server.py
+++ b/tests/compat/test_server.py
@@ -1,6 +1,7 @@
 # test_server.py -- Compatibility tests for git server.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_utils.py
+++ b/tests/compat/test_utils.py
@@ -1,6 +1,7 @@
 # test_utils.py -- Tests for git compatibility utilities
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/test_web.py
+++ b/tests/compat/test_web.py
@@ -1,6 +1,7 @@
 # test_web.py -- Compatibility tests for the git web server.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/compat/utils.py
+++ b/tests/compat/utils.py
@@ -1,6 +1,7 @@
 # utils.py -- Git compatibility utilities
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/contrib/__init__.py
+++ b/tests/contrib/__init__.py
@@ -1,6 +1,7 @@
 # __init__.py -- Contrib module for Dulwich
 # Copyright (C) 2014 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/contrib/test_paramiko_vendor.py
+++ b/tests/contrib/test_paramiko_vendor.py
@@ -1,5 +1,6 @@
 # test_paramiko_vendor.py
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/contrib/test_release_robot.py
+++ b/tests/contrib/test_release_robot.py
@@ -1,5 +1,6 @@
 # release_robot.py
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/contrib/test_swift.py
+++ b/tests/contrib/test_swift.py
@@ -3,6 +3,7 @@
 #
 # Author: Fabien Boucher <fabien.boucher@enovance.com>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/contrib/test_swift_smoke.py
+++ b/tests/contrib/test_swift_smoke.py
@@ -3,6 +3,7 @@
 #
 # Author: Fabien Boucher <fabien.boucher@enovance.com>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,6 +1,7 @@
 # test_archive.py -- tests for archive
 # Copyright (C) 2015 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_blackbox.py
+++ b/tests/test_blackbox.py
@@ -1,6 +1,7 @@
 # test_blackbox.py -- blackbox tests
 # Copyright (C) 2010 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,6 +1,7 @@
 # test_bundle.py -- tests for bundle
 # Copyright (C) 2020 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,7 @@
 # test_client.py -- Tests for the git protocol, client side
 # Copyright (C) 2009 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 # test_config.py -- Tests for reading and writing configuration files
 # Copyright (C) 2011 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -2,6 +2,7 @@
 
 # Copyright (C) 2022 Daniele Trifirò <daniele@iterative.ai>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_diff_tree.py
+++ b/tests/test_diff_tree.py
@@ -1,6 +1,7 @@
 # test_diff_tree.py -- Tests for file and tree diff utilities.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_fastexport.py
+++ b/tests/test_fastexport.py
@@ -1,6 +1,7 @@
 # test_fastexport.py -- Fast export/import functionality
 # Copyright (C) 2010 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,6 +1,7 @@
 # test_file.py -- Test for git files
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_grafts.py
+++ b/tests/test_grafts.py
@@ -1,5 +1,6 @@
 # test_grafts.py -- Tests for graftpoints
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,6 +1,7 @@
 # test_graph.py -- Tests for merge base
 # Copyright (c) 2020 Kevin B. Hendricks, Stratford Ontario Canada
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_greenthreads.py
+++ b/tests/test_greenthreads.py
@@ -3,6 +3,7 @@
 #
 # Author: Fabien Boucher <fabien.boucher@enovance.com>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,6 @@
 # test_hooks.py -- Tests for executing hooks
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,6 +1,7 @@
 # test_ignore.py -- Tests for ignore files.
 # Copyright (C) 2017 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,6 +1,7 @@
 # test_index.py -- Tests for the git index
 # Copyright (C) 2008-2009 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -1,6 +1,7 @@
 # test_lfs.py -- tests for LFS
 # Copyright (C) 2020 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_line_ending.py
+++ b/tests/test_line_ending.py
@@ -1,6 +1,7 @@
 # test_line_ending.py -- Tests for the line ending functions
 # Copyright (C) 2018-2019 Boris Feld <boris.feld@comet.ml>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_lru_cache.py
+++ b/tests/test_lru_cache.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2006, 2008 Canonical Ltd
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_mailmap.py
+++ b/tests/test_mailmap.py
@@ -1,6 +1,7 @@
 # test_mailmap.py -- Tests for dulwich.mailmap
 # Copyright (C) 2018 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_missing_obj_finder.py
+++ b/tests/test_missing_obj_finder.py
@@ -1,6 +1,7 @@
 # test_missing_obj_finder.py -- tests for MissingObjectFinder
 # Copyright (C) 2012 syntevo GmbH
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -1,6 +1,7 @@
 # test_object_store.py -- tests for object_store.py
 # Copyright (C) 2008 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1,6 +1,7 @@
 # test_objects.py -- tests for objects.py
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_objectspec.py
+++ b/tests/test_objectspec.py
@@ -1,6 +1,7 @@
 # test_objectspec.py -- tests for objectspec.py
 # Copyright (C) 2014 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 # Copyright (C) 2008 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,6 +1,7 @@
 # test_patch.py -- tests for patch.py
 # Copyright (C) 2010 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -1,6 +1,7 @@
 # test_porcelain.py -- porcelain tests
 # Copyright (C) 2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,6 +1,7 @@
 # test_protocol.py -- Tests for the git protocol
 # Copyright (C) 2009 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_reflog.py
+++ b/tests/test_reflog.py
@@ -1,6 +1,7 @@
 # test_reflog.py -- tests for reflog.py
 # Copyright (C) 2015 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,6 +1,7 @@
 # test_refs.py -- tests for refs.py
 # Copyright (C) 2013 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,6 +1,7 @@
 # test_repository.py -- tests for repository.py
 # Copyright (C) 2007 James Westby <jw+debian@jameswestby.net>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 # test_server.py -- Tests for the git server
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -1,6 +1,7 @@
 # test_stash.py -- tests for stash
 # Copyright (C) 2018 Jelmer Vernooij <jelmer@jelmer.uk>
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # test_utils.py -- Tests for git test utilities.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -1,6 +1,7 @@
 # test_walk.py -- Tests for commit walking functionality.
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,6 +1,7 @@
 # test_web.py -- Tests for the git HTTP server
 # Copyright (C) 2010 Google, Inc.
 #
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
 # Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
 # General Public License as public by the Free Software Foundation; version 2.0
 # or (at your option) any later version. You can redistribute it and/or


### PR DESCRIPTION
SPDX license identifiers help tools to identify the right licenses. Especially detecting that the user can choose to GPL 2+ or Apache 2.0 is difficult to detect, it can be misinterpreted that the user has to comply with both licenses.

Fixes #1451