### PR TITLE
Add support for core.protectHFS configuration setting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@
  * Print deprecations on usage, not import.
    (Alyssa Coghlan, #1650)
 
+ * Add support for ``core.protectHFS`` configuration setting to protect
+   against paths that could be misinterpreted on HFS+ filesystems.
+   (Jelmer Vernooĳ, #246)
+
  * Only write Git index extensions when they contain meaningful data.
    Previously, dulwich would write empty extensions to the index file,
    causing unnecessary bloat.

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1719,6 +1719,7 @@ class Repo(BaseRepo):
             build_index_from_tree,
             symlink,
             validate_path_element_default,
+            validate_path_element_hfs,
             validate_path_element_ntfs,
         )
 
@@ -1732,6 +1733,8 @@ class Repo(BaseRepo):
         honor_filemode = config.get_boolean(b"core", b"filemode", os.name != "nt")
         if config.get_boolean(b"core", b"core.protectNTFS", os.name == "nt"):
             validate_path_element = validate_path_element_ntfs
+        elif config.get_boolean(b"core", b"core.protectHFS", sys.platform == "darwin"):
+            validate_path_element = validate_path_element_hfs
         else:
             validate_path_element = validate_path_element_default
         if config.get_boolean(b"core", b"symlinks", True):

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -22,6 +22,7 @@
 """Stash handling."""
 
 import os
+import sys
 from typing import TYPE_CHECKING, Optional, TypedDict
 
 from .file import GitFile
@@ -37,6 +38,7 @@ from .index import (
     update_working_tree,
     validate_path,
     validate_path_element_default,
+    validate_path_element_hfs,
     validate_path_element_ntfs,
 )
 from .objects import S_IFGITLINK, Blob, Commit, ObjectID
@@ -139,6 +141,8 @@ class Stash:
 
         if config.get_boolean(b"core", b"core.protectNTFS", os.name == "nt"):
             validate_path_element = validate_path_element_ntfs
+        elif config.get_boolean(b"core", b"core.protectHFS", sys.platform == "darwin"):
+            validate_path_element = validate_path_element_hfs
         else:
             validate_path_element = validate_path_element_default
 


### PR DESCRIPTION
Implement Git's core.protectHFS setting to protect against paths that could be misinterpreted on HFS+ filesystems through Unicode normalization. This includes filtering HFS+ ignorable characters and applying NFD normalization to detect malicious path components.

Fixes #246