### PR TITLE
Add interactive rebase support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,10 @@
  * Fix Windows config loading to only use current Git config path,
    avoiding loading older config files.  (Jelmer Vernooĳ, #1732)
 
+ * Add interactive rebase support with ``git rebase -i``, including support
+   for pick, reword, edit, squash, fixup, drop, exec, and break commands.
+   (Jelmer Vernooĳ, #1696)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.

--- a/dulwich/rebase.py
+++ b/dulwich/rebase.py
@@ -1033,9 +1033,10 @@ def process_interactive_rebase(
         editor_callback: Optional callback for reword operations
 
     Returns:
-        Tuple of (is_complete, pause_reason)
-        - is_complete: True if rebase is complete, False if paused
-        - pause_reason: Reason for pause (e.g., "edit", "conflict", "break") or None
+        Tuple of (is_complete, pause_reason):
+
+        * is_complete: True if rebase is complete, False if paused
+        * pause_reason: Reason for pause (e.g., "edit", "conflict", "break") or None
 
     Raises:
         RebaseError: If rebase fails


### PR DESCRIPTION
This adds support for interactive rebase (`git rebase -i`) with all standard git rebase commands: pick, reword, edit, squash, fixup, drop, exec, and break.

Fixes #1696