### PR TITLE
Apply filters during checkout operations

### DIFF
--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -3025,6 +3025,9 @@ def checkout(
                 with open(target, mode) as f:
                     f.write(source)
 
+        # Get blob normalizer for line ending conversion
+        blob_normalizer = r.get_blob_normalizer()
+
         # Update working tree
         update_working_tree(
             r,
@@ -3034,6 +3037,7 @@ def checkout(
             validate_path_element=validate_path_element,
             symlink_fn=symlink_fn,
             force_remove_untracked=force,
+            blob_normalizer=blob_normalizer,
         )
 
         # Update HEAD


### PR DESCRIPTION
Git applies clean/smudge filters by default during checkout operations to ensure files in the working tree have the expected format (e.g., proper line endings). This change makes Dulwich's checkout behavior consistent with Git's.

The checkout() function now gets the blob normalizer from the repository and passes it to update_working_tree() to ensure filters are applied when materializing files.