### PR TITLE
Add support for core.commitGraph configuration setting

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 0.23.3	UNRELEASED
 
+ * Add support for ``core.commitGraph`` configuration setting to control
+   whether commit-graph files are used for performance optimization.
+   (Jelmer Vernooĳ)
+
  * Add ``reflog`` command in porcelain. (Jelmer Vernooĳ)
 
 0.23.2	2025-07-07

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -129,6 +129,14 @@ class ObjectContainer(Protocol):
     def __getitem__(self, sha1: bytes) -> ShaFile:
         """Retrieve an object."""
 
+    def get_commit_graph(self):
+        """Get the commit graph for this object store.
+
+        Returns:
+          CommitGraph object if available, None otherwise
+        """
+        return None
+
 
 class PackedObjectContainer(ObjectContainer):
     def get_unpacked_object(

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -62,6 +62,7 @@ Currently implemented:
  * tag{_create,_delete,_list}
  * upload_pack
  * update_server_info
+ * write_commit_graph
  * status
  * symbolic_ref
 
@@ -412,6 +413,21 @@ def update_server_info(repo=".") -> None:
     """
     with open_repo_closing(repo) as r:
         server_update_server_info(r)
+
+
+def write_commit_graph(repo=".", reachable=True) -> None:
+    """Write a commit graph file for a repository.
+
+    Args:
+      repo: path to the repository or a Repo object
+      reachable: if True, include all commits reachable from refs.
+                 if False, only include direct ref targets.
+    """
+    with open_repo_closing(repo) as r:
+        # Get all refs
+        refs = list(r.refs.as_dict().values())
+        if refs:
+            r.object_store.write_commit_graph(refs, reachable=reachable)
 
 
 def symbolic_ref(repo, ref_name, force=False) -> None:


### PR DESCRIPTION
This implements Git's core.commitGraph configuration setting which controls whether commit-graph files are used for performance optimization. When enabled (default), commit graph files are used to speed up parent lookups in operations like find_shallow(), get_depth(), and commit ancestry traversal.

Also adds write_commit_graph() porcelain function to generate commit graphs.