### PR TITLE
Add IPv6 support for git:// protocol URLs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -37,6 +37,9 @@
  * Add support for ``patiencediff`` algorithm in diff.
    (Jelmer Vernooĳ, #1795)
 
+ * Add IPv6 support for git:// protocol URLs.
+   (Jelmer Vernooĳ, #1796)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1708,7 +1708,12 @@ class TCPGitClient(TraditionalGitClient):
         Returns:
           ``git://`` URL for the path
         """
-        netloc = self._host
+        # IPv6 addresses contain colons and need to be wrapped in brackets
+        if ":" in self._host:
+            netloc = f"[{self._host}]"
+        else:
+            netloc = self._host
+
         if self._port is not None and self._port != TCP_GIT_PORT:
             netloc += f":{self._port}"
         return urlunsplit(("git", netloc, path, "", ""))


### PR DESCRIPTION
The TCPGitClient class now properly formats IPv6 addresses in git:// URLs by wrapping them in square brackets as required by RFC 3986. The underlying socket connection already supported IPv6 through AF_UNSPEC.

Fixes #1796