### PR TITLE
Add comprehensive include/includeIf support to config parser

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,9 @@
    in the remote were not removed locally due to incorrect path normalization
    on Windows. (#840, Jelmer Vernooĳ)
 
+ * Add support for includes in configuration files.
+   (#1216, Jelmer Vernooĳ)
+
 0.23.0	2025-06-21
 
  * Add basic ``rebase`` subcommand. (Jelmer Vernooĳ)

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1727,7 +1727,8 @@ class Repo(BaseRepo):
 
         path = os.path.join(self.commondir(), "config.worktree")
         try:
-            return ConfigFile.from_path(path)
+            # Pass the git directory (not working tree) for includeIf gitdir conditions
+            return ConfigFile.from_path(path, repo_dir=self._controldir)
         except FileNotFoundError:
             cf = ConfigFile()
             cf.path = path
@@ -1742,7 +1743,8 @@ class Repo(BaseRepo):
 
         path = os.path.join(self._commondir, "config")
         try:
-            return ConfigFile.from_path(path)
+            # Pass the git directory (not working tree) for includeIf gitdir conditions
+            return ConfigFile.from_path(path, repo_dir=self._controldir)
         except FileNotFoundError:
             ret = ConfigFile()
             ret.path = path


### PR DESCRIPTION
This implements full support for Git's include and includeIf directives:

Features:
- Basic include functionality with path resolution
- includeIf with gitdir condition evaluation (including pattern matching)
- Circular include detection and prevention
- Include depth limiting to prevent infinite recursion
- Proper handling of relative and absolute include paths
- Case-insensitive gitdir matching (gitdir/i)
- Graceful handling of missing include files

The implementation follows Git's behavior as documented in git-config(1) and supports the most commonly used include scenarios.

Fixes #1216