### PR TITLE
Add support for GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM environment variables

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@
  * Add support for merge drivers.
    (Jelmer Vernooĳ)
 
+ * Add support for ``GIT_CONFIG_GLOBAL`` and ``GIT_CONFIG_SYSTEM``
+   environment variables to override global and system configuration
+   paths. (Jelmer Vernooĳ, #1193)
+
  * ``dulwich.porcelain.diff``: Support diffing two commits
    and diffing cached and working tree. (Jelmer Vernooĳ)
 

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -1212,13 +1212,22 @@ class StackedConfig(Config):
         See git-config(1) for details on the files searched.
         """
         paths = []
-        paths.append(os.path.expanduser("~/.gitconfig"))
-        paths.append(get_xdg_config_home_path("git", "config"))
 
-        if "GIT_CONFIG_NOSYSTEM" not in os.environ:
-            paths.append("/etc/gitconfig")
-            if sys.platform == "win32":
-                paths.extend(get_win_system_paths())
+        # Handle GIT_CONFIG_GLOBAL - overrides user config paths
+        try:
+            paths.append(os.environ["GIT_CONFIG_GLOBAL"])
+        except KeyError:
+            paths.append(os.path.expanduser("~/.gitconfig"))
+            paths.append(get_xdg_config_home_path("git", "config"))
+
+        # Handle GIT_CONFIG_SYSTEM and GIT_CONFIG_NOSYSTEM
+        try:
+            paths.append(os.environ["GIT_CONFIG_SYSTEM"])
+        except KeyError:
+            if "GIT_CONFIG_NOSYSTEM" not in os.environ:
+                paths.append("/etc/gitconfig")
+                if sys.platform == "win32":
+                    paths.extend(get_win_system_paths())
 
         backends = []
         for path in paths:


### PR DESCRIPTION
These variables allow overriding the default global and system configuration paths.

Fixes #1193