### PR TITLE
Fix porcelain.reset --hard to delete files not in target tree

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,11 @@
    available. The Rust implementation already raised the correct exception.
    (#1606, Jelmer Vernooĳ)
 
+ * Fix ``porcelain.reset --hard`` to properly delete files that don't exist in
+   the target tree. Previously, when resetting to a remote branch, files deleted
+   in the remote were not removed locally due to incorrect path normalization
+   on Windows. (#840, Jelmer Vernooĳ)
+
 0.23.0	2025-06-21
 
  * Add basic ``rebase`` subcommand. (Jelmer Vernooĳ)

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -1549,6 +1549,8 @@ def update_working_tree(
                 full_path = os.path.join(root, file)
                 # Get relative path from repo root
                 rel_path = os.path.relpath(full_path, repo_path_str)
+                # Normalize to use forward slashes like Git does internally
+                rel_path = rel_path.replace(os.sep, "/")
                 rel_path_bytes = rel_path.encode()
 
                 # If this file is not in the target tree, remove it


### PR DESCRIPTION
When resetting to a remote branch, files that were deleted in the remote were not being removed locally due to incorrect path normalization on Windows. The issue was that paths were being compared with different separators (backslash vs forward slash).

This fix normalizes paths to use forward slashes consistently, matching Git's internal representation, ensuring files are properly deleted when they don't exist in the target tree.

Fixes #840