### PR TITLE
Fix intermittent ConnectionResetError in TCP client tests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@
    and make this the default.
    (Jelmer Vernooĳ, #835)
 
+ * Fix ConnectionResetError when using TCPGitClient with git daemon on macOS/Windows.
+   Use socket recv() directly instead of buffered file objects to avoid losing data.
+   (Jelmer Vernooĳ, #1015)
+
  * Fix KeyError when pulling from a shallow clone. Handle missing commits
    gracefully in graph traversal operations for shallow repositories.
    (Jelmer Vernooĳ, #813)


### PR DESCRIPTION
The issue was caused by abrupt termination of git-daemon during test teardown, which left sockets in an inconsistent state. This was particularly problematic on Windows where TerminateProcess was used to forcefully kill the daemon.

Fixes #1015