### PR TITLE
Fix Windows config loading to only use current Git installation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,9 @@
  * Fix Windows path handling in ``_ensure_parent_dir_exists`` to correctly
    handle drive letters during checkout operations. (Jelmer Vernooĳ, #1751)
 
+ * Fix Windows config loading to only use current Git config path,
+   avoiding loading older config files.  (Jelmer Vernooĳ, #1732)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.


### PR DESCRIPTION
Previously, Dulwich would load multiple gitconfig files on Windows including defunct ones from old installations.

Changes:
- Modified get_win_system_paths() to only return the current Git config path
- Added get_win_legacy_system_paths() for diagnostic/migration purposes
- Added debug logging to show which gitconfig files are loaded

Fixes #1732