### PR TITLE
Fix porcelain.describe() hash length to match git describe behavior

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,11 @@
    bisect_reset, bisect_log, bisect_replay), and CLI support.
    (Jelmer Vernooĳ, #1631)
 
+ * Fix ``porcelain.describe()`` to dynamically determine hash length
+   based on uniqueness, matching git describe behavior more closely.
+   Previously used a hardcoded 7-character hash length.
+   (Jelmer Vernooĳ, #824)
+
 0.23.1	2025-06-30
 
  * Support ``untracked_files="normal"`` argument to ``porcelain.status``,

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -6031,6 +6031,27 @@ class DescribeTests(PorcelainTestCase):
             complete_description,
         )
 
+    def test_hash_length_dynamic(self) -> None:
+        """Test that hash length adjusts based on uniqueness."""
+        fullpath = os.path.join(self.repo.path, "foo")
+        with open(fullpath, "w") as f:
+            f.write("content")
+        porcelain.add(repo=self.repo.path, paths=[fullpath])
+        sha = porcelain.commit(
+            self.repo.path,
+            message=b"commit",
+            author=b"Joe <joe@example.com>",
+            committer=b"Bob <bob@example.com>",
+        )
+
+        # When abbrev is None, it should use find_unique_abbrev
+        result = porcelain.describe(self.repo.path)
+        # Should start with 'g' and have at least 7 characters
+        self.assertTrue(result.startswith("g"))
+        self.assertGreaterEqual(len(result[1:]), 7)
+        # Should be a prefix of the full SHA
+        self.assertTrue(sha.decode("ascii").startswith(result[1:]))
+
 
 class PathToTreeTests(PorcelainTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
- Replace hardcoded 7-character hash with dynamic length based on uniqueness
- Update find_unique_abbrev to find shortest unique prefix (minimum 7 chars)

Fixes #824