### PR TITLE
Fix parse_commit to properly dereference annotated tags

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
    and make this the default.
    (Jelmer Vernooĳ, #835)
 
+ * Fix ``parse_commit`` to properly dereference annotated tags when
+   checking out tags. Previously, checking out an annotated tag would
+   fail with a KeyError.
+   (Jelmer Vernooĳ, #1638)
+
  * Fix KeyError when pulling from a shallow clone. Handle missing commits
    gracefully in graph traversal operations for shallow repositories.
    (Jelmer Vernooĳ, #813)


### PR DESCRIPTION
Previously, checking out an annotated tag would fail with a KeyError because parse_commit() didn't dereference tag objects to their target commits. This fix adds tag dereferencing to all code paths in parse_commit(), ensuring that annotated tags are properly resolved to their target commits.

Fixes #1638