### PR TITLE
Support more complicated revision syntax

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,8 +6,9 @@
  * Add support for merge drivers.
    (Jelmer Vernooĳ)
 
- * Add support for Git revision syntax operators ``~`` and ``^`` in
-   ``dulwich.objectspec.parse_object``, e.g. ``HEAD~1``, ``HEAD^2``.
+ * Add support for Git revision syntax operators ``~``, ``^``, ``^{}``,
+   ``@{N}``, and ``:path`` in ``dulwich.objectspec.parse_object``,
+   e.g. ``HEAD~1``, ``HEAD^2``, ``v1.0^{}``, ``HEAD@{1}``, ``HEAD:README``.
    (Jelmer Vernooĳ)
 
  * Add support for ``GIT_CONFIG_GLOBAL`` and ``GIT_CONFIG_SYSTEM``

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@
  * Add support for merge drivers.
    (Jelmer Vernooĳ)
 
+ * Add support for Git revision syntax operators ``~`` and ``^`` in
+   ``dulwich.objectspec.parse_object``, e.g. ``HEAD~1``, ``HEAD^2``.
+   (Jelmer Vernooĳ)
+
  * Add support for ``GIT_CONFIG_GLOBAL`` and ``GIT_CONFIG_SYSTEM``
    environment variables to override global and system configuration
    paths. (Jelmer Vernooĳ, #1193)


### PR DESCRIPTION
E.g. ^1, ~1, rev:path, ^{}