### PR TITLE
add --no-merged to branch command 

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -2063,7 +2063,9 @@ class cmd_branch(Command):
             "--merged", action="store_true", help="List merged into current branch"
         )
         parser.add_argument(
-            "--no-merged", action="store_true", help="List branches not merged into current branch"
+            "--no-merged",
+            action="store_true",
+            help="List branches not merged into current branch",
         )
         parser.add_argument(
             "--remotes", action="store_true", help="List remotes branches"

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -2060,7 +2060,10 @@ class cmd_branch(Command):
         )
         parser.add_argument("--all", action="store_true", help="List all branches")
         parser.add_argument(
-            "--merged", action="store_true", help="List merged branches"
+            "--merged", action="store_true", help="List merged into current branch"
+        )
+        parser.add_argument(
+            "--no-merged", action="store_true", help="List branches not merged into current branch"
         )
         parser.add_argument(
             "--remotes", action="store_true", help="List remotes branches"
@@ -2084,6 +2087,18 @@ class cmd_branch(Command):
         if args.merged:
             try:
                 branches_iter = porcelain.merged_branches(".")
+
+                for branch in branches_iter:
+                    sys.stdout.write(f"{branch.decode()}\n")
+
+                return 0
+            except porcelain.Error as e:
+                sys.stderr.write(f"{e}")
+                return 1
+
+        if args.no_merged:
+            try:
+                branches_iter = porcelain.no_merged_branches(".")
 
                 for branch in branches_iter:
                     sys.stdout.write(f"{branch.decode()}\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -495,6 +495,42 @@ class BranchCommandTest(DulwichCliTestCase):
         expected_branches = {"master", "merged-branch"}
         self.assertEqual(set(branches), expected_branches)
 
+    def test_branch_list_no_merged(self):
+        # Create initial commit
+        test_file = os.path.join(self.repo_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("test")
+        self._run_cli("add", "test.txt")
+        self._run_cli("commit", "--message=Initial")
+
+        master_sha = self.repo.refs[b"refs/heads/master"]
+
+        # Create a merged branch (points to same commit as master)
+        self.repo.refs[b"refs/heads/merged-branch"] = master_sha
+
+        # Create a new branch with different content (not merged)
+        test_file2 = os.path.join(self.repo_path, "test2.txt")
+        with open(test_file2, "w") as f:
+            f.write("test2")
+        self._run_cli("add", "test2.txt")
+        self._run_cli("commit", "--message=New branch commit")
+        new_branch_sha = self.repo.refs[b"HEAD"]
+
+        # Switch back to master
+        self.repo.refs[b"HEAD"] = master_sha
+
+        # Create a non-merged branch that points to the new branch commit
+        self.repo.refs[b"refs/heads/non-merged-branch"] = new_branch_sha
+
+        # Test --no-merged listing
+        result, stdout, stderr = self._run_cli("branch", "--no-merged")
+        self.assertEqual(result, 0)
+
+        branches = [line.strip() for line in stdout.splitlines()]
+        expected_branches = {"non-merged-branch"}
+
+        self.assertEqual(set(branches), expected_branches)
+
     def test_branch_list_remotes(self):
         # Create initial commit
         test_file = os.path.join(self.repo_path, "test.txt")


### PR DESCRIPTION
Implements the --no-merged flag for the dulwich branch command, 
which lists branches that have not been merged into the current branch
https://github.com/jelmer/dulwich/issues/1847