### PR TITLE
porcelain: permit printing commits that contain no commit message

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -768,9 +768,10 @@ def print_commit(commit, decode, outstream=sys.stdout) -> None:
     time_str = time.strftime("%a %b %d %Y %H:%M:%S", time_tuple)
     timezone_str = format_timezone(commit.author_timezone).decode("ascii")
     outstream.write("Date:   " + time_str + " " + timezone_str + "\n")
-    outstream.write("\n")
-    outstream.write(decode(commit.message) + "\n")
-    outstream.write("\n")
+    if commit.message is not None:
+        outstream.write("\n")
+        outstream.write(decode(commit.message) + "\n")
+        outstream.write("\n")
 
 
 def print_tag(tag, decode, outstream=sys.stdout) -> None:


### PR DESCRIPTION
Adds logic to detect an empty commit message during `print_commit`, preventing failures during attempts to decode `None`.

Resolves #1510.