### PR TITLE
Readme: Python 3.9 is tested and required, not 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,5 +89,5 @@ file and `list of open issues <https://github.com/dulwich/dulwich/issues>`_.
 Supported versions of Python
 ----------------------------
 
-At the moment, Dulwich supports (and is tested on) CPython 3.6 and later and
+At the moment, Dulwich supports (and is tested on) CPython 3.9 and later and
 Pypy.


### PR DESCRIPTION
Maybe I just misunderstood the Github Actions and Python required line.