### PR TITLE
add --all flag to branch command

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -2058,20 +2058,18 @@ class cmd_branch(Command):
             action="store_true",
             help="Delete branch",
         )
-        parser.add_argument(
-            "--all",
-            action="store_true",
-            help="List all branches"
-        )
+        parser.add_argument("--all", action="store_true", help="List all branches")
         args = parser.parse_args(args)
-        
+
         if args.all:
             try:
-                branches = porcelain.branch_list(".") + porcelain.branch_remotes_list(".")
+                branches = porcelain.branch_list(".") + porcelain.branch_remotes_list(
+                    "."
+                )
 
                 for branch in branches:
                     sys.stdout.write(f"{branch.decode()}\n")
-                    
+
                 return 0
             except porcelain.Error as e:
                 sys.stderr.write(f"{e}")

--- a/dulwich/porcelain.py
+++ b/dulwich/porcelain.py
@@ -3232,10 +3232,10 @@ def branch_list(repo: RepoPath) -> list[bytes]:
                 branches.sort(key=lambda b: (get_commit_date(b), b))
         else:
             # Unknown sort key, fall back to default
-            branches.sort()  
+            branches.sort()
 
         return branches
-        
+
 
 def branch_remotes_list(repo: RepoPath) -> list[bytes]:
     """List the short names of all remote branches.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -421,7 +421,7 @@ class BranchCommandTest(DulwichCliTestCase):
         # Delete branch
         result, stdout, stderr = self._run_cli("branch", "-d", "test-branch")
         self.assertNotIn(b"refs/heads/test-branch", self.repo.refs.keys())
-    
+
     def test_branch_list_all(self):
         # Create initial commit and local branches
         test_file = os.path.join(self.repo_path, "test.txt")
@@ -431,13 +431,17 @@ class BranchCommandTest(DulwichCliTestCase):
         self._run_cli("commit", "--message=Initial")
 
         # Create local test branches
-        self._run_cli("branch", "feature-1") 
+        self._run_cli("branch", "feature-1")
         self._run_cli("branch", "feature-2")
-        
-        # Setup a remote and create remote branches 
-        self.repo.refs[b"refs/remotes/origin/master"] = self.repo.refs[b"refs/heads/master"]
-        self.repo.refs[b"refs/remotes/origin/feature-remote"] = self.repo.refs[b"refs/heads/master"]
-        
+
+        # Setup a remote and create remote branches
+        self.repo.refs[b"refs/remotes/origin/master"] = self.repo.refs[
+            b"refs/heads/master"
+        ]
+        self.repo.refs[b"refs/remotes/origin/feature-remote"] = self.repo.refs[
+            b"refs/heads/master"
+        ]
+
         # Test --all listing
         result, stdout, stderr = self._run_cli("branch", "--all")
         self.assertEqual(result, 0)
@@ -445,17 +449,17 @@ class BranchCommandTest(DulwichCliTestCase):
         expected_branches = {
             "feature-1",  # local branch
             "feature-2",  # local branch
-            "master",     # local branch
-            "origin/master",      # remote branch
-            "origin/feature-remote"  # remote branch 
+            "master",  # local branch
+            "origin/master",  # remote branch
+            "origin/feature-remote",  # remote branch
         }
         lines = [line.strip() for line in stdout.splitlines()]
 
         # All branches from stdout
-        all_branches = set(line for line in lines)   
+        all_branches = set(line for line in lines)
         self.assertEqual(all_branches, expected_branches)
-        
-        
+
+
 class CheckoutCommandTest(DulwichCliTestCase):
     """Tests for checkout command."""
 

--- a/tests/test_porcelain.py
+++ b/tests/test_porcelain.py
@@ -6581,9 +6581,13 @@ class BranchRemoteListTests(PorcelainTestCase):
 
         # Should return only branch names, sorted alphabetically
         branches = porcelain.branch_remotes_list(self.repo)
-        expected = [b"origin/feature-1", b"origin/feature-2", b"origin/feature-3", b"origin/feature-4"]
+        expected = [
+            b"origin/feature-1",
+            b"origin/feature-2",
+            b"origin/feature-3",
+            b"origin/feature-4",
+        ]
         self.assertEqual(expected, branches)
-    
 
     def test_remote_branches_refname_reverse_sort(self) -> None:
         [c1] = build_commit_graph(self.repo.object_store, [[1]])
@@ -6599,7 +6603,12 @@ class BranchRemoteListTests(PorcelainTestCase):
         config.write_to_path()
 
         branches = porcelain.branch_remotes_list(self.repo)
-        expected = [b"origin/feature-4", b"origin/feature-3", b"origin/feature-2", b"origin/feature-1"]
+        expected = [
+            b"origin/feature-4",
+            b"origin/feature-3",
+            b"origin/feature-2",
+            b"origin/feature-1",
+        ]
         self.assertEqual(expected, branches)
 
     def test_remote_branches_committerdate_sort(self) -> None:
@@ -6611,8 +6620,8 @@ class BranchRemoteListTests(PorcelainTestCase):
             attrs={
                 1: {"commit_time": 1000},
                 2: {"commit_time": 2000},
-                3: {"commit_time": 3000}
-            }
+                3: {"commit_time": 3000},
+            },
         )
 
         self.repo.refs[b"refs/remotes/origin/oldest"] = c1.id
@@ -6635,8 +6644,8 @@ class BranchRemoteListTests(PorcelainTestCase):
             self.repo.object_store,
             [[1], [2], [3]],
             attrs={
-                1: {"commit_time": 1000},  
-                2: {"commit_time": 2000},  
+                1: {"commit_time": 1000},
+                2: {"commit_time": 2000},
                 3: {"commit_time": 1500},
             },
         )
@@ -6661,9 +6670,9 @@ class BranchRemoteListTests(PorcelainTestCase):
             self.repo.object_store,
             [[1], [2], [3]],
             attrs={
-                1: {"author_time": 1500},  
-                2: {"author_time": 2000},  
-                3: {"author_time": 1000},  
+                1: {"author_time": 1500},
+                2: {"author_time": 2000},
+                3: {"author_time": 1000},
             },
         )
 
@@ -6679,7 +6688,7 @@ class BranchRemoteListTests(PorcelainTestCase):
         branches = porcelain.branch_remotes_list(self.repo)
         expected = [b"origin/oldest", b"origin/middle", b"origin/newest"]
         self.assertEqual(expected, branches)
-    
+
     def test_unknown_sort_key(self) -> None:
         """Test that unknown sort key raises ValueError."""
         [c1] = build_commit_graph(self.repo.object_store, [[1]])
@@ -6693,11 +6702,11 @@ class BranchRemoteListTests(PorcelainTestCase):
         with self.assertRaises(ValueError) as cm:
             porcelain.branch_remotes_list(self.repo)
         self.assertIn("Unknown sort key: unknown", str(cm.exception))
-    
+
     def test_default_sort_no_config(self) -> None:
         """Test default sorting when no config is set."""
         [c1] = build_commit_graph(self.repo.object_store, [[1]])
-        
+
         self.repo.refs[b"refs/remotes/origin/feature-1"] = c1.id
         self.repo.refs[b"refs/remotes/origin/feature-2"] = c1.id
         self.repo.refs[b"refs/remotes/origin/feature-3"] = c1.id
@@ -6706,7 +6715,7 @@ class BranchRemoteListTests(PorcelainTestCase):
         branches = porcelain.branch_remotes_list(self.repo)
         expected = [b"origin/feature-1", b"origin/feature-2", b"origin/feature-3"]
         self.assertEqual(expected, branches)
-    
+
 
 class BranchCreateTests(PorcelainTestCase):
     def test_branch_exists(self) -> None:


### PR DESCRIPTION
This PR implements the --all flag for the dulwich branch command, which lists both local and remote-tracking branches.
 #1847
