### PR TITLE
docs: Clarify trailing slash requirement for directory ignore checks

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -54,6 +54,11 @@
 
  * Support quote_path flag for ignore checking. (Jelmer Vernooĳ)
 
+ * Clarify documentation for ``IgnoreFilter`` and ``IgnoreFilterManager`` to
+   explicitly state that directory paths should include trailing slashes when
+   checking if they are ignored. This matches Git's behavior and ensures
+   consistent results. (Jelmer Vernooĳ, #972)
+
  * Add support for Git's ``feature.manyFiles`` configuration and index version 4.
    This enables faster Git operations in large repositories through path prefix
    compression (30-50% smaller index files) and optional hash skipping for faster

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -21,6 +21,9 @@
 """Parsing of gitignore files.
 
 For details for the matching rules, see https://git-scm.com/docs/gitignore
+
+Important: When checking if directories are ignored, include a trailing slash in the path.
+For example, use "dir/" instead of "dir" to check if a directory is ignored.
 """
 
 import os.path
@@ -360,6 +363,12 @@ class Pattern:
 
 
 class IgnoreFilter:
+    """Filter to apply gitignore patterns.
+
+    Important: When checking if directories are ignored, include a trailing slash.
+    For example, use is_ignored("dir/") instead of is_ignored("dir").
+    """
+
     def __init__(
         self, patterns: Iterable[bytes], ignorecase: bool = False, path=None
     ) -> None:
@@ -477,7 +486,11 @@ def default_user_ignore_filter_path(config: Config) -> str:
 
 
 class IgnoreFilterManager:
-    """Ignore file manager with Git-compliant behavior."""
+    """Ignore file manager with Git-compliant behavior.
+
+    Important: When checking if directories are ignored, include a trailing slash.
+    For example, use is_ignored("dir/") instead of is_ignored("dir").
+    """
 
     def __init__(
         self,

--- a/tests/compat/test_check_ignore.py
+++ b/tests/compat/test_check_ignore.py
@@ -150,6 +150,16 @@ class CheckIgnoreCompatTestCase(CompatTestCase):
         paths = ["build/", "node_modules/", "build.txt"]
         self._assert_ignore_match(paths)
 
+    def test_issue_972_directory_pattern_with_slash(self) -> None:
+        """Test issue #972: /data/ pattern should match both 'data' and 'data/'."""
+        self._write_gitignore("/data/\n")
+        self._create_dir("data")
+        self._create_file("data/file.txt")
+
+        # Both 'data' and 'data/' should be matched by /data/ pattern
+        paths = ["data", "data/", "data/file.txt"]
+        self._assert_ignore_match(paths)
+
     def test_wildcard_patterns(self) -> None:
         """Test wildcard patterns."""
         self._write_gitignore("*.py[cod]\n__pycache__/\n*.so\n")


### PR DESCRIPTION
When checking if directories are ignored, users must include a trailing slash (e.g., "dir/" instead of "dir") to get correct results. This matches Git's behavior.

Added compatibility test to verify behavior matches Git.

Fixes #972