### PR TITLE
porcelain: respect 'abbrev' argument when describing annotated-tagless repositories

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2225,7 +2225,7 @@ def describe(repo, abbrev=None):
         if len(sorted_tags) == 0:
             object_id = r[r.head()].id
             if abbrev is not None:
-                return object_id[abbrev_slice].decode("ascii")
+                return object_id.decode("ascii")[abbrev_slice]
             return f"g{find_unique_abbrev(r.object_store, object_id)}"
 
         # We're now 0 commits from the top

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -116,7 +116,7 @@ from .objectspec import (
     parse_tree,
     to_bytes,
 )
-from .pack import write_pack_from_container, write_pack_index
+from .pack import ObjectContainer, write_pack_from_container, write_pack_index
 from .patch import write_tree_diff
 from .protocol import ZERO_SHA, Protocol
 from .refs import (
@@ -2177,11 +2177,11 @@ def ls_files(repo):
         return sorted(r.open_index())
 
 
-def find_unique_abbrev(object_store, object_id):
+def find_unique_abbrev(object_store: ObjectContainer, object_id: str, abbrev: int | None = 7) -> str:
     """For now, just return 7 characters."""
     # TODO(jelmer): Add some logic here to return a number of characters that
     # scales relative with the size of the repository
-    return object_id.decode("ascii")[:7]
+    return object_id.decode("ascii")[:abbrev]
 
 
 def describe(repo, abbrev=7):
@@ -2222,7 +2222,7 @@ def describe(repo, abbrev=7):
 
         # If there are no tags, return the current commit
         if len(sorted_tags) == 0:
-            return f"g{find_unique_abbrev(r.object_store, r[r.head()].id)}"
+            return f"g{find_unique_abbrev(r.object_store, r[r.head()].id, abbrev=abbrev)}"
 
         # We're now 0 commits from the top
         commit_count = 0

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2221,18 +2221,17 @@ def describe(repo, abbrev=None):
 
         sorted_tags = sorted(tags.items(), key=lambda tag: tag[1][0], reverse=True)
 
-        # If there are no tags, return the current commit
+        # Get the latest commit
+        latest_commit = r[r.head()]
+
+        # If there are no tags, return the latest commit
         if len(sorted_tags) == 0:
-            object_id = r[r.head()].id
             if abbrev is not None:
-                return object_id.decode("ascii")[abbrev_slice]
-            return f"g{find_unique_abbrev(r.object_store, object_id)}"
+                return latest_commit.id.decode("ascii")[abbrev_slice]
+            return f"g{find_unique_abbrev(r.object_store, latest_commit.id)}"
 
         # We're now 0 commits from the top
         commit_count = 0
-
-        # Get the latest commit
-        latest_commit = r[r.head()]
 
         # Walk through all commits
         walker = r.get_walker()

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2194,6 +2194,7 @@ def describe(repo, abbrev=None):
 
     Examples: "gabcdefh", "v0.1" or "v0.1-5-gabcdefh".
     """
+    abbrev_slice = slice(0, abbrev if abbrev is not None else 7)
     # Get the repository
     with open_repo_closing(repo) as r:
         # Get a list of all tags
@@ -2224,7 +2225,7 @@ def describe(repo, abbrev=None):
         if len(sorted_tags) == 0:
             object_id = r[r.head()].id
             if abbrev is not None:
-                return object_id[:abbrev].decode("ascii")
+                return object_id[abbrev_slice].decode("ascii")
             return f"g{find_unique_abbrev(r.object_store, object_id)}"
 
         # We're now 0 commits from the top
@@ -2248,13 +2249,13 @@ def describe(repo, abbrev=None):
                         return "{}-{}-g{}".format(
                             tag_name,
                             commit_count,
-                            latest_commit.id.decode("ascii")[:abbrev or 7],
+                            latest_commit.id.decode("ascii")[abbrev_slice],
                         )
 
             commit_count += 1
 
         # Return plain commit if no parent tag can be found
-        return "g{}".format(latest_commit.id.decode("ascii")[:abbrev or 7])
+        return "g{}".format(latest_commit.id.decode("ascii")[abbrev_slice])
 
 
 def get_object_by_path(repo, path, committish=None):

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2227,7 +2227,7 @@ def describe(repo, abbrev=None):
         # If there are no tags, return the latest commit
         if len(sorted_tags) == 0:
             if abbrev is not None:
-                return latest_commit.id.decode("ascii")[abbrev_slice]
+                return "g{}".format(latest_commit.id.decode("ascii")[abbrev_slice])
             return f"g{find_unique_abbrev(r.object_store, latest_commit.id)}"
 
         # We're now 0 commits from the top

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -3403,6 +3403,16 @@ class DescribeTests(PorcelainTestCase):
             porcelain.describe(self.repo.path, abbrev=40),
         )
 
+    def test_untagged_commit_abbreviation(self) -> None:
+        _, _, c3 = build_commit_graph(
+            self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
+        )
+        self.repo.refs[b"HEAD"] = c3.id
+        self.assertEqual(
+            c3.id.decode("ascii"),
+            porcelain.describe(self.repo, abbrev=40),
+        )
+
 
 class PathToTreeTests(PorcelainTestCase):
     def setUp(self) -> None:
@@ -3512,26 +3522,14 @@ class ActiveBranchTests(PorcelainTestCase):
 
 
 class FindUniqueAbbrevTests(PorcelainTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.graph = build_commit_graph(
+    def test_simple(self) -> None:
+        c1, c2, c3 = build_commit_graph(
             self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
         )
-
-    def test_simple(self) -> None:
-        c1, c2, c3 = self.graph
         self.repo.refs[b"HEAD"] = c3.id
         self.assertEqual(
             c1.id.decode("ascii")[:7],
             porcelain.find_unique_abbrev(self.repo.object_store, c1.id),
-        )
-
-    def test_commit_full(self) -> None:
-        c1, c2, c3 = self.graph
-        self.repo.refs[b"HEAD"] = c3.id
-        self.assertEqual(
-            c1.id.decode("ascii"),
-            porcelain.find_unique_abbrev(self.repo.object_store, c1.id, abbrev=40),
         )
 
 

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -3512,14 +3512,26 @@ class ActiveBranchTests(PorcelainTestCase):
 
 
 class FindUniqueAbbrevTests(PorcelainTestCase):
-    def test_simple(self) -> None:
-        c1, c2, c3 = build_commit_graph(
+    def setUp(self) -> None:
+        super().setUp()
+        self.graph = build_commit_graph(
             self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
         )
+
+    def test_simple(self) -> None:
+        c1, c2, c3 = self.graph
         self.repo.refs[b"HEAD"] = c3.id
         self.assertEqual(
             c1.id.decode("ascii")[:7],
             porcelain.find_unique_abbrev(self.repo.object_store, c1.id),
+        )
+
+    def test_commit_full(self) -> None:
+        c1, c2, c3 = self.graph
+        self.repo.refs[b"HEAD"] = c3.id
+        self.assertEqual(
+            c1.id.decode("ascii"),
+            porcelain.find_unique_abbrev(self.repo.object_store, c1.id, abbrev=40),
         )
 
 

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -3404,17 +3404,13 @@ class DescribeTests(PorcelainTestCase):
         )
 
     def test_untagged_commit_abbreviation(self) -> None:
-        _, _, c3 = build_commit_graph(
-            self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
-        )
+        _, _, c3 = build_commit_graph(self.repo.object_store, [[1], [2, 1], [3, 1, 2]])
         self.repo.refs[b"HEAD"] = c3.id
         brief_description, complete_description = (
             porcelain.describe(self.repo),
             porcelain.describe(self.repo, abbrev=40),
         )
-        self.assertTrue(
-            complete_description.startswith(brief_description)
-        )
+        self.assertTrue(complete_description.startswith(brief_description))
         self.assertEqual(
             "g{}".format(c3.id.decode("ascii")),
             complete_description,

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -3409,7 +3409,7 @@ class DescribeTests(PorcelainTestCase):
         )
         self.repo.refs[b"HEAD"] = c3.id
         self.assertEqual(
-            c3.id.decode("ascii"),
+            "g{}".format(c3.id.decode("ascii")),
             porcelain.describe(self.repo, abbrev=40),
         )
 

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -3408,9 +3408,16 @@ class DescribeTests(PorcelainTestCase):
             self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
         )
         self.repo.refs[b"HEAD"] = c3.id
+        brief_description, complete_description = (
+            porcelain.describe(self.repo),
+            porcelain.describe(self.repo, abbrev=40),
+        )
+        self.assertTrue(
+            complete_description.startswith(brief_description)
+        )
         self.assertEqual(
             "g{}".format(c3.id.decode("ascii")),
-            porcelain.describe(self.repo, abbrev=40),
+            complete_description,
         )
 
 


### PR DESCRIPTION
Resolves #1477.