### PR TITLE
Optimize update_working_tree and prevent overwriting uncommitted changes

### DIFF
--- a/dulwich/errors.py
+++ b/dulwich/errors.py
@@ -180,3 +180,7 @@ class RefFormatError(Exception):
 
 class HookError(Exception):
     """An error occurred while executing a hook."""
+
+
+class WorkingTreeModifiedError(Exception):
+    """Indicates that the working tree has modifications that would be overwritten."""

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -42,6 +42,7 @@ from typing import (
 )
 
 if TYPE_CHECKING:
+    from .diff_tree import TreeChange
     from .file import _GitFile
     from .line_ending import BlobNormalizer
     from .repo import Repo
@@ -1613,7 +1614,7 @@ def _check_symlink_matches(
 ) -> bool:
     """Check if symlink target matches expected target.
 
-    Returns True if symlink needs to be written, False if it matches.
+    Returns True if symlink matches, False if it doesn't match.
     """
     try:
         current_target = os.readlink(full_path)
@@ -1621,14 +1622,14 @@ def _check_symlink_matches(
         expected_target = blob_obj.as_raw_string()
         if isinstance(current_target, str):
             current_target = current_target.encode()
-        return current_target != expected_target
+        return current_target == expected_target
     except FileNotFoundError:
         # Symlink doesn't exist
-        return True
+        return False
     except OSError as e:
         if e.errno == errno.EINVAL:
             # Not a symlink
-            return True
+            return False
         raise
 
 
@@ -1644,19 +1645,43 @@ def _check_file_matches(
 ) -> bool:
     """Check if a file on disk matches the expected git object.
 
-    Returns True if file needs to be written, False if it matches.
+    Returns True if file matches, False if it doesn't match.
     """
     # Check mode first (if honor_filemode is True)
     if honor_filemode:
         current_mode = stat.S_IMODE(current_stat.st_mode)
         expected_mode = stat.S_IMODE(entry_mode)
-        if current_mode != expected_mode:
-            return True
+
+        # For regular files, only check the user executable bit, not group/other permissions
+        # This matches Git's behavior where umask differences don't count as modifications
+        if stat.S_ISREG(current_stat.st_mode):
+            # Normalize regular file modes to ignore group/other write permissions
+            current_mode_normalized = (
+                current_mode & 0o755
+            )  # Keep only user rwx and all read+execute
+            expected_mode_normalized = expected_mode & 0o755
+
+            # For Git compatibility, regular files should be either 644 or 755
+            if expected_mode_normalized not in (0o644, 0o755):
+                expected_mode_normalized = 0o644  # Default for regular files
+            if current_mode_normalized not in (0o644, 0o755):
+                # Determine if it should be executable based on user execute bit
+                if current_mode & 0o100:  # User execute bit is set
+                    current_mode_normalized = 0o755
+                else:
+                    current_mode_normalized = 0o644
+
+            if current_mode_normalized != expected_mode_normalized:
+                return False
+        else:
+            # For non-regular files (symlinks, etc.), check mode exactly
+            if current_mode != expected_mode:
+                return False
 
     # If mode matches (or we don't care), check content via size first
     blob_obj = repo_object_store[entry_sha]
     if current_stat.st_size != blob_obj.raw_length():
-        return True
+        return False
 
     # Size matches, check actual content
     try:
@@ -1668,9 +1693,9 @@ def _check_file_matches(
                     blob_obj, tree_path
                 )
                 expected_content = normalized_blob.as_raw_string()
-            return current_content != expected_content
+            return current_content == expected_content
     except (FileNotFoundError, PermissionError, IsADirectoryError):
-        return True
+        return False
 
 
 def _transition_to_submodule(repo, path, full_path, current_stat, entry, index):
@@ -1710,7 +1735,7 @@ def _transition_to_file(
         and not stat.S_ISLNK(entry.mode)
     ):
         # File to file - check if update needed
-        needs_update = _check_file_matches(
+        file_matches = _check_file_matches(
             object_store,
             full_path,
             entry.sha,
@@ -1720,13 +1745,15 @@ def _transition_to_file(
             blob_normalizer,
             path,
         )
+        needs_update = not file_matches
     elif (
         current_stat is not None
         and stat.S_ISLNK(current_stat.st_mode)
         and stat.S_ISLNK(entry.mode)
     ):
         # Symlink to symlink - check if update needed
-        needs_update = _check_symlink_matches(full_path, object_store, entry.sha)
+        symlink_matches = _check_symlink_matches(full_path, object_store, entry.sha)
+        needs_update = not symlink_matches
     else:
         needs_update = True
 
@@ -1814,12 +1841,14 @@ def update_working_tree(
     repo: "Repo",
     old_tree_id: Optional[bytes],
     new_tree_id: bytes,
+    change_iterator: Iterator["TreeChange"],
     honor_filemode: bool = True,
     validate_path_element: Optional[Callable[[bytes], bool]] = None,
     symlink_fn: Optional[Callable] = None,
     force_remove_untracked: bool = False,
     blob_normalizer: Optional["BlobNormalizer"] = None,
     tree_encoding: str = "utf-8",
+    allow_overwrite_modified: bool = False,
 ) -> None:
     """Update the working tree and index to match a new tree.
 
@@ -1833,6 +1862,7 @@ def update_working_tree(
       repo: Repository object
       old_tree_id: SHA of the tree before the update
       new_tree_id: SHA of the tree to update to
+      change_iterator: Iterator of TreeChange objects to apply
       honor_filemode: An optional flag to honor core.filemode setting
       validate_path_element: Function to validate path elements to check out
       symlink_fn: Function to use for creating symlinks
@@ -1841,168 +1871,243 @@ def update_working_tree(
       blob_normalizer: An optional BlobNormalizer to use for converting line
         endings when writing blobs to the working directory.
       tree_encoding: Encoding used for tree paths (default: utf-8)
+      allow_overwrite_modified: If False, raise an error when attempting to
+        overwrite files that have been modified compared to old_tree_id
     """
     if validate_path_element is None:
         validate_path_element = validate_path_element_default
 
+    from .diff_tree import (
+        CHANGE_ADD,
+        CHANGE_COPY,
+        CHANGE_DELETE,
+        CHANGE_MODIFY,
+        CHANGE_RENAME,
+        CHANGE_UNCHANGED,
+    )
+
     repo_path = repo.path if isinstance(repo.path, bytes) else repo.path.encode()
     index = repo.open_index()
 
-    # Build sets of paths for efficient lookup
-    new_paths = {}
-    for entry in iter_tree_contents(repo.object_store, new_tree_id):
-        if entry.path.startswith(b".git") or not validate_path(
-            entry.path, validate_path_element
-        ):
-            continue
-        new_paths[entry.path] = entry
+    # Convert iterator to list since we need multiple passes
+    changes = list(change_iterator)
 
-    old_paths = {}
-    if old_tree_id:
-        for entry in iter_tree_contents(repo.object_store, old_tree_id):
-            if not entry.path.startswith(b".git"):
-                old_paths[entry.path] = entry
-
-    # Process all paths
-    all_paths = set(new_paths.keys()) | set(old_paths.keys())
-
-    # Check for paths that need to become directories
-    paths_needing_dir = set()
-    for path in new_paths:
-        parts = path.split(b"/")
-        for i in range(1, len(parts)):
-            parent = b"/".join(parts[:i])
-            if parent in old_paths and parent not in new_paths:
-                paths_needing_dir.add(parent)
+    # Check for path conflicts where files need to become directories
+    paths_becoming_dirs = set()
+    for change in changes:
+        if change.type in (CHANGE_ADD, CHANGE_MODIFY, CHANGE_RENAME, CHANGE_COPY):
+            path = change.new.path
+            if b"/" in path:  # This is a file inside a directory
+                # Check if any parent path exists as a file in the old tree or changes
+                parts = path.split(b"/")
+                for i in range(1, len(parts)):
+                    parent = b"/".join(parts[:i])
+                    # See if this parent path is being deleted (was a file, becoming a dir)
+                    for other_change in changes:
+                        if (
+                            other_change.type == CHANGE_DELETE
+                            and other_change.old
+                            and other_change.old.path == parent
+                        ):
+                            paths_becoming_dirs.add(parent)
 
     # Check if any path that needs to become a directory has been modified
-    current_stat: Optional[os.stat_result]
-    stat_cache: dict[bytes, Optional[os.stat_result]] = {}
-    for path in paths_needing_dir:
+    for path in paths_becoming_dirs:
         full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
         try:
             current_stat = os.lstat(full_path)
         except FileNotFoundError:
-            # File doesn't exist, proceed
-            stat_cache[full_path] = None
-        except PermissionError:
-            # Can't read file, proceed
-            pass
-        else:
-            stat_cache[full_path] = current_stat
-            if stat.S_ISREG(current_stat.st_mode):
+            continue  # File doesn't exist, nothing to check
+        except OSError as e:
+            raise OSError(
+                f"Cannot access {path.decode('utf-8', errors='replace')}: {e}"
+            ) from e
+
+        if stat.S_ISREG(current_stat.st_mode):
+            # Find the old entry for this path
+            old_change = None
+            for change in changes:
+                if (
+                    change.type == CHANGE_DELETE
+                    and change.old
+                    and change.old.path == path
+                ):
+                    old_change = change
+                    break
+
+            if old_change:
                 # Check if file has been modified
-                old_entry = old_paths[path]
-                if _check_file_matches(
+                file_matches = _check_file_matches(
                     repo.object_store,
                     full_path,
-                    old_entry.sha,
-                    old_entry.mode,
+                    old_change.old.sha,
+                    old_change.old.mode,
                     current_stat,
                     honor_filemode,
                     blob_normalizer,
                     path,
-                ):
-                    # File has been modified, can't replace with directory
+                )
+                if not file_matches:
                     raise OSError(
                         f"Cannot replace modified file with directory: {path!r}"
                     )
 
-    # Process in two passes: deletions first, then additions/updates
-    # This handles case-only renames on case-insensitive filesystems correctly
-    paths_to_remove = []
-    paths_to_update = []
+    # Check for uncommitted modifications before making any changes
+    if not allow_overwrite_modified and old_tree_id:
+        for change in changes:
+            # Only check files that are being modified or deleted
+            if change.type in (CHANGE_MODIFY, CHANGE_DELETE) and change.old:
+                path = change.old.path
+                if path.startswith(b".git") or not validate_path(
+                    path, validate_path_element
+                ):
+                    continue
 
-    for path in sorted(all_paths):
-        if path in new_paths:
-            paths_to_update.append(path)
-        else:
-            paths_to_remove.append(path)
-
-    # First process removals
-    for path in paths_to_remove:
-        full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
-
-        # Determine current state - use cache if available
-        try:
-            current_stat = stat_cache[full_path]
-        except KeyError:
-            try:
-                current_stat = os.lstat(full_path)
-            except FileNotFoundError:
-                current_stat = None
-
-        _transition_to_absent(repo, path, full_path, current_stat, index)
-
-    # Then process additions/updates
-    for path in paths_to_update:
-        full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
-
-        # Determine current state - use cache if available
-        try:
-            current_stat = stat_cache[full_path]
-        except KeyError:
-            try:
-                current_stat = os.lstat(full_path)
-            except FileNotFoundError:
-                current_stat = None
-
-        new_entry = new_paths[path]
-
-        # Path should exist
-        if S_ISGITLINK(new_entry.mode):
-            _transition_to_submodule(
-                repo, path, full_path, current_stat, new_entry, index
-            )
-        else:
-            _transition_to_file(
-                repo.object_store,
-                path,
-                full_path,
-                current_stat,
-                new_entry,
-                index,
-                honor_filemode,
-                symlink_fn,
-                blob_normalizer,
-                tree_encoding,
-            )
-
-    # Handle force_remove_untracked
-    if force_remove_untracked:
-        for root, dirs, files in os.walk(repo_path):
-            if b".git" in os.fsencode(root):
-                continue
-            root_bytes = os.fsencode(root)
-            for file in files:
-                full_path = os.path.join(root_bytes, os.fsencode(file))
-                tree_path = os.path.relpath(full_path, repo_path)
-                if os.sep != "/":
-                    tree_path = tree_path.replace(os.sep.encode(), b"/")
-
-                if tree_path not in new_paths:
-                    _remove_file_with_readonly_handling(full_path)
-                    if tree_path in index:
-                        del index[tree_path]
-
-        # Clean up empty directories
-        for root, dirs, files in os.walk(repo_path, topdown=False):
-            root_bytes = os.fsencode(root)
-            if (
-                b".git" not in root_bytes
-                and root_bytes != repo_path
-                and not files
-                and not dirs
-            ):
+                full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
                 try:
-                    os.rmdir(root)
+                    current_stat = os.lstat(full_path)
                 except FileNotFoundError:
-                    # Directory was already removed
-                    pass
+                    continue  # File doesn't exist, nothing to check
                 except OSError as e:
-                    if e.errno != errno.ENOTEMPTY:
-                        # Only ignore "directory not empty" errors
-                        raise
+                    raise OSError(
+                        f"Cannot access {path.decode('utf-8', errors='replace')}: {e}"
+                    ) from e
+
+                if stat.S_ISREG(current_stat.st_mode):
+                    # Check if working tree file differs from old tree
+                    file_matches = _check_file_matches(
+                        repo.object_store,
+                        full_path,
+                        change.old.sha,
+                        change.old.mode,
+                        current_stat,
+                        honor_filemode,
+                        blob_normalizer,
+                        path,
+                    )
+                    if not file_matches:
+                        from .errors import WorkingTreeModifiedError
+
+                        raise WorkingTreeModifiedError(
+                            f"Your local changes to '{path.decode('utf-8', errors='replace')}' "
+                            f"would be overwritten by checkout. "
+                            f"Please commit your changes or stash them before you switch branches."
+                        )
+
+    # Apply the changes
+    for change in changes:
+        if change.type == CHANGE_DELETE:
+            # Remove file/directory
+            path = change.old.path
+            if path.startswith(b".git") or not validate_path(
+                path, validate_path_element
+            ):
+                continue
+
+            full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
+            try:
+                delete_stat: Optional[os.stat_result] = os.lstat(full_path)
+            except FileNotFoundError:
+                delete_stat = None
+            except OSError as e:
+                raise OSError(
+                    f"Cannot access {path.decode('utf-8', errors='replace')}: {e}"
+                ) from e
+
+            _transition_to_absent(repo, path, full_path, delete_stat, index)
+
+        elif change.type in (CHANGE_ADD, CHANGE_MODIFY, CHANGE_UNCHANGED):
+            # Add or modify file
+            path = change.new.path
+            if path.startswith(b".git") or not validate_path(
+                path, validate_path_element
+            ):
+                continue
+
+            full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
+            try:
+                modify_stat: Optional[os.stat_result] = os.lstat(full_path)
+            except FileNotFoundError:
+                modify_stat = None
+            except OSError as e:
+                raise OSError(
+                    f"Cannot access {path.decode('utf-8', errors='replace')}: {e}"
+                ) from e
+
+            if S_ISGITLINK(change.new.mode):
+                _transition_to_submodule(
+                    repo, path, full_path, modify_stat, change.new, index
+                )
+            else:
+                _transition_to_file(
+                    repo.object_store,
+                    path,
+                    full_path,
+                    modify_stat,
+                    change.new,
+                    index,
+                    honor_filemode,
+                    symlink_fn,
+                    blob_normalizer,
+                    tree_encoding,
+                )
+
+        elif change.type in (CHANGE_RENAME, CHANGE_COPY):
+            # Handle rename/copy: remove old, add new
+            old_path = change.old.path
+            new_path = change.new.path
+
+            if not old_path.startswith(b".git") and validate_path(
+                old_path, validate_path_element
+            ):
+                old_full_path = _tree_to_fs_path(repo_path, old_path, tree_encoding)
+                try:
+                    old_current_stat = os.lstat(old_full_path)
+                except FileNotFoundError:
+                    old_current_stat = None
+                except OSError as e:
+                    raise OSError(
+                        f"Cannot access {old_path.decode('utf-8', errors='replace')}: {e}"
+                    ) from e
+                _transition_to_absent(
+                    repo, old_path, old_full_path, old_current_stat, index
+                )
+
+            if not new_path.startswith(b".git") and validate_path(
+                new_path, validate_path_element
+            ):
+                new_full_path = _tree_to_fs_path(repo_path, new_path, tree_encoding)
+                try:
+                    new_current_stat = os.lstat(new_full_path)
+                except FileNotFoundError:
+                    new_current_stat = None
+                except OSError as e:
+                    raise OSError(
+                        f"Cannot access {new_path.decode('utf-8', errors='replace')}: {e}"
+                    ) from e
+
+                if S_ISGITLINK(change.new.mode):
+                    _transition_to_submodule(
+                        repo,
+                        new_path,
+                        new_full_path,
+                        new_current_stat,
+                        change.new,
+                        index,
+                    )
+                else:
+                    _transition_to_file(
+                        repo.object_store,
+                        new_path,
+                        new_full_path,
+                        new_current_stat,
+                        change.new,
+                        index,
+                        honor_filemode,
+                        symlink_fn,
+                        blob_normalizer,
+                        tree_encoding,
+                    )
 
     index.write()
 

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -25,6 +25,7 @@ import os
 import sys
 from typing import TYPE_CHECKING, Optional, TypedDict
 
+from .diff_tree import tree_changes
 from .file import GitFile
 from .index import (
     IndexEntry,
@@ -317,10 +318,13 @@ class Stash:
         # Update from stash tree to HEAD tree
         # This will remove files that were in stash but not in HEAD,
         # and restore files to their HEAD versions
+        changes = tree_changes(self._repo.object_store, stash_tree_id, head_tree_id)
         update_working_tree(
             self._repo,
             old_tree_id=stash_tree_id,
             new_tree_id=head_tree_id,
+            change_iterator=changes,
+            allow_overwrite_modified=True,  # We need to overwrite modified files
         )
 
         return cid


### PR DESCRIPTION
- Replace iter_tree_contents with diff_tree for massive performance improvement
- Only process files that actually changed between trees
- Add safety check to prevent overwriting uncommitted changes by default