### PR TITLE
Add support for http.extraHeader configuration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,6 +30,10 @@
    unchanged files from appearing as unstaged in status.
    (Jelmer Vernooĳ, #1770)
 
+ * Add support for ``http.extraHeader`` configuration to pass additional HTTP
+   headers to the server when communicating over HTTP(S).
+   (Jelmer Vernooĳ, #1769)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.


### PR DESCRIPTION
This allows passing additional HTTP headers to the server when communicating over HTTP(S), following Git's standard configuration pattern. Users can set single or multiple headers via:

  git config --add http.extraHeader "Authorization: Bearer token"
  git config --add http.extraHeader "X-Custom-Header: value"

The headers are parsed from the config and applied to all HTTP requests made by the client.

Fixes #1769