### PR TITLE
Require ``typing_extensions`` on Python 3.10.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+0.24.1	UNRELEASE
+
+ * Require ``typing_extensions`` on Python 3.10.
+   (Jelmer Vernooĳ, #1735)
+
 0.24.0	2025-08-01
 
  * Split out ``WorkTree`` from ``Repo``. (Jelmer Vernooĳ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
     "urllib3>=1.25",
-    'typing_extensions >=4.0 ; python_version < "3.10"',
+    'typing_extensions >=4.0 ; python_version < "3.11"',
 ]
 dynamic = ["version"]
 license-files = ["COPYING"]


### PR DESCRIPTION
Fixes #1735