### PR TITLE
Some fixes for the dumb transfer protocol

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2813,9 +2813,9 @@ class AbstractHttpGitClient(GitClient):
             wants = determine_wants(refs)
         if wants is not None:
             wants = [cid for cid in wants if cid != ZERO_SHA]
-        if not wants:
+        if not wants and not self.dumb:
             return FetchPackResult(refs, symrefs, agent)
-        if self.dumb:
+        elif self.dumb:
             # Use dumb HTTP protocol
             from .dumb import DumbRemoteHTTPRepo
 
@@ -2828,6 +2828,8 @@ class AbstractHttpGitClient(GitClient):
                     graph_walker, lambda refs: wants, progress=progress, depth=depth
                 )
             )
+
+            symrefs[b"HEAD"] = dumb_repo.get_head()
 
             # Write pack data
             if pack_data:

--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -461,4 +461,4 @@ class DumbRemoteHTTPRepo(BaseRepo):
                     to_fetch.add(item_sha)
 
             if progress:
-                progress(f"Fetching objects: {len(seen)} done")
+                progress(f"Fetching objects: {len(seen)} done\n".encode())

--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -398,6 +398,17 @@ class DumbRemoteHTTPRepo(BaseRepo):
 
         return dict(self._refs)
 
+    def get_head(self) -> Ref:
+        head_resp_bytes = self._fetch_url("HEAD")
+        head_split = head_resp_bytes.replace(b"\n", b"").split(b" ")
+        head_target = head_split[1] if len(head_split) > 1 else head_split[0]
+        # handle HEAD legacy format containing a commit id instead of a ref name
+        for ref_name, ret_target in self.get_refs().items():
+            if ret_target == head_target:
+                head_target = ref_name
+                break
+        return head_target
+
     def get_peeled(self, ref: Ref) -> ObjectID:
         """Get the peeled value of a ref."""
         # For dumb HTTP, we don't have peeled refs readily available

--- a/tests/compat/test_dumb.py
+++ b/tests/compat/test_dumb.py
@@ -101,8 +101,10 @@ class DumbHTTPGitServer:
         return f"http://127.0.0.1:{self.port}"
 
 
-class DumbHTTPClientTests(CompatTestCase):
+class DumbHTTPClientNoPackTests(CompatTestCase):
     """Tests for dumb HTTP client against real git repositories."""
+
+    with_pack = False
 
     def setUp(self):
         super().setUp()
@@ -124,12 +126,17 @@ class DumbHTTPClientTests(CompatTestCase):
         )
         run_git_or_fail(["config", "user.name", "Test User"], cwd=self.work_path)
 
-        # Create initial commit
-        test_file = os.path.join(self.work_path, "test.txt")
-        with open(test_file, "w") as f:
-            f.write("Hello, world!\n")
-        run_git_or_fail(["add", "test.txt"], cwd=self.work_path)
-        run_git_or_fail(["commit", "-m", "Initial commit"], cwd=self.work_path)
+        nb_files = 10
+        if self.with_pack:
+            # adding more files will create a pack file in the repository
+            nb_files = 50
+
+        for i in range(nb_files):
+            test_file = os.path.join(self.work_path, f"test{i}.txt")
+            with open(test_file, "w") as f:
+                f.write(f"Hello, world {i}!\n")
+            run_git_or_fail(["add", f"test{i}.txt"], cwd=self.work_path)
+            run_git_or_fail(["commit", "-m", f"Commit {i}"], cwd=self.work_path)
 
         # Push to origin
         run_git_or_fail(
@@ -144,6 +151,12 @@ class DumbHTTPClientTests(CompatTestCase):
         self.server = DumbHTTPGitServer(self.origin_path)
         self.server.start()
         self.addCleanup(self.server.stop)
+
+        pack_dir = os.path.join(self.origin_path, "objects", "pack")
+        if self.with_pack:
+            assert os.listdir(pack_dir)
+        else:
+            assert not os.listdir(pack_dir)
 
     @skipUnless(
         sys.platform != "win32", "git clone from Python HTTPServer fails on Windows"
@@ -181,10 +194,10 @@ class DumbHTTPClientTests(CompatTestCase):
             dest_repo.reset_index()
 
             # Verify the clone
-            test_file = os.path.join(dest_path, "test.txt")
+            test_file = os.path.join(dest_path, "test0.txt")
             self.assertTrue(os.path.exists(test_file))
             with open(test_file) as f:
-                self.assertEqual("Hello, world!\n", f.read())
+                self.assertEqual("Hello, world 0!\n", f.read())
         finally:
             # Ensure repo is closed before cleanup
             dest_repo.close()
@@ -285,3 +298,7 @@ class DumbHTTPClientTests(CompatTestCase):
         finally:
             # Ensure repo is closed before cleanup
             dest_repo.close()
+
+
+class DumbHTTPClientWithPackTests(DumbHTTPClientNoPackTests):
+    with_pack = True

--- a/tests/compat/test_dumb.py
+++ b/tests/compat/test_dumb.py
@@ -29,6 +29,7 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from unittest import skipUnless
 
 from dulwich.client import HttpGitClient
+from dulwich.porcelain import clone
 from dulwich.repo import Repo
 from tests.compat.utils import (
     CompatTestCase,
@@ -143,6 +144,14 @@ class DumbHTTPClientTests(CompatTestCase):
         self.server = DumbHTTPGitServer(self.origin_path)
         self.server.start()
         self.addCleanup(self.server.stop)
+
+    @skipUnless(
+        sys.platform != "win32", "git clone from Python HTTPServer fails on Windows"
+    )
+    def test_clone_dumb(self):
+        dest_path = os.path.join(self.temp_dir, "cloned")
+        repo = clone(self.server.url, dest_path)
+        assert b"HEAD" in repo
 
     def test_clone_from_dumb_http(self):
         """Test cloning from a dumb HTTP server."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1305,6 +1305,7 @@ class HttpGitClientTests(TestCase):
         info_refs_content = (
             b"0123456789abcdef0123456789abcdef01234567\trefs/heads/master\n"
         )
+        head_content = b"ref: refs/heads/master"
 
         # Create a blob object for testing
         blob_content = b"Hello, dumb HTTP!"
@@ -1316,6 +1317,11 @@ class HttpGitClientTests(TestCase):
         blob_compressed = zlib.compress(blob_obj_data)
 
         responses = {
+            "/HEAD": {
+                "status": 200,
+                "content": head_content,
+                "content_type": "text/plain",
+            },
             "/git-upload-pack": {
                 "status": 404,
                 "content": b"Not Found",

--- a/tests/test_dumb.py
+++ b/tests/test_dumb.py
@@ -280,7 +280,12 @@ fedcba9876543210fedcba9876543210fedcba98\trefs/tags/v1.0
         def determine_wants(refs):
             return [blob_sha]
 
-        result = list(self.repo.fetch_pack_data(graph_walker, determine_wants))
+        def progress(msg):
+            assert isinstance(msg, bytes)
+
+        result = list(
+            self.repo.fetch_pack_data(graph_walker, determine_wants, progress)
+        )
         self.assertEqual(1, len(result))
         self.assertEqual(Blob.type_num, result[0].pack_type_num)
         self.assertEqual([blob.as_raw_string()], result[0].obj_chunks)


### PR DESCRIPTION
I noticed the dumb transport protocol was added in latest dulwich release and tried to use that new feature in the Software Heritage git loader so we could remove our [homemade support](https://gitlab.softwareheritage.org/swh/devel/swh-loader-git/-/blob/67b322effb00e81d7696a0ce676ec0d3241143ef/swh/loader/git/dumb.py) of it and only relies on dulwich.

I stumbled across a couple of bugs after plugging dulwich dumb transfer protocol into the SWH loader, this pull request fixes the issue I observed and adds more tests.

After these fixes, the loader works fine when encountering a repository that only offers dumb transfer protocol. Almost all of our git loader tests are still passing apart a couple that need some mocking adaptation due to the changes in the loader implementation.