### PR TITLE
fix: handle missing sshCommand in config

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2233,10 +2233,14 @@ class SSHGitClient(TraditionalGitClient):
 
             # Fall back to config if no environment variable set
             if not self.ssh_command and config is not None:
-                config_ssh_command = config.get((b"core",), b"sshCommand")
-                self.ssh_command = (
-                    config_ssh_command.decode() if config_ssh_command else None
-                )
+                try:
+                    config_ssh_command = config.get((b"core",), b"sshCommand")
+                    self.ssh_command = (
+                        config_ssh_command.decode() if config_ssh_command else None
+                    )
+                except KeyError:
+                    pass
+
         super().__init__(**kwargs)
         self.alternative_paths: dict[bytes, bytes] = {}
         if vendor is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -532,6 +532,12 @@ class TestGetTransportAndPath(TestCase):
         from dulwich.config import ConfigDict
 
         config = ConfigDict()
+        c, path = get_transport_and_path(
+            "ssh://git@github.com/user/repo.git", config=config
+        )
+        self.assertIsInstance(c, SSHGitClient)
+        self.assertIsNone(c.ssh_command)
+
         config.set((b"core",), b"sshCommand", b"custom-ssh -o CustomOption=yes")
 
         c, path = get_transport_and_path(


### PR DESCRIPTION
Adds a check for KeyError when accessing the sshCommand in the config, which may or may not be present.

Following snippet of code was failing for us after 0.23 release (due to #1550).

```
from dulwich.porcelain import clone

clone("git@github.com:iterative/example-get-started.git")
```

Closes https://github.com/iterative/dvc/issues/10788.