### PR TITLE
Fix subprocess filter performance issues (#1789)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,8 @@
    performance in repositories with many LFS-tracked files.
    (Jelmer Vernooĳ, #1789)
 
+ * Add filter server support. (Jelmer Vernooĳ, #1789)
+
  * Add support for ``patiencediff`` algorithm in diff.
    (Jelmer Vernooĳ, #1795)
 

--- a/dulwich/lfs.py
+++ b/dulwich/lfs.py
@@ -324,6 +324,15 @@ class LFSFilterDriver:
 
         return content
 
+    def cleanup(self) -> None:
+        """Clean up any resources held by this filter driver."""
+        # LFSFilterDriver doesn't hold any resources that need cleanup
+
+    def reuse(self, config, filter_name: str) -> bool:
+        """Check if this filter driver should be reused with the given configuration."""
+        # LFSFilterDriver is stateless and lightweight, no need to cache
+        return False
+
 
 def _get_lfs_user_agent(config: Optional["Config"]) -> str:
     """Get User-Agent string for LFS requests, respecting git config."""

--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -190,6 +190,16 @@ class LineEndingFilter(FilterDriver):
 
         return self.smudge_conversion(data)
 
+    def cleanup(self) -> None:
+        """Clean up any resources held by this filter driver."""
+        # LineEndingFilter doesn't hold any resources that need cleanup
+
+    def reuse(self, config, filter_name: str) -> bool:
+        """Check if this filter driver should be reused with the given configuration."""
+        # LineEndingFilter is lightweight and should always be recreated
+        # to ensure it uses the latest configuration
+        return False
+
 
 def convert_crlf_to_lf(text_hunk: bytes) -> bytes:
     """Convert CRLF in text hunk into LF.

--- a/dulwich/sparse_patterns.py
+++ b/dulwich/sparse_patterns.py
@@ -167,7 +167,9 @@ def apply_included_paths(
         # Create a temporary blob for normalization
         temp_blob = Blob()
         temp_blob.data = disk_data
-        norm_blob = normalizer.checkin_normalize(temp_blob, os.path.relpath(full_path, repo.path).encode())
+        norm_blob = normalizer.checkin_normalize(
+            temp_blob, os.path.relpath(full_path, repo.path).encode()
+        )
         norm_data = norm_blob.data
         if not isinstance(blob_obj, Blob):
             return True

--- a/dulwich/sparse_patterns.py
+++ b/dulwich/sparse_patterns.py
@@ -164,7 +164,11 @@ def apply_included_paths(
             blob_obj = repo.object_store[index_entry.sha]
         except KeyError:
             return True
-        norm_data = normalizer.checkin_normalize(disk_data, full_path)
+        # Create a temporary blob for normalization
+        temp_blob = Blob()
+        temp_blob.data = disk_data
+        norm_blob = normalizer.checkin_normalize(temp_blob, os.path.relpath(full_path, repo.path).encode())
+        norm_data = norm_blob.data
         if not isinstance(blob_obj, Blob):
             return True
         return bool(norm_data != blob_obj.data)

--- a/tests/test_line_ending.py
+++ b/tests/test_line_ending.py
@@ -519,6 +519,12 @@ class LineEndingIntegrationTests(TestCase):
             def smudge(self, data):
                 return b"LFS content"
 
+            def cleanup(self):
+                pass
+
+            def reuse(self, config, filter_name):
+                return False
+
         self.registry.register_driver("lfs", MockLFSFilter())
 
         # Different files use different filters


### PR DESCRIPTION
The ProcessFilterDriver was spawning a new subprocess for every file operation, causing severe performance degradation for large repositories (minutes instead of milliseconds for git status).

This commit implements the Git filter process protocol to use a single long-running process for all filter operations:

- Add support for filter.<driver>.process configuration
- Implement Git filter process protocol (version 2) with proper pkt-line format

Fixes #1789