### PR TITLE
ParamikoSSHVendor: Add support for SSH config file

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,11 @@
    Previously used a hardcoded 7-character hash length.
    (Jelmer Vernooĳ, #824)
 
+ * ParamikoSSHVendor now reads SSH configuration from ~/.ssh/config.
+   Host settings including hostname, user, port, and identity file are
+   now respected when establishing SSH connections.
+   (Jelmer Vernooĳ, #443)
+
 0.23.1	2025-06-30
 
  * Support ``untracked_files="normal"`` argument to ``porcelain.status``,


### PR DESCRIPTION
The ParamikoSSHVendor now reads SSH configuration from ~/.ssh/config and uses host-specific settings when establishing connections. This includes hostname aliases, user, port, and identity file settings.

Fixes #443