### PR TITLE
Fix Rust implementation of sorted_tree_items() for submodules (#1325)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,11 @@
    with different format versions by setting the ``core.repositoryformatversion``
    configuration value. (Jelmer Vernooĳ)
 
+ * Fix Rust implementation of ``sorted_tree_items()`` to correctly handle submodules.
+   Previously, submodules (mode 0o160000) were incorrectly treated as directories
+   in the sorting order, causing different results compared to the Python
+   implementation. (Jelmer Vernooĳ, #1325)
+
  * Fix ``porcelain.add()`` to stage both untracked and modified files when no
    paths are specified. Previously, only untracked files were staged, inconsistent
    with Git's behavior. Now behaves like ``git add -A`` when called without paths.

--- a/crates/objects/src/lib.rs
+++ b/crates/objects/src/lib.rs
@@ -28,6 +28,7 @@ use pyo3::types::{PyBytes, PyDict};
 import_exception!(dulwich.errors, ObjectFormatException);
 
 const S_IFDIR: u32 = 0o40000;
+const S_IFMT: u32 = 0o170000;  // File type mask
 
 #[inline]
 fn bytehex(byte: u8) -> u8 {
@@ -96,10 +97,10 @@ fn cmp_with_suffix(a: (u32, &[u8]), b: (u32, &[u8])) -> std::cmp::Ordering {
 
     let c1 =
         a.1.get(len)
-            .map_or_else(|| if a.0 & S_IFDIR != 0 { b'/' } else { 0 }, |&c| c);
+            .map_or_else(|| if (a.0 & S_IFMT) == S_IFDIR { b'/' } else { 0 }, |&c| c);
     let c2 =
         b.1.get(len)
-            .map_or_else(|| if b.0 & S_IFDIR != 0 { b'/' } else { 0 }, |&c| c);
+            .map_or_else(|| if (b.0 & S_IFMT) == S_IFDIR { b'/' } else { 0 }, |&c| c);
     c1.cmp(&c2)
 }
 


### PR DESCRIPTION
The Rust implementation was incorrectly treating submodules (mode 0o160000) as directories during tree sorting. This happened because it used a simple bitwise AND check (mode & S_IFDIR != 0) which matches both directories (0o40000) and submodules (0o160000).

Fixed by properly checking the file type using the S_IFMT mask, matching the Python implementation's behavior with stat.S_ISDIR().

Added test case that reproduces the issue and verifies both implementations now produce identical sorting results.

Fixes #1325