### PR TITLE
cli: protocol argument consistency and fixups

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -288,7 +288,9 @@ class cmd_clone(Command):
             help="git-rev-list-style object filter",
         )
         parser.add_option(
-            "--protocol", dest="protocol", type=int, help="Git protocol version to use"
+            "--protocol",
+            type=int,
+            help="Git protocol version to use",
         )
         options, args = parser.parse_args(args)
 
@@ -620,14 +622,14 @@ class cmd_pull(Command):
         parser.add_argument("from_location", type=str)
         parser.add_argument("refspec", type=str, nargs="*")
         parser.add_argument("--filter", type=str, nargs=1)
-        parser.add_argument("--protocol", type=int, nargs=1)
+        parser.add_argument("--protocol", type=int)
         args = parser.parse_args(args)
         porcelain.pull(
             ".",
             args.from_location or None,
             args.refspec or None,
             filter_spec=args.filter,
-            protocol_version=args.protocol_version or None,
+            protocol_version=args.protocol or None,
         )
 
 


### PR DESCRIPTION
A couple of problems encountered while attempting to use `dulwich pull` with Git protocol v2:

  * Mismatched argument name / attribute access (`protocol_version` vs `args.protocol`)
  * Mismatched attribute value type (`list[int]` vs `int`)

Also some minor consistency fixups for `dulwich clone` (neither of these should affect functionality):

  * Remove a redundant `dest` parameter
  * Use consistent Python argument indentation / trailing-comma style for param