### PR TITLE
Add callback-based authentication support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,13 @@
    functionality works as expected.
    (Jelmer Vernooĳ, #780)
 
+ * Add callback-based authentication support for HTTP and proxy authentication
+   in ``Urllib3HttpGitClient``. This allows applications to handle
+   authentication dynamically without intercepting exceptions. Callbacks
+   receive the authentication scheme information (via WWW-Authenticate or
+   Proxy-Authenticate headers) and can provide credentials or cancel.
+   (Jelmer Vernooĳ, #822)
+
 0.23.1	2025-06-30
 
  * Support ``untracked_files="normal"`` argument to ``porcelain.status``,

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2325,14 +2325,92 @@ def default_user_agent_string():
     return "git/dulwich/{}".format(".".join([str(x) for x in dulwich.__version__]))
 
 
+class AuthCallbackPoolManager:
+    """Pool manager wrapper that handles authentication callbacks."""
+
+    def __init__(self, pool_manager, auth_callback=None, proxy_auth_callback=None):
+        self._pool_manager = pool_manager
+        self._auth_callback = auth_callback
+        self._proxy_auth_callback = proxy_auth_callback
+        self._auth_attempts = {}
+
+    def __getattr__(self, name):
+        # Delegate all other attributes to the wrapped pool manager
+        return getattr(self._pool_manager, name)
+
+    def request(self, method, url, *args, **kwargs):
+        """Make HTTP request with authentication callback support."""
+        max_attempts = 3
+        attempts = self._auth_attempts.get(url, 0)
+
+        while attempts < max_attempts:
+            response = self._pool_manager.request(method, url, *args, **kwargs)
+
+            if response.status == 401 and self._auth_callback:
+                # HTTP authentication required
+                www_authenticate = response.headers.get("WWW-Authenticate", "")
+                attempts += 1
+                self._auth_attempts[url] = attempts
+
+                # Call the authentication callback
+                credentials = self._auth_callback(url, www_authenticate, attempts)
+                if credentials:
+                    # Update request with new credentials
+                    import urllib3.util
+
+                    auth_header = urllib3.util.make_headers(
+                        basic_auth=f"{credentials['username']}:{credentials.get('password', '')}"
+                    )
+                    if "headers" in kwargs:
+                        kwargs["headers"].update(auth_header)
+                    else:
+                        kwargs["headers"] = auth_header
+                    # Retry the request
+                    continue
+
+            elif response.status == 407 and self._proxy_auth_callback:
+                # Proxy authentication required
+                proxy_authenticate = response.headers.get("Proxy-Authenticate", "")
+                attempts += 1
+                self._auth_attempts[url] = attempts
+
+                # Call the proxy authentication callback
+                credentials = self._proxy_auth_callback(
+                    url, proxy_authenticate, attempts
+                )
+                if credentials:
+                    # Update request with new proxy credentials
+                    import urllib3.util
+
+                    proxy_auth_header = urllib3.util.make_headers(
+                        proxy_basic_auth=f"{credentials['username']}:{credentials.get('password', '')}"
+                    )
+                    if "headers" in kwargs:
+                        kwargs["headers"].update(proxy_auth_header)
+                    else:
+                        kwargs["headers"] = proxy_auth_header
+                    # Retry the request
+                    continue
+
+            # Clear attempts on success or non-auth failure
+            if url in self._auth_attempts:
+                del self._auth_attempts[url]
+            return response
+
+        # Max attempts reached
+        return response
+
+
 def default_urllib3_manager(
     config,
     pool_manager_cls=None,
     proxy_manager_cls=None,
     base_url=None,
     timeout=None,
+    auth_callback=None,
+    proxy_auth_callback=None,
     **override_kwargs,
-) -> Union["urllib3.ProxyManager", "urllib3.PoolManager"]:
+) -> Union["urllib3.ProxyManager", "urllib3.PoolManager", "AuthCallbackPoolManager"]:
     """Return urllib3 connection pool manager.
 
     Honour detected proxy configurations.
@@ -2340,12 +2418,19 @@ def default_urllib3_manager(
     Args:
       config: `dulwich.config.ConfigDict` instance with Git configuration.
       timeout: Timeout for HTTP requests in seconds
+      auth_callback: Callback function for HTTP authentication.
+        Called with (url, www_authenticate_header, attempt_number).
+        Should return {'username': str, 'password': str} or None.
+      proxy_auth_callback: Callback function for proxy authentication.
+        Called with (url, proxy_authenticate_header, attempt_number).
+        Should return {'username': str, 'password': str} or None.
       override_kwargs: Additional arguments for `urllib3.ProxyManager`
 
     Returns:
       Either pool_manager_cls (defaults to `urllib3.ProxyManager`) instance for
       proxy configurations, proxy_manager_cls
-      (defaults to `urllib3.PoolManager`) instance otherwise
+      (defaults to `urllib3.PoolManager`) instance otherwise.
+      If auth callbacks are provided, returns AuthCallbackPoolManager wrapper.
 
     """
     proxy_server = user_agent = None
@@ -2416,12 +2501,37 @@ def default_urllib3_manager(
 
     import urllib3
 
+    # Check for proxy authentication method configuration
+    proxy_auth_method = None
+    if config is not None:
+        try:
+            proxy_auth_method = config.get(b"http", b"proxyAuthMethod")
+            if proxy_auth_method and isinstance(proxy_auth_method, bytes):
+                proxy_auth_method = proxy_auth_method.decode().lower()
+        except KeyError:
+            pass
+
+    # Check environment variable override
+    env_proxy_auth = os.environ.get("GIT_HTTP_PROXY_AUTHMETHOD")
+    if env_proxy_auth:
+        proxy_auth_method = env_proxy_auth.lower()
+
     if proxy_server is not None:
         if proxy_manager_cls is None:
             proxy_manager_cls = urllib3.ProxyManager
         if not isinstance(proxy_server, str):
             proxy_server = proxy_server.decode()
         proxy_server_url = urlparse(proxy_server)
+
+        # Validate proxy auth method if specified
+        if proxy_auth_method and proxy_auth_method not in ("anyauth", "basic"):
+            # Only basic and anyauth are currently supported
+            # Other methods like digest, negotiate, ntlm would require additional libraries
+            raise NotImplementedError(
+                f"Proxy authentication method '{proxy_auth_method}' is not supported. "
+                "Only 'basic' and 'anyauth' are currently supported."
+            )
+
         if proxy_server_url.username is not None:
             proxy_headers = urllib3.make_headers(
                 proxy_basic_auth=f"{proxy_server_url.username}:{proxy_server_url.password or ''}"  # type: ignore
@@ -2435,6 +2545,10 @@ def default_urllib3_manager(
         if pool_manager_cls is None:
             pool_manager_cls = urllib3.PoolManager
         manager = pool_manager_cls(headers=headers, **kwargs)
+
+    # Wrap with auth callback support if callbacks are provided
+    if auth_callback or proxy_auth_callback:
+        manager = AuthCallbackPoolManager(manager, auth_callback, proxy_auth_callback)
 
     return manager
 
@@ -2946,6 +3060,23 @@ def _wrap_urllib3_exceptions(func):
 
 
 class Urllib3HttpGitClient(AbstractHttpGitClient):
+    """HTTP Git client using urllib3.
+
+    Supports callback-based authentication for both HTTP and proxy authentication,
+    allowing dynamic credential handling without intercepting exceptions.
+
+    Example:
+        >>> def auth_callback(url, www_authenticate, attempt):
+        ...     # Parse www_authenticate header to determine auth scheme
+        ...     # Return credentials or None to cancel
+        ...     return {"username": "user", "password": "pass"}
+        >>>
+        >>> client = Urllib3HttpGitClient(
+        ...     "https://github.com/private/repo.git",
+        ...     auth_callback=auth_callback
+        ... )
+    """
+
     def __init__(
         self,
         base_url,
@@ -2955,18 +3086,33 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
         username=None,
         password=None,
         timeout=None,
+        auth_callback=None,
+        proxy_auth_callback=None,
         **kwargs,
     ) -> None:
         self._username = username
         self._password = password
         self._timeout = timeout
+        self._auth_callback = auth_callback
+        self._proxy_auth_callback = proxy_auth_callback
 
         if pool_manager is None:
             self.pool_manager = default_urllib3_manager(
-                config, base_url=base_url, timeout=timeout
+                config,
+                base_url=base_url,
+                timeout=timeout,
+                auth_callback=auth_callback,
+                proxy_auth_callback=proxy_auth_callback,
             )
         else:
-            self.pool_manager = pool_manager
+            # If a custom pool_manager is provided and callbacks are specified,
+            # wrap it with AuthCallbackPoolManager
+            if auth_callback or proxy_auth_callback:
+                self.pool_manager = AuthCallbackPoolManager(
+                    pool_manager, auth_callback, proxy_auth_callback
+                )
+            else:
+                self.pool_manager = pool_manager
 
         if username is not None:
             # No escaping needed: ":" is not allowed in username:

--- a/examples/auth_callback.py
+++ b/examples/auth_callback.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Example of using callback-based authentication with dulwich HTTP client.
+
+This example demonstrates how to use the new callback-based authentication
+feature to handle HTTP and proxy authentication dynamically.
+
+Note: Dulwich currently supports 'basic' and 'anyauth' proxy authentication
+methods via the http.proxyAuthMethod git config option or the
+GIT_HTTP_PROXY_AUTHMETHOD environment variable. Other methods like 'digest',
+'negotiate', and 'ntlm' will raise NotImplementedError.
+"""
+
+from dulwich.client import HttpGitClient
+
+
+def my_auth_callback(url, www_authenticate, attempt):
+    """Callback function for HTTP authentication.
+
+    Args:
+        url: The URL that requires authentication
+        www_authenticate: The WWW-Authenticate header value from the server
+        attempt: The attempt number (starts at 1)
+
+    Returns:
+        dict: Credentials with 'username' and 'password' keys, or None to cancel
+    """
+    print(f"Authentication required for {url}")
+    print(f"Server says: {www_authenticate}")
+    print(f"Attempt {attempt} of 3")
+
+    # In a real application, you might:
+    # - Prompt the user for credentials
+    # - Look up credentials in a password manager
+    # - Parse the www_authenticate header to determine the auth scheme
+
+    if attempt <= 2:
+        # Example: return hardcoded credentials for demo
+        return {"username": "myuser", "password": "mypassword"}
+    else:
+        # Give up after 2 attempts
+        return None
+
+
+def my_proxy_auth_callback(url, proxy_authenticate, attempt):
+    """Callback function for proxy authentication.
+
+    Args:
+        url: The URL being accessed through the proxy
+        proxy_authenticate: The Proxy-Authenticate header value from the proxy
+        attempt: The attempt number (starts at 1)
+
+    Returns:
+        dict: Credentials with 'username' and 'password' keys, or None to cancel
+    """
+    print(f"Proxy authentication required for accessing {url}")
+    print(f"Proxy says: {proxy_authenticate}")
+
+    # Return proxy credentials
+    return {"username": "proxyuser", "password": "proxypass"}
+
+
+def main():
+    # Create an HTTP Git client with authentication callbacks
+    client = HttpGitClient(
+        "https://github.com/private/repo.git",
+        auth_callback=my_auth_callback,
+        proxy_auth_callback=my_proxy_auth_callback,
+    )
+
+    # Now when you use the client, it will call your callbacks
+    # if authentication is required
+    try:
+        # Example: fetch refs from the repository
+        refs = client.fetch_refs("https://github.com/private/repo.git")
+        print(f"Successfully fetched refs: {refs}")
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,13 +27,14 @@ import tempfile
 import warnings
 from io import BytesIO
 from typing import NoReturn
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import quote as urlquote
 from urllib.parse import urlparse
 
 import dulwich
 from dulwich import client
 from dulwich.client import (
+    AuthCallbackPoolManager,
     FetchPackResult,
     GitProtocolError,
     HangupException,
@@ -529,7 +530,6 @@ class TestGetTransportAndPath(TestCase):
 
     def test_ssh_with_config(self) -> None:
         # Test that core.sshCommand from config is passed to SSHGitClient
-        from dulwich.config import ConfigDict
 
         config = ConfigDict()
         c, path = get_transport_and_path(
@@ -844,7 +844,6 @@ class SSHGitClientTests(TestCase):
 
     def test_ssh_command_config(self) -> None:
         # Test core.sshCommand config setting
-        from dulwich.config import ConfigDict
 
         # No config, no environment - should be None
         self.overrideEnv("GIT_SSH", None)
@@ -1433,7 +1432,6 @@ class HttpGitClientTests(TestCase):
 
     def test_timeout_from_config(self) -> None:
         """Test that timeout can be configured via git config."""
-        from dulwich.config import ConfigDict
 
         url = "https://github.com/jelmer/dulwich"
         config = ConfigDict()
@@ -1447,7 +1445,6 @@ class HttpGitClientTests(TestCase):
 
     def test_timeout_parameter_precedence(self) -> None:
         """Test that explicit timeout parameter takes precedence over config."""
-        from dulwich.config import ConfigDict
 
         url = "https://github.com/jelmer/dulwich"
         config = ConfigDict()
@@ -1455,6 +1452,24 @@ class HttpGitClientTests(TestCase):
 
         c = HttpGitClient(url, config=config, timeout=15)
         self.assertEqual(c._timeout, 15)
+
+    def test_auth_callbacks(self) -> None:
+        url = "https://github.com/jelmer/dulwich"
+
+        def auth_callback(url, www_authenticate, attempt):
+            return {"username": "user", "password": "pass"}
+
+        def proxy_auth_callback(url, proxy_authenticate, attempt):
+            return {"username": "proxy_user", "password": "proxy_pass"}
+
+        c = HttpGitClient(
+            url, auth_callback=auth_callback, proxy_auth_callback=proxy_auth_callback
+        )
+
+        # Check that the pool manager is wrapped with AuthCallbackPoolManager
+        self.assertIsInstance(c.pool_manager, AuthCallbackPoolManager)
+        self.assertEqual(c._auth_callback, auth_callback)
+        self.assertEqual(c._proxy_auth_callback, proxy_auth_callback)
 
 
 class TCPGitClientTests(TestCase):
@@ -1476,10 +1491,191 @@ class TCPGitClientTests(TestCase):
         self.assertEqual("git://github.com:9090/jelmer/dulwich", url)
 
 
+class AuthCallbackPoolManagerTest(TestCase):
+    def test_http_auth_callback(self) -> None:
+        # Create a mock pool manager
+        mock_pool_manager = Mock()
+        mock_response = Mock()
+
+        # First request returns 401
+        mock_response.status = 401
+        mock_response.headers = {"WWW-Authenticate": 'Basic realm="test"'}
+
+        # Second request (after auth) returns 200
+        mock_response_success = Mock()
+        mock_response_success.status = 200
+        mock_response_success.headers = {}
+
+        mock_pool_manager.request = MagicMock(
+            side_effect=[mock_response, mock_response_success]
+        )
+
+        # Auth callback that returns credentials
+        def auth_callback(url, www_authenticate, attempt):
+            if attempt == 1:
+                return {"username": "testuser", "password": "testpass"}
+            return None
+
+        # Create the wrapper
+        auth_manager = AuthCallbackPoolManager(
+            mock_pool_manager, auth_callback=auth_callback
+        )
+
+        # Make request
+        result = auth_manager.request("GET", "https://example.com/test")
+
+        # Verify two requests were made
+        self.assertEqual(mock_pool_manager.request.call_count, 2)
+
+        # Verify auth headers were added on second request
+        second_call_kwargs = mock_pool_manager.request.call_args_list[1][1]
+        self.assertIn("headers", second_call_kwargs)
+        # urllib3 returns lowercase header names
+        self.assertIn("authorization", second_call_kwargs["headers"])
+
+        # Result should be the successful response
+        self.assertEqual(result, mock_response_success)
+
+    def test_proxy_auth_callback(self) -> None:
+        # Create a mock pool manager
+        mock_pool_manager = Mock()
+        mock_response = Mock()
+
+        # First request returns 407
+        mock_response.status = 407
+        mock_response.headers = {"Proxy-Authenticate": 'Basic realm="proxy"'}
+
+        # Second request (after auth) returns 200
+        mock_response_success = Mock()
+        mock_response_success.status = 200
+        mock_response_success.headers = {}
+
+        mock_pool_manager.request = MagicMock(
+            side_effect=[mock_response, mock_response_success]
+        )
+
+        # Proxy auth callback that returns credentials
+        def proxy_auth_callback(url, proxy_authenticate, attempt):
+            if attempt == 1:
+                return {"username": "proxyuser", "password": "proxypass"}
+            return None
+
+        # Create the wrapper
+        auth_manager = AuthCallbackPoolManager(
+            mock_pool_manager, proxy_auth_callback=proxy_auth_callback
+        )
+
+        # Make request
+        result = auth_manager.request("GET", "https://example.com/test")
+
+        # Verify two requests were made
+        self.assertEqual(mock_pool_manager.request.call_count, 2)
+
+        # Verify proxy auth headers were added on second request
+        second_call_kwargs = mock_pool_manager.request.call_args_list[1][1]
+        self.assertIn("headers", second_call_kwargs)
+        # urllib3 returns lowercase header names
+        self.assertIn("proxy-authorization", second_call_kwargs["headers"])
+
+        # Result should be the successful response
+        self.assertEqual(result, mock_response_success)
+
+    def test_max_attempts(self) -> None:
+        # Create a mock pool manager that always returns 401
+        mock_pool_manager = Mock()
+        mock_response = Mock()
+        mock_response.status = 401
+        mock_response.headers = {"WWW-Authenticate": 'Basic realm="test"'}
+        mock_pool_manager.request.return_value = mock_response
+
+        # Auth callback that always returns credentials
+        def auth_callback(url, www_authenticate, attempt):
+            return {"username": "user", "password": "pass"}
+
+        # Create the wrapper
+        auth_manager = AuthCallbackPoolManager(
+            mock_pool_manager, auth_callback=auth_callback
+        )
+
+        # Make request
+        result = auth_manager.request("GET", "https://example.com/test")
+
+        # Should have made 3 attempts (initial + 2 retries)
+        self.assertEqual(mock_pool_manager.request.call_count, 3)
+
+        # Result should be the last 401 response
+        self.assertEqual(result.status, 401)
+
+
 class DefaultUrllib3ManagerTest(TestCase):
     def test_no_config(self) -> None:
         manager = default_urllib3_manager(config=None)
         self.assertEqual(manager.connection_pool_kw["cert_reqs"], "CERT_REQUIRED")
+
+    def test_auth_callbacks(self) -> None:
+        def auth_callback(url, www_authenticate, attempt):
+            return {"username": "user", "password": "pass"}
+
+        def proxy_auth_callback(url, proxy_authenticate, attempt):
+            return {"username": "proxy_user", "password": "proxy_pass"}
+
+        manager = default_urllib3_manager(
+            config=None,
+            auth_callback=auth_callback,
+            proxy_auth_callback=proxy_auth_callback,
+        )
+        self.assertIsInstance(manager, AuthCallbackPoolManager)
+        self.assertEqual(manager._auth_callback, auth_callback)
+        self.assertEqual(manager._proxy_auth_callback, proxy_auth_callback)
+
+    def test_proxy_auth_method_unsupported(self) -> None:
+        import os
+
+
+        # Test with config
+        config = ConfigDict()
+        config.set((b"http",), b"proxy", b"http://user@proxy.example.com:8080")
+        config.set((b"http",), b"proxyAuthMethod", b"digest")
+
+        with self.assertRaises(NotImplementedError) as cm:
+            default_urllib3_manager(config=config)
+
+        self.assertIn("digest", str(cm.exception))
+        self.assertIn("not supported", str(cm.exception))
+
+        # Test with environment variable
+        config = ConfigDict()
+        config.set((b"http",), b"proxy", b"http://user@proxy.example.com:8080")
+
+        old_env = os.environ.get("GIT_HTTP_PROXY_AUTHMETHOD")
+        try:
+            os.environ["GIT_HTTP_PROXY_AUTHMETHOD"] = "ntlm"
+            with self.assertRaises(NotImplementedError) as cm:
+                default_urllib3_manager(config=config)
+
+            self.assertIn("ntlm", str(cm.exception))
+            self.assertIn("not supported", str(cm.exception))
+        finally:
+            if old_env is None:
+                os.environ.pop("GIT_HTTP_PROXY_AUTHMETHOD", None)
+            else:
+                os.environ["GIT_HTTP_PROXY_AUTHMETHOD"] = old_env
+
+    def test_proxy_auth_method_supported(self) -> None:
+
+        # Test basic auth method
+        config = ConfigDict()
+        config.set((b"http",), b"proxy", b"http://user@proxy.example.com:8080")
+        config.set((b"http",), b"proxyAuthMethod", b"basic")
+
+        # Should not raise
+        manager = default_urllib3_manager(config=config)
+        self.assertIsNotNone(manager)
+
+        # Test anyauth (default)
+        config.set((b"http",), b"proxyAuthMethod", b"anyauth")
+        manager = default_urllib3_manager(config=config)
+        self.assertIsNotNone(manager)
 
     def test_config_no_proxy(self) -> None:
         import urllib3
@@ -1723,7 +1919,6 @@ class DefaultUrllib3ManagerTest(TestCase):
 
     def test_timeout_from_config(self) -> None:
         """Test that timeout can be configured via git config."""
-        from dulwich.config import ConfigDict
 
         config = ConfigDict()
         config.set((b"http",), b"timeout", b"25")
@@ -1733,7 +1928,6 @@ class DefaultUrllib3ManagerTest(TestCase):
 
     def test_timeout_parameter_precedence(self) -> None:
         """Test that explicit timeout parameter takes precedence over config."""
-        from dulwich.config import ConfigDict
 
         config = ConfigDict()
         config.set((b"http",), b"timeout", b"25")


### PR DESCRIPTION
Implement callback-based authentication for HTTP and proxy authentication in Urllib3HttpGitClient. This provides a cleaner alternative to exception interception for handling authentication challenges.

The implementation wraps the urllib3 pool manager with AuthCallbackPoolManager which intercepts 401/407 responses and invokes the appropriate callbacks.

Fixes #822