### PR TITLE
cli: adjust 'message' argument parsing to require a value

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -321,14 +321,14 @@ class cmd_clone(Command):
 
 class cmd_commit(Command):
     def run(self, args) -> None:
-        opts, args = getopt(args, "", ["message"])
+        opts, args = getopt(args, "", ["message="])
         kwopts = dict(opts)
         porcelain.commit(".", message=kwopts["--message"])
 
 
 class cmd_commit_tree(Command):
     def run(self, args) -> None:
-        opts, args = getopt(args, "", ["message"])
+        opts, args = getopt(args, "", ["message="])
         if args == []:
             print("usage: dulwich commit-tree tree")
             sys.exit(1)


### PR DESCRIPTION
As per the [Python `getopt` documentation](https://docs.python.org/3.9/library/getopt.html#getopt.getopt), add an equals symbol to require that the message option has a corresponding value (argument).

Resolves #1508.