### PR TITLE
Fix Windows path handling regression in checkout operations

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@
  * Add colorized diff support for the ``show`` command with ``--color``
    argument. (Jelmer Vernooĳ, #1741)
 
+ * Fix Windows path handling in ``_ensure_parent_dir_exists`` to correctly
+   handle drive letters during checkout operations. (Jelmer Vernooĳ, #1751)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.


### PR DESCRIPTION
Fix a regression introduced in 0.23.1 where checkout operations on Windows would fail with "Cannot create directory, parent path is a file: b'C:'" error.

The issue occurred in _ensure_parent_dir_exists when validating parent paths. The original implementation manually split paths and reconstructed them, which didn't correctly handle Windows drive letters or UNC paths.

The fix uses os.path.dirname() to properly walk up the directory tree, letting Python's built-in path handling deal with all platform-specific cases including:
- Windows drive letters (C:\, D:\, etc.)
- UNC paths (\\server\share\...)
- Unix paths (/home/user/...)

This approach is more robust and eliminates the need for platform-specific special cases.

Fixes #1751