### PR TITLE
dumb: Optimize number of HTTP requests sent to git server

### DIFF
--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -258,16 +258,16 @@ class DumbHTTPObjectStore(BaseObjectStore):
         if sha in self._cached_objects:
             return self._cached_objects[sha]
 
-        # Try loose object first
+        # Try packs first
         try:
-            result = self._fetch_loose_object(sha)
+            result = self._fetch_from_pack(sha)
             self._cached_objects[sha] = result
             return result
         except KeyError:
             pass
 
-        # Try packs
-        result = self._fetch_from_pack(sha)
+        # Try loose object
+        result = self._fetch_loose_object(sha)
         self._cached_objects[sha] = result
         return result
 
@@ -284,16 +284,16 @@ class DumbHTTPObjectStore(BaseObjectStore):
         if sha in self._cached_objects:
             return True
 
-        # Try loose object
+        # Try packs
         try:
-            self._fetch_loose_object(sha)
+            self._fetch_from_pack(sha)
             return True
         except KeyError:
             pass
 
-        # Try packs
+        # Try loose object
         try:
-            self._fetch_from_pack(sha)
+            self._fetch_loose_object(sha)
             return True
         except KeyError:
             return False


### PR DESCRIPTION
In pratice, it is better to check objects existence in pack files first to avoid flooding git server with numerous HTTP requests.

For instance to load the following git repository only supporting dumb transfer protocol: https://tinc-vpn.org/git/tinc
```
$ curl -I https://tinc-vpn.org/git/tinc/info/refs?service=git-upload-pack
HTTP/1.1 200 OK
Date: Tue, 15 Jul 2025 14:06:00 GMT
Server: Apache/2.4.62 (Debian)
Strict-Transport-Security: max-age=31556952
Last-Modified: Sun, 07 Apr 2024 15:29:31 GMT
ETag: "1f4b-615835af9bff4"
Accept-Ranges: bytes
Content-Length: 8011
```
using the SWH git loader with that [merge request](https://gitlab.softwareheritage.org/swh/devel/swh-loader-git/-/merge_requests/204) applied, it takes around 30 minutes without the changes in that PR and around 40 seconds with the changes in that PR.