### PR TITLE
Support empty path in Tree.lookup_path

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1313,6 +1313,10 @@ class Tree(ShaFile):
           path: Path to lookup
         Returns: A tuple of (mode, SHA) of the resulting path.
         """
+        # Handle empty path - return the tree itself
+        if not path:
+            return stat.S_IFDIR, self.id
+
         parts = path.split(b"/")
         sha = self.id
         mode: Optional[int] = None

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -826,6 +826,12 @@ class TreeLookupPathTests(TestCase):
             b"ad/b/j",
         )
 
+    def test_lookup_empty_path(self) -> None:
+        # Empty path should return the tree itself
+        mode, sha = tree_lookup_path(self.get_object, self.tree_id, b"")
+        self.assertEqual(sha, self.tree_id)
+        self.assertEqual(mode, stat.S_IFDIR)
+
 
 class ObjectStoreGraphWalkerTests(TestCase):
     def get_walker(self, heads, parent_map):


### PR DESCRIPTION
Allow Tree.lookup_path to handle empty byte strings by returning the tree itself with S_IFDIR mode. This matches the expected behavior when looking up the root of a tree.