### PR TITLE
Fix support for short commit hashes in porcelain.reset()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 0.23.1	UNRELEASED
 
+ * Support short commit hashes in ``porcelain.reset()``.
+   (Jelmer Vernooĳ, #1154)
+
  * Support dumb repository access.
    (Jelmer Vernooĳ, #1097)
 

--- a/dulwich/objectspec.py
+++ b/dulwich/objectspec.py
@@ -66,7 +66,15 @@ def parse_tree(repo: "Repo", treeish: Union[bytes, str]) -> "Tree":
         treeish = parse_ref(repo, treeish)
     except KeyError:  # treeish is commit sha
         pass
-    o = repo[treeish]
+    try:
+        o = repo[treeish]
+    except KeyError:
+        # Try parsing as commit (handles short hashes)
+        try:
+            commit = parse_commit(repo, treeish)
+            return repo[commit.tree]
+        except KeyError:
+            raise KeyError(treeish)
     if o.type_name == b"commit":
         return repo[o.tree]
     return o


### PR DESCRIPTION
Modified parse_tree() to handle short commit hashes by falling back to parse_commit() when direct repository lookup fails. This resolves issue

Fixes #1154