### PR TITLE
Convert assertion to ApplyDeltaError in apply_delta function

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,12 @@
  * Add annotate support as well as ``annotate`` and ``blame``
    commands.  (#245, Jelmer Vernooĳ)
 
+ * Fix ``apply_delta`` to raise ``ApplyDeltaError`` instead of ``AssertionError``
+   when the source buffer size doesn't match the delta header. This issue only
+   affected the pure Python implementation when the Rust extension was not
+   available. The Rust implementation already raised the correct exception.
+   (#1606, Jelmer Vernooĳ)
+
 0.23.0	2025-06-21
 
  * Add basic ``rebase`` subcommand. (Jelmer Vernooĳ)

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2516,7 +2516,10 @@ def apply_delta(src_buf, delta):
 
     src_size, index = get_delta_header_size(delta, index)
     dest_size, index = get_delta_header_size(delta, index)
-    assert src_size == len(src_buf), f"{src_size} vs {len(src_buf)}"
+    if src_size != len(src_buf):
+        raise ApplyDeltaError(
+            f"Unexpected source buffer size: {src_size} vs {len(src_buf)}"
+        )
     while index < delta_length:
         cmd = ord(delta[index : index + 1])
         index += 1


### PR DESCRIPTION
apply_delta was raising AssertionError instead of ApplyDeltaError in the pure Python implementation when the Rust extension was not available.

Fixes #1606