### PR TITLE
Add unpack-objects plumbing command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 0.22.9	UNRELEASED
 
+ * Add ``unpack-objects`` plumbing command to unpack objects from pack files
+   into loose objects in the repository. This command extracts all objects
+   from a pack file and writes them to the object store as individual files.
+   Available in both ``dulwich.porcelain.unpack_objects()`` and as a CLI
+   command ``dulwich unpack-objects``. (Jelmer Vernooĳ)
+
  * Add support for pack index format version 3. This format supports variable
    hash sizes to enable future SHA-256 support. The implementation includes
    reading and writing v3 indexes with proper hash algorithm identification

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -633,6 +633,16 @@ class cmd_pack_objects(Command):
             f.close()
 
 
+class cmd_unpack_objects(Command):
+    def run(self, args) -> None:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("pack_file", help="Pack file to unpack")
+        args = parser.parse_args(args)
+
+        count = porcelain.unpack_objects(args.pack_file)
+        print(f"Unpacked {count} objects")
+
+
 class cmd_pull(Command):
     def run(self, args) -> None:
         parser = argparse.ArgumentParser()
@@ -975,6 +985,7 @@ commands = {
     "symbolic-ref": cmd_symbolic_ref,
     "submodule": cmd_submodule,
     "tag": cmd_tag,
+    "unpack-objects": cmd_unpack_objects,
     "update-server-info": cmd_update_server_info,
     "upload-pack": cmd_upload_pack,
     "web-daemon": cmd_web_daemon,

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2831,3 +2831,26 @@ def merge(
         return _do_merge(
             r, merge_commit_id, no_commit, no_ff, message, author, committer
         )
+
+
+def unpack_objects(pack_path, target="."):
+    """Unpack objects from a pack file into the repository.
+
+    Args:
+      pack_path: Path to the pack file to unpack
+      target: Path to the repository to unpack into
+
+    Returns:
+      Number of objects unpacked
+    """
+    from .pack import Pack
+
+    with open_repo_closing(target) as r:
+        pack_basename = os.path.splitext(pack_path)[0]
+        with Pack(pack_basename) as pack:
+            count = 0
+            for unpacked in pack.iter_unpacked():
+                obj = unpacked.sha_file()
+                r.object_store.add_object(obj)
+                count += 1
+            return count


### PR DESCRIPTION
This implements the unpack-objects command that extracts all objects from a pack file and writes them as loose objects to the repository's object store.