### PR TITLE
add --remotes to branch command

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -2059,6 +2059,9 @@ class cmd_branch(Command):
             help="Delete branch",
         )
         parser.add_argument("--all", action="store_true", help="List all branches")
+        parser.add_argument(
+            "--remotes", action="store_true", help="List remotes branches"
+        )
         args = parser.parse_args(args)
 
         if args.all:
@@ -2066,6 +2069,18 @@ class cmd_branch(Command):
                 branches = porcelain.branch_list(".") + porcelain.branch_remotes_list(
                     "."
                 )
+
+                for branch in branches:
+                    sys.stdout.write(f"{branch.decode()}\n")
+
+                return 0
+            except porcelain.Error as e:
+                sys.stderr.write(f"{e}")
+                return 1
+
+        if args.remotes:
+            try:
+                branches = porcelain.branch_remotes_list(".")
 
                 for branch in branches:
                     sys.stdout.write(f"{branch.decode()}\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -423,7 +423,7 @@ class BranchCommandTest(DulwichCliTestCase):
         self.assertNotIn(b"refs/heads/test-branch", self.repo.refs.keys())
 
     def test_branch_list_all(self):
-        # Create initial commit and local branches
+        # Create initial commit
         test_file = os.path.join(self.repo_path, "test.txt")
         with open(test_file, "w") as f:
             f.write("test")
@@ -458,6 +458,38 @@ class BranchCommandTest(DulwichCliTestCase):
         # All branches from stdout
         all_branches = set(line for line in lines)
         self.assertEqual(all_branches, expected_branches)
+
+    def test_branch_list_remotes(self):
+        # Create initial commit
+        test_file = os.path.join(self.repo_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("test")
+        self._run_cli("add", "test.txt")
+        self._run_cli("commit", "--message=Initial")
+
+        # Setup a remote and create remote branches
+        self.repo.refs[b"refs/remotes/origin/master"] = self.repo.refs[
+            b"refs/heads/master"
+        ]
+        self.repo.refs[b"refs/remotes/origin/feature-remote-1"] = self.repo.refs[
+            b"refs/heads/master"
+        ]
+        self.repo.refs[b"refs/remotes/origin/feature-remote-2"] = self.repo.refs[
+            b"refs/heads/master"
+        ]
+
+        # Test --remotes listing
+        result, stdout, stderr = self._run_cli("branch", "--remotes")
+        self.assertEqual(result, 0)
+
+        branches = [line.strip() for line in stdout.splitlines()]
+        expected_branches = [
+            "origin/feature-remote-1",
+            "origin/feature-remote-2",
+            "origin/master",
+        ]
+
+        self.assertEqual(branches, expected_branches)
 
 
 class CheckoutCommandTest(DulwichCliTestCase):


### PR DESCRIPTION
This PR implements the --remotes flag for the dulwich branch command, which lists remotes branches.
https://github.com/jelmer/dulwich/issues/1847