### PR TITLE
refs:  handle per-worktree and shared refs on read and on reflog writes

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -1764,6 +1764,16 @@ def filter_ref_prefix(refs: T, prefixes: Iterable[bytes]) -> T:
 
 
 def is_per_worktree_ref(ref: bytes) -> bool:
+    """Returns whether a reference is stored per worktree or not.
+
+    Per-worktree references are:
+    - all pseudorefs, e.g. HEAD
+    - all references stored inside "refs/bisect/", "refs/worktree/" and "refs/rewritten/"
+
+    All refs starting with "refs/" are shared, except for the ones listed above.
+
+    See https://git-scm.com/docs/git-worktree#_refs.
+    """
     return not ref.startswith(b"refs/") or ref.startswith(
         (b"refs/bisect/", b"refs/worktree/", b"refs/rewritten/")
     )

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1338,9 +1338,9 @@ class Repo(BaseRepo):
             )
 
     def _reflog_path(self, ref: bytes) -> str:
-        assert not ref.startswith((b"main-worktree/", b"worktrees/")), (
-            "special paths are not supported"
-        )
+        if ref.startswith((b"main-worktree/", b"worktrees/")):
+            raise NotImplementedError(f"refs {ref.decode()} are not supported")
+
         base = self.controldir() if is_per_worktree_ref(ref) else self.commondir()
         return os.path.join(base, "logs", os.fsdecode(ref))
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -36,6 +36,7 @@ from dulwich.refs import (
     SymrefLoop,
     _split_ref_line,
     check_ref_format,
+    is_per_worktree_ref,
     parse_remote_ref,
     parse_symref_value,
     read_packed_refs,
@@ -837,6 +838,25 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
 
         # Now it should work
         self._refs[ref_name] = ref_value
+
+
+class IsPerWorktreeRefsTests(TestCase):
+    def test(self) -> None:
+        cases = [
+            (b"HEAD", True),
+            (b"refs/bisect/good", True),
+            (b"refs/worktree/foo", True),
+            (b"refs/rewritten/onto", True),
+            (b"refs/stash", False),
+            (b"refs/heads/main", False),
+            (b"refs/tags/v1.0", False),
+            (b"refs/remotes/origin/main", False),
+            (b"refs/custom/foo", False),
+            (b"refs/replace/aaaaaa", False),
+        ]
+        for ref, expected in cases:
+            with self.subTest(ref=ref, expected=expected):
+                self.assertEqual(is_per_worktree_ref(ref), expected)
 
 
 class DiskRefsContainerWorktreeRefsTest(TestCase):

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -900,6 +900,9 @@ class DiskRefsContainerWorktreeRefsTest(TestCase):
         self.assertEqual(expected, self.refs.keys())
         self.assertEqual(expected, self.wt_refs.keys())
 
+        self.assertEqual({b"main", b"wt-main"}, set(self.refs.keys(b"refs/heads/")))
+        self.assertEqual({b"main", b"wt-main"}, set(self.wt_refs.keys(b"refs/heads/")))
+
         ref_path = os.path.join(self.refs.path, b"refs", b"heads", b"main")
         self.assertTrue(os.path.exists(ref_path))
 
@@ -953,6 +956,7 @@ class DiskRefsContainerWorktreeRefsTest(TestCase):
             b"refs/bisect/start",
         }
         self.assertEqual(self.refs.keys(), expected_refs)
+        self.assertEqual({b"good", b"start"}, self.refs.keys(b"refs/bisect/"))
 
         expected_wt_refs = {
             b"HEAD",
@@ -962,6 +966,7 @@ class DiskRefsContainerWorktreeRefsTest(TestCase):
             b"refs/bisect/bad",
         }
         self.assertEqual(self.wt_refs.keys(), expected_wt_refs)
+        self.assertEqual({b"good", b"bad"}, self.wt_refs.keys(b"refs/bisect/"))
 
     def test_delete_per_worktree_ref(self) -> None:
         self.refs[b"refs/worktree/foo"] = self.first_commit

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -28,6 +28,7 @@ import tempfile
 from dulwich.objects import Blob, Tree
 from dulwich.repo import Repo
 from dulwich.stash import DEFAULT_STASH_REF, Stash
+from dulwich.worktree import add_worktree
 
 from . import TestCase
 
@@ -221,3 +222,12 @@ class StashTests(TestCase):
         # Verify index has the staged changes
         index = self.repo.open_index()
         self.assertIn(b"new.txt", index)
+
+
+class StashInWorktreeTest(StashTests):
+    """Tests for stash in a worktree."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.repo_dir = os.path.join(self.test_dir, "wt")
+        self.repo = add_worktree(self.repo, self.repo_dir, "worktree")


### PR DESCRIPTION
This commit adds a proper support for reading and iterating over
references from shared and per-worktree "refs" directory depending on
the reference name.

It also updates the reflog writing to use the correct directory based
on the reference.

Fixes https://github.com/iterative/dvc/issues/10821.
Related documentation: https://git-scm.com/docs/git-worktree#_refs

### TODO

- [x] Add tests