### PR TITLE
Fix handling of CRLF line endings with core.autocrlf = input

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -26,6 +26,10 @@
    for pick, reword, edit, squash, fixup, drop, exec, and break commands.
    (Jelmer Vernooĳ, #1696)
 
+ * Fix handling of CRLF line endings with ``core.autocrlf = input`` to prevent
+   unchanged files from appearing as unstaged in status.
+   (Jelmer Vernooĳ, #1770)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.

--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -476,10 +476,13 @@ class TreeBlobNormalizer(BlobNormalizer):
 
     def checkin_normalize(self, blob: Blob, tree_path: bytes) -> Blob:
         """Normalize blob for checkin, considering existing tree state."""
-        # Existing files should only be normalized on checkin if it was
-        # previously normalized on checkout
+        # Existing files should only be normalized on checkin if:
+        # 1. They were previously normalized on checkout (autocrlf=true), OR
+        # 2. We have a write filter (autocrlf=true or autocrlf=input), OR
+        # 3. They are new files
         if (
             self.fallback_read_filter is not None
+            or self.fallback_write_filter is not None
             or tree_path not in self.existing_paths
         ):
             return super().checkin_normalize(blob, tree_path)


### PR DESCRIPTION
When core.autocrlf = input is set, files with CRLF line endings were incorrectly showing as unstaged even when their content hadn't changed. This was because TreeBlobNormalizer.checkin_normalize() was not applying the clean filter (CRLF to LF conversion) for existing files when autocrlf=input was set.

The fix ensures that when autocrlf=input is configured, all text files are normalized during checkin operations, including when checking status. This makes Dulwich's behavior consistent with Git.

Fixes #1770