### PR TITLE
Handle empty commit messages in porcelain.log

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -768,7 +768,7 @@ def print_commit(commit, decode, outstream=sys.stdout) -> None:
     time_str = time.strftime("%a %b %d %Y %H:%M:%S", time_tuple)
     timezone_str = format_timezone(commit.author_timezone).decode("ascii")
     outstream.write("Date:   " + time_str + " " + timezone_str + "\n")
-    if commit.message is not None:
+    if commit.message:
         outstream.write("\n")
         outstream.write(decode(commit.message) + "\n")
         outstream.write("\n")
@@ -908,7 +908,13 @@ def log(
       max_entries: Optional maximum number of entries to display
     """
     with open_repo_closing(repo) as r:
-        walker = r.get_walker(max_entries=max_entries, paths=paths, reverse=reverse)
+        try:
+            include = [r.head()]
+        except KeyError:
+            include = []
+        walker = r.get_walker(
+            include=include, max_entries=max_entries, paths=paths, reverse=reverse
+        )
         for entry in walker:
 
             def decode(x):

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -768,9 +768,10 @@ def print_commit(commit, decode, outstream=sys.stdout) -> None:
     time_str = time.strftime("%a %b %d %Y %H:%M:%S", time_tuple)
     timezone_str = format_timezone(commit.author_timezone).decode("ascii")
     outstream.write("Date:   " + time_str + " " + timezone_str + "\n")
-    outstream.write("\n")
-    outstream.write(decode(commit.message) + "\n")
-    outstream.write("\n")
+    if commit.message is not None:
+        outstream.write("\n")
+        outstream.write(decode(commit.message) + "\n")
+        outstream.write("\n")
 
 
 def print_tag(tag, decode, outstream=sys.stdout) -> None:

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -1082,9 +1082,39 @@ class LogTests(PorcelainTestCase):
             self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
         )
         self.repo.refs[b"HEAD"] = c3.id
+        self.maxDiff = None
         outstream = StringIO()
         porcelain.log(self.repo.path, outstream=outstream)
-        self.assertEqual(3, outstream.getvalue().count("-" * 50))
+        self.assertEqual(
+            outstream.getvalue(),
+            """\
+--------------------------------------------------
+commit: 4a3b887baa9ecb2d054d2469b628aef84e2d74f0
+merge: 7508036b1cfec5aa9cef0d5a7f04abcecfe09112
+Author: Test Author <test@nodomain.com>
+Committer: Test Committer <test@nodomain.com>
+Date:   Fri Jan 01 2010 00:00:00 +0000
+
+Commit 3
+
+--------------------------------------------------
+commit: 7508036b1cfec5aa9cef0d5a7f04abcecfe09112
+Author: Test Author <test@nodomain.com>
+Committer: Test Committer <test@nodomain.com>
+Date:   Fri Jan 01 2010 00:00:00 +0000
+
+Commit 2
+
+--------------------------------------------------
+commit: 11d3cf672a19366435c1983c7340b008ec6b8bf3
+Author: Test Author <test@nodomain.com>
+Committer: Test Committer <test@nodomain.com>
+Date:   Fri Jan 01 2010 00:00:00 +0000
+
+Commit 1
+
+""",
+        )
 
     def test_max_entries(self) -> None:
         c1, c2, c3 = build_commit_graph(
@@ -1094,6 +1124,28 @@ class LogTests(PorcelainTestCase):
         outstream = StringIO()
         porcelain.log(self.repo.path, outstream=outstream, max_entries=1)
         self.assertEqual(1, outstream.getvalue().count("-" * 50))
+
+    def test_no_revisions(self) -> None:
+        outstream = StringIO()
+        porcelain.log(self.repo.path, outstream=outstream)
+        self.assertEqual("", outstream.getvalue())
+
+    def test_empty_message(self) -> None:
+        c1 = make_commit(message="")
+        self.repo.object_store.add_object(c1)
+        self.repo.refs[b"HEAD"] = c1.id
+        outstream = StringIO()
+        porcelain.log(self.repo.path, outstream=outstream)
+        self.assertEqual(
+            outstream.getvalue(),
+            """\
+--------------------------------------------------
+commit: 4a7ad5552fad70647a81fb9a4a923ccefcca4b76
+Author: Test Author <test@nodomain.com>
+Committer: Test Committer <test@nodomain.com>
+Date:   Fri Jan 01 2010 00:00:00 +0000
+""",
+        )
 
 
 class ShowTests(PorcelainTestCase):


### PR DESCRIPTION
Basically #1513 with tests.

Fixes #1510 