### PR TITLE
Fix Unicode filename encoding on Windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -39,6 +39,10 @@
    is preserved to ensure proper concurrency control.
    (Dan Villiom Podlaski Christiansen, Jelmer Vernooĳ, #1120)
 
+ * Fix Unicode filename encoding issue on Windows where non-ASCII
+   filenames were corrupted during clone/checkout operations.
+   (Jelmer Vernooĳ, #203)
+
 0.23.2	2025-07-07
 
  * Print deprecations on usage, not import.


### PR DESCRIPTION
Fixes #203 (hopefully) where filenames containing Unicode characters like 'À' were incorrectly encoded/decoded on Windows, resulting in corruption during clone and checkout operations.

The fix adds proper handling of UTF-8 encoded tree paths on Windows by:
- Converting UTF-8 tree paths to filesystem encoding when creating files
- Converting filesystem paths back to UTF-8 when storing in git trees
- Adding a tree_encoding parameter (defaulting to 'utf-8') to relevant functions for future flexibility

Added comprehensive test coverage for Unicode filename handling.