### PR TITLE
cli: add basic branch management commands

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -739,7 +739,7 @@ class cmd_branch(Command):
         parser.add_argument(
             "branch",
             type=str,
-            help="Name of the branch to create",
+            help="Name of the branch",
         )
         parser.add_argument(
             "-d",
@@ -768,7 +768,7 @@ class cmd_checkout(Command):
         parser.add_argument(
             "branch",
             type=str,
-            help="Name of the branch to checkout",
+            help="Name of the branch",
         )
         parser.add_argument(
             "-f",

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -111,23 +111,6 @@ class cmd_rm(Command):
         porcelain.rm(".", paths=args.path)
 
 
-class cmd_rm_branch(Command):
-    def run(self, args) -> None:
-        parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "branch",
-            type=str,
-            help="Name of the branch to remove",
-        )
-        args = parser.parse_args(args)
-        if not args.branch:
-            print("Usage: dulwich rm-branch BRANCH_NAME")
-            sys.exit(1)
-
-        r = Repo(".")
-        porcelain.branch_delete(r, name=args.branch)
-
-
 class cmd_fetch_pack(Command):
     def run(self, argv) -> None:
         parser = argparse.ArgumentParser()
@@ -750,7 +733,7 @@ class cmd_check_mailmap(Command):
             print(canonical_identity)
 
 
-class cmd_create_branch(Command):
+class cmd_branch(Command):
     def run(self, args) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -758,19 +741,28 @@ class cmd_create_branch(Command):
             type=str,
             help="Name of the branch to create",
         )
+        parser.add_argument(
+            "-d",
+            "--delete",
+            action="store_true",
+            help="Delete branch",
+        )
         args = parser.parse_args(args)
         if not args.branch:
-            print("Usage: dulwich create-branch BRANCH_NAME")
+            print("Usage: dulwich branch [-d] BRANCH_NAME")
             sys.exit(1)
 
         r = Repo(".")
-        try:
-            porcelain.branch_create(r, name=args.branch)
-        except porcelain.Error as e:
-            print(f"{e}")
+        if args.delete:
+            porcelain.branch_delete(r, name=args.branch)
+        else:
+            try:
+                porcelain.branch_create(r, name=args.branch)
+            except porcelain.Error as e:
+                print(f"{e}")
 
 
-class cmd_checkout_branch(Command):
+class cmd_checkout(Command):
     def run(self, args) -> None:
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -786,7 +778,7 @@ class cmd_checkout_branch(Command):
         )
         args = parser.parse_args(args)
         if not args.branch:
-            print("Usage: dulwich checkout-branch BRANCH_NAME [--force]")
+            print("Usage: dulwich checkout BRANCH_NAME [--force]")
             sys.exit(1)
 
         r = Repo(".")
@@ -873,10 +865,10 @@ For a list of supported commands, see 'dulwich help -a'.
 commands = {
     "add": cmd_add,
     "archive": cmd_archive,
+    "branch": cmd_branch,
     "check-ignore": cmd_check_ignore,
     "check-mailmap": cmd_check_mailmap,
-    "checkout-branch": cmd_checkout_branch,
-    "create-branch": cmd_create_branch,
+    "checkout": cmd_checkout,
     "clone": cmd_clone,
     "commit": cmd_commit,
     "commit-tree": cmd_commit_tree,
@@ -906,7 +898,6 @@ commands = {
     "reset": cmd_reset,
     "rev-list": cmd_rev_list,
     "rm": cmd_rm,
-    "rm-branch": cmd_rm_branch,
     "show": cmd_show,
     "stash": cmd_stash,
     "status": cmd_status,

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -758,7 +758,8 @@ class cmd_branch(Command):
             try:
                 porcelain.branch_create(".", name=args.branch)
             except porcelain.Error as e:
-                print(f"{e}")
+                sys.stderr.write(f"{e}")
+                sys.exit(1)
 
 
 class cmd_checkout(Command):
@@ -783,7 +784,8 @@ class cmd_checkout(Command):
         try:
             porcelain.checkout_branch(".", target=args.branch, force=args.force)
         except porcelain.CheckoutError as e:
-            print(f"{e}")
+            sys.stderr.write(f"{e}\n")
+            sys.exit(1)
 
 
 class cmd_stash_list(Command):

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -123,7 +123,7 @@ class cmd_rm_branch(Command):
         if not args.branch:
             print("Usage: dulwich rm-branch BRANCH_NAME")
             sys.exit(1)
-            
+
         r = Repo(".")
         porcelain.branch_delete(r, name=args.branch)
 
@@ -762,7 +762,7 @@ class cmd_create_branch(Command):
         if not args.branch:
             print("Usage: dulwich create-branch BRANCH_NAME")
             sys.exit(1)
-            
+
         r = Repo(".")
         try:
             porcelain.branch_create(r, name=args.branch)
@@ -788,7 +788,7 @@ class cmd_checkout_branch(Command):
         if not args.branch:
             print("Usage: dulwich checkout-branch BRANCH_NAME [--force]")
             sys.exit(1)
-            
+
         r = Repo(".")
         try:
             porcelain.checkout_branch(r, target=args.branch, force=args.force)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -752,12 +752,11 @@ class cmd_branch(Command):
             print("Usage: dulwich branch [-d] BRANCH_NAME")
             sys.exit(1)
 
-        r = Repo(".")
         if args.delete:
-            porcelain.branch_delete(r, name=args.branch)
+            porcelain.branch_delete(".", name=args.branch)
         else:
             try:
-                porcelain.branch_create(r, name=args.branch)
+                porcelain.branch_create(".", name=args.branch)
             except porcelain.Error as e:
                 print(f"{e}")
 
@@ -781,9 +780,8 @@ class cmd_checkout(Command):
             print("Usage: dulwich checkout BRANCH_NAME [--force]")
             sys.exit(1)
 
-        r = Repo(".")
         try:
-            porcelain.checkout_branch(r, target=args.branch, force=args.force)
+            porcelain.checkout_branch(".", target=args.branch, force=args.force)
         except porcelain.CheckoutError as e:
             print(f"{e}")
 


### PR DESCRIPTION
This branch / pull request prepared using these commands (except for 2e1791b1e50e05a6332434a3a6f6f25319230989, 17780fff50f32f15ab56939f3c74ca832d568326, cd0450a3e7608b76fcfb623120656a01fdc6f780 and 04136969ac29f3f82a10d9a3c0faec4ab231afc1 that were committed -- but not pushed -- using the `git-scm` tooling).

NB: the `reset` command, despite being modified here to accept a treeish, doesn't appear to reset the HEAD commit correctly (`dulwich log` continues to report from the pre-reset commit, instead of the expected resetted-to treeish).