### PR TITLE
Add porcelain.shortlog function to summarize commits by author

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 0.24.2	UNRELEASED
 
  * Added ``porcelain.shortlog`` function to summarize commits by author,
-   similar to git shortlog. (Muhammad Usama, #1865)
+   similar to git shortlog. (Muhammad Usama, #1693)
 
  * Fix merge functionality to gracefully handle missing optional merge3 dependency
    by raising informative ImportError with installation instructions.

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 0.24.2	UNRELEASED
 
  * Added ``porcelain.shortlog`` function to summarize commits by author,
-   similar to git shortlog. (Muhammad Usama, #<PRNumber>)
+   similar to git shortlog. (Muhammad Usama, #1865)
 
  * Fix merge functionality to gracefully handle missing optional merge3 dependency
    by raising informative ImportError with installation instructions.

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 0.24.2	UNRELEASED
 
+ * Added ``porcelain.shortlog`` function to summarize commits by author,
+   similar to git shortlog. (Muhammad Usama, #<PRNumber>)
+
  * Fix merge functionality to gracefully handle missing optional merge3 dependency
    by raising informative ImportError with installation instructions.
    (Jelmer Vernooĳ, #1759)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -1555,41 +1555,37 @@ class cmd_shortlog(Command):
     """Show a shortlog of commits by author."""
 
     def run(self, args) -> None:
-        """Execute the shortlog command.
+        """Execute the shortlog command with the given CLI arguments.
 
         Args:
-            args: Command line arguments
+            args: List of command line arguments.
         """
         parser = argparse.ArgumentParser()
+        parser.add_argument("gitdir", nargs="?", default=".", help="Git directory")
+        parser.add_argument("--summary", action="store_true", help="Show summary only")
         parser.add_argument(
-                "gitdir", nargs="?", default=".", help="Git directory"
-                )
-        parser.add_argument(
-                "--summary", action="store_true", help="Show summary only"
-                )
-        parser.add_argument(
-                "--sort", action="store_true", help="Sort authors by commit count"
-                )
+            "--sort", action="store_true", help="Sort authors by commit count"
+        )
         args = parser.parse_args(args)
 
-        # Tell mypy that this is a list of dicts
-        shortlog_items: list[dict[str, Any]] = porcelain.shortlog(
-                repo=args.gitdir,
-                summary_only=args.summary,
-                sort_by_commits=args.sort,
-                )
+        shortlog_items: list[dict[str, str]] = porcelain.shortlog(
+            repo=args.gitdir,
+            summary_only=args.summary,
+            sort_by_commits=args.sort,
+        )
 
-        # Render structured output
         for item in shortlog_items:
             author: str = item["author"]
-            messages: list[str] = item["messages"]
+            messages: str = item["messages"]
             if args.summary:
-                sys.stdout.write(f"{len(messages)}\t{author}\n")
+                count = len(messages.splitlines())
+                sys.stdout.write(f"{count}\t{author}\n")
             else:
-                sys.stdout.write(f"{author} ({len(messages)}):\n")
-                for msg in messages:
+                sys.stdout.write(f"{author} ({len(messages.splitlines())}):\n")
+                for msg in messages.splitlines():
                     sys.stdout.write(f"    {msg}\n")
                 sys.stdout.write("\n")
+
 
 class cmd_status(Command):
     """Show the working tree status."""

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -1561,23 +1561,28 @@ class cmd_shortlog(Command):
             args: Command line arguments
         """
         parser = argparse.ArgumentParser()
-        parser.add_argument("gitdir", nargs="?", default=".", help="Git directory")
-        parser.add_argument("--summary", action="store_true", help="Show summary only")
         parser.add_argument(
-            "--sort", action="store_true", help="Sort authors by commit count"
-        )
+                "gitdir", nargs="?", default=".", help="Git directory"
+                )
+        parser.add_argument(
+                "--summary", action="store_true", help="Show summary only"
+                )
+        parser.add_argument(
+                "--sort", action="store_true", help="Sort authors by commit count"
+                )
         args = parser.parse_args(args)
 
-        shortlog_items = porcelain.shortlog(
-            repo=args.gitdir,
-            summary_only=args.summary,
-            sort_by_commits=args.sort,
-        )
+        # Tell mypy that this is a list of dicts
+        shortlog_items: list[dict[str, Any]] = porcelain.shortlog(
+                repo=args.gitdir,
+                summary_only=args.summary,
+                sort_by_commits=args.sort,
+                )
 
         # Render structured output
         for item in shortlog_items:
-            author = item["author"]
-            messages = item["messages"]
+            author: str = item["author"]
+            messages: list[str] = item["messages"]
             if args.summary:
                 sys.stdout.write(f"{len(messages)}\t{author}\n")
             else:
@@ -1585,7 +1590,6 @@ class cmd_shortlog(Command):
                 for msg in messages:
                     sys.stdout.write(f"    {msg}\n")
                 sys.stdout.write("\n")
-
 
 class cmd_status(Command):
     """Show the working tree status."""

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -1550,6 +1550,7 @@ class cmd_upload_pack(Command):
         args = parser.parse_args(args)
         porcelain.upload_pack(args.gitdir)
 
+
 class cmd_shortlog(Command):
     """Show a shortlog of commits by author."""
 
@@ -1560,12 +1561,8 @@ class cmd_shortlog(Command):
             args: Command line arguments
         """
         parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "gitdir", nargs="?", default=".", help="Git directory"
-        )
-        parser.add_argument(
-            "--summary", action="store_true", help="Show summary only"
-        )
+        parser.add_argument("gitdir", nargs="?", default=".", help="Git directory")
+        parser.add_argument("--summary", action="store_true", help="Show summary only")
         parser.add_argument(
             "--sort", action="store_true", help="Sort authors by commit count"
         )
@@ -3999,7 +3996,7 @@ commands = {
     "show": cmd_show,
     "stash": cmd_stash,
     "status": cmd_status,
-    "shortlog":cmd_shortlog,
+    "shortlog": cmd_shortlog,
     "symbolic-ref": cmd_symbolic_ref,
     "submodule": cmd_submodule,
     "tag": cmd_tag,

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -1550,6 +1550,45 @@ class cmd_upload_pack(Command):
         args = parser.parse_args(args)
         porcelain.upload_pack(args.gitdir)
 
+class cmd_shortlog(Command):
+    """Show a shortlog of commits by author."""
+
+    def run(self, args) -> None:
+        """Execute the shortlog command.
+
+        Args:
+            args: Command line arguments
+        """
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "gitdir", nargs="?", default=".", help="Git directory"
+        )
+        parser.add_argument(
+            "--summary", action="store_true", help="Show summary only"
+        )
+        parser.add_argument(
+            "--sort", action="store_true", help="Sort authors by commit count"
+        )
+        args = parser.parse_args(args)
+
+        shortlog_items = porcelain.shortlog(
+            repo=args.gitdir,
+            summary_only=args.summary,
+            sort_by_commits=args.sort,
+        )
+
+        # Render structured output
+        for item in shortlog_items:
+            author = item["author"]
+            messages = item["messages"]
+            if args.summary:
+                sys.stdout.write(f"{len(messages)}\t{author}\n")
+            else:
+                sys.stdout.write(f"{author} ({len(messages)}):\n")
+                for msg in messages:
+                    sys.stdout.write(f"    {msg}\n")
+                sys.stdout.write("\n")
+
 
 class cmd_status(Command):
     """Show the working tree status."""
@@ -3960,6 +3999,7 @@ commands = {
     "show": cmd_show,
     "stash": cmd_stash,
     "status": cmd_status,
+    "shortlog":cmd_shortlog,
     "symbolic-ref": cmd_symbolic_ref,
     "submodule": cmd_submodule,
     "tag": cmd_tag,

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2670,6 +2670,7 @@ def status(
 
         return GitStatus(tracked_changes, unstaged_changes, untracked_changes)
 
+
 def shortlog(
     repo: Union[str, os.PathLike, Repo],
     summary_only: bool = False,
@@ -2699,11 +2700,14 @@ def shortlog(
                 authors[author] = [message]
 
         # Optionally sort authors
-        items = [{"author": author, "messages": msgs} for author, msgs in authors.items()]
+        items = [
+            {"author": author, "messages": msgs} for author, msgs in authors.items()
+        ]
         if sort_by_commits:
             items.sort(key=lambda x: len(x["messages"]), reverse=True)
 
         return items
+
 
 def _walk_working_dir_paths(
     frompath: Union[str, bytes, os.PathLike],

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2684,11 +2684,14 @@ def shortlog(
       sort_by_commits: If True, sort authors by number of commits (like `git shortlog -n`).
 
     Returns:
-      A string containing authors and their commit messages or counts.
+      A list of dictionaries, each containing:
+        - "author": the author's name as a string
+        - "messages": a list of commit messages from that author
+      The list is optionally sorted by number of commits if 'sort_by_commits' is True
     """
     with open_repo_closing(repo) as r:
         walker = r.get_walker()
-        authors = {}  # dict mapping author -> list of messages
+        authors: dict[str, list[str]] = {}  # dict mapping author -> list of messages
 
         for entry in walker:
             commit = entry.commit

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -2691,30 +2691,19 @@ def shortlog(
 
         for entry in walker:
             commit = entry.commit
-            author = commit.author.decode("utf-8")
-            message = commit.message.decode("utf-8").strip()
+            author = commit.author.decode(commit.encoding or "utf-8")
+            message = commit.message.decode(commit.encoding or "utf-8").strip()
             if author in authors:
                 authors[author].append(message)
             else:
                 authors[author] = [message]
 
         # Optionally sort authors
-        items = list(authors.items())
+        items = [{"author": author, "messages": msgs} for author, msgs in authors.items()]
         if sort_by_commits:
-            items.sort(key=lambda x: len(x[1]), reverse=True)
+            items.sort(key=lambda x: len(x["messages"]), reverse=True)
 
-        # Format output
-        out_lines = []
-        for author, msgs in items:
-            if summary_only:
-                out_lines.append(f"{len(msgs)}\t{author}")
-            else:
-                out_lines.append(f"{author} ({len(msgs)}):")
-                for msg in msgs:
-                    out_lines.append(f"    {msg}")
-                out_lines.append("")  # blank line between authors
-
-        return "\n".join(out_lines)
+        return items
 
 def _walk_working_dir_paths(
     frompath: Union[str, bytes, os.PathLike],

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -6347,6 +6347,7 @@ class ShortlogTests(PorcelainTestCase):
     def test_shortlog(self) -> None:
         """Test porcelain.shortlog function with multiple authors and commits."""
 
+        # Create first file and commit
         file_a = os.path.join(self.repo.path, "a.txt")
         with open(file_a, "w") as f:
             f.write("hello")
@@ -6357,23 +6358,28 @@ class ShortlogTests(PorcelainTestCase):
             author=b"John <john@example.com>",
         )
 
+        # Create second file and commit
         file_b = os.path.join(self.repo.path, "b.txt")
         with open(file_b, "w") as f:
             f.write("update")
         porcelain.add(self.repo.path, paths=[file_b])
         porcelain.commit(
-            repo=self.repo.path, message=b"Update file", author=b"Doe <doe@example.com>"
+            repo=self.repo.path,
+            message=b"Update file",
+            author=b"Doe <doe@example.com>",
         )
 
+        # Call shortlog
         output = porcelain.shortlog(self.repo.path)
         expected = [
-            {"author": "John <john@example.com>", "messages": ["Initial commit"]},
-            {"author": "Doe <doe@example.com>", "messages": ["Update file"]},
+            {"author": "John <john@example.com>", "messages": "Initial commit"},
+            {"author": "Doe <doe@example.com>", "messages": "Update file"},
         ]
         self.assertCountEqual(output, expected)
 
+        # Test summary output (count of messages)
         output_summary = [
-            {"author": entry["author"], "count": len(entry["messages"])}
+            {"author": entry["author"], "count": len(entry["messages"].splitlines())}
             for entry in output
         ]
         expected_summary = [

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -6347,7 +6347,6 @@ class ShortlogTests(PorcelainTestCase):
     def test_shortlog(self) -> None:
         """Test porcelain.shortlog function with multiple authors and commits."""
 
-        # First commit by John
         file_a = os.path.join(self.repo.path, "a.txt")
         with open(file_a, "w") as f:
             f.write("hello")
@@ -6358,7 +6357,6 @@ class ShortlogTests(PorcelainTestCase):
             author=b"John <john@example.com>",
         )
 
-        # Second commit by Doe
         file_b = os.path.join(self.repo.path, "b.txt")
         with open(file_b, "w") as f:
             f.write("update")
@@ -6367,7 +6365,6 @@ class ShortlogTests(PorcelainTestCase):
             repo=self.repo.path, message=b"Update file", author=b"Doe <doe@example.com>"
         )
 
-        # Check normal shortlog (structured output)
         output = porcelain.shortlog(self.repo.path)
         expected = [
             {"author": "John <john@example.com>", "messages": ["Initial commit"]},
@@ -6375,7 +6372,6 @@ class ShortlogTests(PorcelainTestCase):
         ]
         self.assertCountEqual(output, expected)
 
-        # Check summary only
         output_summary = [
             {"author": entry["author"], "count": len(entry["messages"])}
             for entry in output
@@ -6385,12 +6381,6 @@ class ShortlogTests(PorcelainTestCase):
             {"author": "Doe <doe@example.com>", "count": 1},
         ]
         self.assertCountEqual(output_summary, expected_summary)
-
-        # Check sort by commits
-        output_sorted = porcelain.shortlog(self.repo.path, sort_by_commits=True)
-        # Expected sorted by commit count
-        expected_sorted = sorted(output, key=lambda x: len(x["messages"]), reverse=True)
-        self.assertEqual(output_sorted, expected_sorted)
 
 
 class UploadPackTests(PorcelainTestCase):

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -6342,6 +6342,7 @@ class StatusTests(PorcelainTestCase):
 
 # TODO(jelmer): Add test for dulwich.porcelain.daemon
 
+
 class ShortlogTests(PorcelainTestCase):
     def test_shortlog(self) -> None:
         """Test porcelain.shortlog function with multiple authors and commits."""
@@ -6354,7 +6355,7 @@ class ShortlogTests(PorcelainTestCase):
         porcelain.commit(
             repo=self.repo.path,
             message=b"Initial commit",
-            author=b"John <john@example.com>"
+            author=b"John <john@example.com>",
         )
 
         # Second commit by Doe
@@ -6363,9 +6364,7 @@ class ShortlogTests(PorcelainTestCase):
             f.write("update")
         porcelain.add(self.repo.path, paths=[file_b])
         porcelain.commit(
-            repo=self.repo.path,
-            message=b"Update file",
-            author=b"Doe <doe@example.com>"
+            repo=self.repo.path, message=b"Update file", author=b"Doe <doe@example.com>"
         )
 
         # Check normal shortlog (structured output)
@@ -6392,8 +6391,6 @@ class ShortlogTests(PorcelainTestCase):
         # Expected sorted by commit count
         expected_sorted = sorted(output, key=lambda x: len(x["messages"]), reverse=True)
         self.assertEqual(output_sorted, expected_sorted)
-
-
 
 
 class UploadPackTests(PorcelainTestCase):

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -6343,6 +6343,48 @@ class StatusTests(PorcelainTestCase):
 # TODO(jelmer): Add test for dulwich.porcelain.daemon
 
 
+class ShortlogTests(PorcelainTestCase):
+    def test_shortlog(self) -> None:
+        """Test porcelain.shortlog function with multiple authors and commits."""
+        
+        # First commit by John
+        file_a = os.path.join(self.repo.path, "a.txt")
+        with open(file_a, "w") as f:
+            f.write("hello")
+        porcelain.add(self.repo.path, paths=[file_a])
+        porcelain.commit(
+            repo=self.repo.path,
+            message=b"Initial commit",
+            author=b"John <john@example.com>"
+        )
+
+        # Second commit by Doe
+        file_b = os.path.join(self.repo.path, "b.txt")
+        with open(file_b, "w") as f:
+            f.write("update")
+        porcelain.add(self.repo.path, paths=[file_b])
+        porcelain.commit(
+            repo=self.repo.path,
+            message=b"Update file",
+            author=b"Doe <doe@example.com>"
+        )
+
+        # Check normal shortlog
+        output = porcelain.shortlog(self.repo.path)
+        self.assertIn("John <john@example.com> (1):", output)
+        self.assertIn("Doe <doe@example.com> (1):", output)
+
+        # Check summary only
+        output_summary = porcelain.shortlog(self.repo.path, summary_only=True)
+        self.assertIn("1\tJohn <john@example.com>", output_summary)
+        self.assertIn("1\tDoe <doe@example.com>", output_summary)
+
+        # Check sort by commits
+        output_sorted = porcelain.shortlog(self.repo.path, sort_by_commits=True)
+        lines = output_sorted.splitlines()
+        self.assertTrue(any("John <john@example.com>" in line for line in lines))
+        self.assertTrue(any("Doe <doe@example.com>" in line for line in lines))
+
 class UploadPackTests(PorcelainTestCase):
     """Tests for upload_pack."""
 


### PR DESCRIPTION
This PR adds a new function porcelain.shortlog to the Dulwich porcelain module. The function summarizes commits by author, similar to Git’s git shortlog.