### PR TITLE
client: Ensure thin_packs parameter is honored with git protocol v2

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1415,6 +1415,8 @@ class TraditionalGitClient(GitClient):
             if self.protocol_version == 2:
                 proto.write_pkt_line(b"command=fetch\n")
                 proto.write(b"0001")  # delim-pkt
+                if CAPABILITY_THIN_PACK in self._fetch_capabilities:
+                    proto.write(pkt_line(b"thin-pack\n"))
                 if (
                     find_capability(
                         negotiated_capabilities, CAPABILITY_FETCH, CAPABILITY_FILTER
@@ -2693,6 +2695,8 @@ class AbstractHttpGitClient(GitClient):
         )
         if self.protocol_version == 2:
             data = pkt_line(b"command=fetch\n") + b"0001"
+            if CAPABILITY_THIN_PACK in self._fetch_capabilities:
+                data += pkt_line(b"thin-pack\n")
             if (
                 find_capability(
                     negotiated_capabilities, CAPABILITY_FETCH, CAPABILITY_FILTER


### PR DESCRIPTION
When hacking on the Software Heritage git loader, I noticed it was no longer possible to request fetching a thin pack file using latest dulwich release.

After a git bisect session, I identified the regression was due to the recent support of git protocol v2 by dulwich that is now used by default when fetching a pack file (2b975ec).

After some research on the subject, it turns out that with git protocol v2, requesting a thin pack must be done through an argument to the [fetch command](https://git-scm.com/docs/protocol-v2#_fetch) sent to the git server.

I can confirm that thin-pack feature with git protocol v2 works as expected after these small changes .
