### PR TITLE
Add autogc disable mechanisms for API users

### DIFF
--- a/dulwich/gc.py
+++ b/dulwich/gc.py
@@ -321,6 +321,14 @@ def should_run_gc(repo: "BaseRepo", config: Optional["Config"] = None) -> bool:
     Returns:
         True if GC should run, False otherwise
     """
+    # Check environment variable first
+    if os.environ.get("GIT_AUTO_GC") == "0":
+        return False
+
+    # Check programmatic disable flag
+    if getattr(repo, "_autogc_disabled", False):
+        return False
+
     if config is None:
         config = repo.get_config()
 

--- a/tests/test_gc.py
+++ b/tests/test_gc.py
@@ -283,6 +283,30 @@ class AutoGCTestCase(TestCase):
 
         self.assertFalse(should_run_gc(r, config))
 
+    def test_should_run_gc_disabled_by_env_var(self):
+        """Test that auto GC doesn't run when GIT_AUTO_GC environment variable is 0."""
+        r = MemoryRepo()
+        config = ConfigDict()
+        config.set(b"gc", b"auto", b"10")  # Should normally run
+
+        with patch.dict(os.environ, {"GIT_AUTO_GC": "0"}):
+            self.assertFalse(should_run_gc(r, config))
+
+    def test_should_run_gc_disabled_programmatically(self):
+        """Test that auto GC doesn't run when disabled via _autogc_disabled attribute."""
+        r = MemoryRepo()
+        config = ConfigDict()
+        config.set(b"gc", b"auto", b"10")  # Should normally run
+
+        # Disable autogc programmatically
+        r._autogc_disabled = True
+        self.assertFalse(should_run_gc(r, config))
+
+        # Re-enable autogc
+        r._autogc_disabled = False
+        # Still false because MemoryRepo doesn't support counting loose objects
+        self.assertFalse(should_run_gc(r, config))
+
     def test_should_run_gc_default_values(self):
         """Test auto GC with default configuration values."""
         r = MemoryRepo()


### PR DESCRIPTION
- Support GIT_AUTO_GC=0 environment variable to disable autogc
- Allow setting repo._autogc_disabled = True to programmatically disable autogc