### PR TITLE
porcelain.status: Support untracked_files="normal" and make it the default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 0.23.1	UNRELEASED
 
+ * Support ``untracked_files="normal"`` argument to ``porcelain.status``,
+   and make this the default.
+   (Jelmer Vernooĳ, #835)
+
  * Return symrefs from ls_refs. (Jelmer Vernooĳ, #863)
 
  * Support short commit hashes in ``porcelain.reset()``.


### PR DESCRIPTION
Fixes #835