### PR TITLE
SubprocessClient: timeout after 60s of inactivity when closing channel

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@
 
  * Bump PyO3 to 0.25. (Jelmer Vernooĳ)
 
+ * In ``SubprocessClient`` time out after 60 seconds
+   when the subprocess hasn't terminated when closing
+   the channel. (Jelmer Vernooĳ)
+
 0.22.8	2025-03-02
 
  * Allow passing in plain strings to ``dulwich.porcelain.tag_create``


### PR DESCRIPTION
This will prevent any indefinite hangs, and instead turn them into exceptions. Hopefully that will help drill down why this is happening for some users.