### PR TITLE
Fix worktree CLI tests to properly change to repository directory

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+0.24.2	UNRELEASED
+
+ * Fix worktree CLI tests to properly change to repository directory.
+   (Jelmer Vernooĳ, #1738)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2338,12 +2338,18 @@ class WorktreeCliTests(DulwichCliTestCase):
 
     def test_worktree_list(self):
         """Test worktree list command."""
-        io.StringIO()
-        cmd = cli.cmd_worktree()
-        result = cmd.run(["list"])
+        # Change to repo directory
+        old_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            io.StringIO()
+            cmd = cli.cmd_worktree()
+            result = cmd.run(["list"])
 
-        # Should list the main worktree
-        self.assertEqual(result, 0)
+            # Should list the main worktree
+            self.assertEqual(result, 0)
+        finally:
+            os.chdir(old_cwd)
 
     def test_worktree_add(self):
         """Test worktree add command."""
@@ -2367,81 +2373,115 @@ class WorktreeCliTests(DulwichCliTestCase):
         """Test worktree add with detached HEAD."""
         wt_path = os.path.join(self.test_dir, "detached-wt")
 
-        cmd = cli.cmd_worktree()
-        with patch("sys.stdout", new_callable=io.StringIO):
-            result = cmd.run(["add", "--detach", wt_path])
+        # Change to repo directory
+        old_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            cmd = cli.cmd_worktree()
+            with patch("sys.stdout", new_callable=io.StringIO):
+                result = cmd.run(["add", "--detach", wt_path])
 
-        self.assertEqual(result, 0)
-        self.assertTrue(os.path.exists(wt_path))
+            self.assertEqual(result, 0)
+            self.assertTrue(os.path.exists(wt_path))
+        finally:
+            os.chdir(old_cwd)
 
     def test_worktree_remove(self):
         """Test worktree remove command."""
         # First add a worktree
         wt_path = os.path.join(self.test_dir, "to-remove")
-        cmd = cli.cmd_worktree()
-        cmd.run(["add", wt_path])
 
-        # Then remove it
-        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
-            result = cmd.run(["remove", wt_path])
+        # Change to repo directory
+        old_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            cmd = cli.cmd_worktree()
+            cmd.run(["add", wt_path])
 
-        self.assertEqual(result, 0)
-        self.assertFalse(os.path.exists(wt_path))
-        self.assertIn("Worktree removed:", mock_stdout.getvalue())
+            # Then remove it
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                result = cmd.run(["remove", wt_path])
+
+            self.assertEqual(result, 0)
+            self.assertFalse(os.path.exists(wt_path))
+            self.assertIn("Worktree removed:", mock_stdout.getvalue())
+        finally:
+            os.chdir(old_cwd)
 
     def test_worktree_prune(self):
         """Test worktree prune command."""
         # Add a worktree and manually remove it
         wt_path = os.path.join(self.test_dir, "to-prune")
-        cmd = cli.cmd_worktree()
-        cmd.run(["add", wt_path])
-        shutil.rmtree(wt_path)
 
-        # Prune
-        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
-            result = cmd.run(["prune", "-v"])
+        # Change to repo directory
+        old_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            cmd = cli.cmd_worktree()
+            cmd.run(["add", wt_path])
+            shutil.rmtree(wt_path)
 
-        self.assertEqual(result, 0)
-        output = mock_stdout.getvalue()
-        self.assertIn("to-prune", output)
+            # Prune
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                result = cmd.run(["prune", "-v"])
+
+            self.assertEqual(result, 0)
+            output = mock_stdout.getvalue()
+            self.assertIn("to-prune", output)
+        finally:
+            os.chdir(old_cwd)
 
     def test_worktree_lock_unlock(self):
         """Test worktree lock and unlock commands."""
         # Add a worktree
         wt_path = os.path.join(self.test_dir, "lockable")
-        cmd = cli.cmd_worktree()
-        cmd.run(["add", wt_path])
 
-        # Lock it
-        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
-            result = cmd.run(["lock", wt_path, "--reason", "Testing"])
+        # Change to repo directory
+        old_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            cmd = cli.cmd_worktree()
+            cmd.run(["add", wt_path])
 
-        self.assertEqual(result, 0)
-        self.assertIn("Worktree locked:", mock_stdout.getvalue())
+            # Lock it
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                result = cmd.run(["lock", wt_path, "--reason", "Testing"])
 
-        # Unlock it
-        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
-            result = cmd.run(["unlock", wt_path])
+            self.assertEqual(result, 0)
+            self.assertIn("Worktree locked:", mock_stdout.getvalue())
 
-        self.assertEqual(result, 0)
-        self.assertIn("Worktree unlocked:", mock_stdout.getvalue())
+            # Unlock it
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                result = cmd.run(["unlock", wt_path])
+
+            self.assertEqual(result, 0)
+            self.assertIn("Worktree unlocked:", mock_stdout.getvalue())
+        finally:
+            os.chdir(old_cwd)
 
     def test_worktree_move(self):
         """Test worktree move command."""
         # Add a worktree
         old_path = os.path.join(self.test_dir, "old-location")
         new_path = os.path.join(self.test_dir, "new-location")
-        cmd = cli.cmd_worktree()
-        cmd.run(["add", old_path])
 
-        # Move it
-        with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
-            result = cmd.run(["move", old_path, new_path])
+        # Change to repo directory
+        old_cwd = os.getcwd()
+        os.chdir(self.repo_path)
+        try:
+            cmd = cli.cmd_worktree()
+            cmd.run(["add", old_path])
 
-        self.assertEqual(result, 0)
-        self.assertFalse(os.path.exists(old_path))
-        self.assertTrue(os.path.exists(new_path))
-        self.assertIn("Worktree moved:", mock_stdout.getvalue())
+            # Move it
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_stdout:
+                result = cmd.run(["move", old_path, new_path])
+
+            self.assertEqual(result, 0)
+            self.assertFalse(os.path.exists(old_path))
+            self.assertTrue(os.path.exists(new_path))
+            self.assertIn("Worktree moved:", mock_stdout.getvalue())
+        finally:
+            os.chdir(old_cwd)
 
     def test_worktree_invalid_command(self):
         """Test invalid worktree subcommand."""


### PR DESCRIPTION
The worktree CLI commands expect to be run from within a repository directory. Updated the test methods to change to the repo directory before running commands and restore the original directory afterward.

Fixes #1738