### PR TITLE
Apply filters when materializing files in sparse checkout

### DIFF
--- a/dulwich/sparse_patterns.py
+++ b/dulwich/sparse_patterns.py
@@ -246,6 +246,10 @@ def apply_included_paths(
                 ensure_dir_exists(os.path.dirname(full_path))
                 from .objects import Blob
 
+                # Apply checkout normalization if normalizer is available
+                if normalizer and isinstance(blob, Blob):
+                    blob = normalizer.checkout_normalize(blob, path_bytes)
+
                 with open(full_path, "wb") as f:
                     if isinstance(blob, Blob):
                         f.write(blob.data)


### PR DESCRIPTION
The sparse checkout code was correctly getting a blob normalizer but only using it for checking modifications (checkin normalization). Files materialized during sparse checkout operations should also have checkout normalization applied to ensure proper line endings and other transformations.

This fix ensures that when sparse checkout materializes missing files, they go through the same filter pipeline as regular checkout operations.