### PR TITLE
Add support for core.whitespace and core.safecrlf

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,7 +31,16 @@
 
  * Fix handling of CRLF line endings with ``core.autocrlf = input`` to prevent
    unchanged files from appearing as unstaged in status.
-   (Jelmer Vernooĳ, #1770)
+   (Jelmer Vernooĳ, #1773)
+
+ * Add support for ``core.whitespace`` configuration for whitespace error
+   detection and fixing. Supports blank-at-eol, space-before-tab, indent-with-non-tab,
+   tab-in-indent, blank-at-eof, cr-at-eol, and tabwidth settings.
+   (Jelmer Vernooĳ, #1806)
+
+ * Add support for ``core.safecrlf`` configuration to check if CRLF/LF conversions
+   would be reversible and optionally abort or warn on potentially lossy conversions.
+   (Jelmer Vernooĳ, #1806)
 
  * Add support for ``http.extraHeader`` configuration to pass additional HTTP
    headers to the server when communicating over HTTP(S).

--- a/dulwich/filters.py
+++ b/dulwich/filters.py
@@ -652,53 +652,9 @@ class FilterRegistry:
         This filter is used when files have the 'text' attribute set explicitly.
         It always normalizes line endings on checkin (CRLF -> LF).
         """
-        from .line_ending import (
-            LineEndingFilter,
-            convert_crlf_to_lf,
-            get_smudge_filter,
-        )
+        from .line_ending import LineEndingFilter
 
-        if self.config is None:
-            # Default text filter: always normalize on checkin
-            return LineEndingFilter(
-                clean_conversion=convert_crlf_to_lf,
-                smudge_conversion=None,
-                binary_detection=True,
-            )
-
-        # Get core.eol and core.autocrlf settings for smudge behavior
-        try:
-            core_eol_raw = self.config.get("core", "eol")
-            core_eol: str = (
-                core_eol_raw.decode("ascii")
-                if isinstance(core_eol_raw, bytes)
-                else core_eol_raw
-            )
-        except KeyError:
-            core_eol = "native"
-
-        # Parse autocrlf as bytes (can be b"true", b"input", or b"false")
-        try:
-            autocrlf_raw = self.config.get("core", "autocrlf")
-            autocrlf: bytes = (
-                autocrlf_raw.lower()
-                if isinstance(autocrlf_raw, bytes)
-                else str(autocrlf_raw).lower().encode("ascii")
-            )
-        except KeyError:
-            autocrlf = b"false"
-
-        # For explicit text attribute:
-        # - Always normalize to LF on checkin (clean)
-        # - Smudge behavior depends on core.eol and core.autocrlf
-        smudge_filter = get_smudge_filter(core_eol, autocrlf)
-        clean_filter = convert_crlf_to_lf
-
-        return LineEndingFilter(
-            clean_conversion=clean_filter,
-            smudge_conversion=smudge_filter,
-            binary_detection=True,
-        )
+        return LineEndingFilter.from_config(self.config, for_text_attr=True)
 
     def _setup_line_ending_filter(self) -> None:
         """Automatically register line ending filter if configured."""

--- a/dulwich/whitespace.py
+++ b/dulwich/whitespace.py
@@ -1,0 +1,282 @@
+# whitespace.py -- Whitespace error detection and fixing
+# Copyright (C) 2025 Dulwich contributors
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+"""Whitespace error detection and fixing functionality.
+
+This module implements Git's core.whitespace configuration and related
+whitespace error detection capabilities.
+"""
+
+from typing import Optional
+
+# Default whitespace errors Git checks for
+DEFAULT_WHITESPACE_ERRORS = {
+    "blank-at-eol",
+    "space-before-tab",
+    "blank-at-eof",
+}
+
+# All available whitespace error types
+WHITESPACE_ERROR_TYPES = {
+    "blank-at-eol",  # Trailing whitespace at end of line
+    "space-before-tab",  # Space before tab in indentation
+    "indent-with-non-tab",  # Indent with space when tabs expected (8+ spaces)
+    "tab-in-indent",  # Tab in indentation when spaces expected
+    "blank-at-eof",  # Blank lines at end of file
+    "trailing-space",  # Trailing whitespace (same as blank-at-eol)
+    "cr-at-eol",  # Carriage return at end of line
+    "tabwidth",  # Special: sets tab width (not an error type)
+}
+
+
+def parse_whitespace_config(value: Optional[str]) -> tuple[set[str], int]:
+    """Parse core.whitespace configuration value.
+
+    Args:
+        value: The core.whitespace config value (e.g., "blank-at-eol,space-before-tab")
+
+    Returns:
+        Tuple of (enabled error types, tab width)
+    """
+    if value is None:
+        return DEFAULT_WHITESPACE_ERRORS.copy(), 8
+
+    if value == "":
+        return set(), 8
+
+    # Start with defaults if no explicit errors are specified or if negation is used
+    parts = value.split(",")
+    has_negation = any(p.strip().startswith("-") for p in parts)
+    has_explicit_errors = any(p.strip() in WHITESPACE_ERROR_TYPES for p in parts)
+
+    if has_negation or not has_explicit_errors:
+        enabled = DEFAULT_WHITESPACE_ERRORS.copy()
+    else:
+        enabled = set()
+
+    tab_width = 8
+
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+
+        # Handle negation
+        if part.startswith("-"):
+            error_type = part[1:]
+            if error_type in WHITESPACE_ERROR_TYPES:
+                enabled.discard(error_type)
+        elif part.startswith("tabwidth="):
+            try:
+                tab_width = int(part[9:])
+                if tab_width < 1:
+                    tab_width = 8
+            except ValueError:
+                tab_width = 8
+        elif part in WHITESPACE_ERROR_TYPES:
+            enabled.add(part)
+
+    # Handle aliases
+    if "trailing-space" in enabled:
+        enabled.add("blank-at-eol")
+        enabled.discard("trailing-space")
+
+    return enabled, tab_width
+
+
+class WhitespaceChecker:
+    """Checks for whitespace errors in text content."""
+
+    def __init__(self, enabled_errors: set[str], tab_width: int = 8):
+        """Initialize whitespace checker.
+
+        Args:
+            enabled_errors: Set of error types to check for
+            tab_width: Width of tab character for indentation checking
+        """
+        self.enabled_errors = enabled_errors
+        self.tab_width = tab_width
+
+    def check_line(self, line: bytes, line_num: int) -> list[tuple[str, int]]:
+        """Check a single line for whitespace errors.
+
+        Args:
+            line: Line content (without newline)
+            line_num: Line number (1-based)
+
+        Returns:
+            List of (error_type, line_number) tuples
+        """
+        errors = []
+
+        # Check for trailing whitespace (blank-at-eol)
+        if "blank-at-eol" in self.enabled_errors:
+            if line and (line[-1:] == b" " or line[-1:] == b"\t"):
+                # Find where trailing whitespace starts
+                i = len(line) - 1
+                while i >= 0 and line[i : i + 1] in (b" ", b"\t"):
+                    i -= 1
+                errors.append(("blank-at-eol", line_num))
+
+        # Check for space before tab
+        if "space-before-tab" in self.enabled_errors:
+            # Check in indentation
+            i = 0
+            while i < len(line) and line[i : i + 1] in (b" ", b"\t"):
+                if i > 0 and line[i - 1 : i] == b" " and line[i : i + 1] == b"\t":
+                    errors.append(("space-before-tab", line_num))
+                    break
+                i += 1
+
+        # Check for indent-with-non-tab (8+ spaces at start)
+        if "indent-with-non-tab" in self.enabled_errors:
+            space_count = 0
+            for i in range(len(line)):
+                if line[i : i + 1] == b" ":
+                    space_count += 1
+                    if space_count >= self.tab_width:
+                        errors.append(("indent-with-non-tab", line_num))
+                        break
+                elif line[i : i + 1] == b"\t":
+                    space_count = 0  # Reset on tab
+                else:
+                    break  # Non-whitespace character
+
+        # Check for tab-in-indent
+        if "tab-in-indent" in self.enabled_errors:
+            for i in range(len(line)):
+                if line[i : i + 1] == b"\t":
+                    errors.append(("tab-in-indent", line_num))
+                    break
+                elif line[i : i + 1] not in (b" ", b"\t"):
+                    break  # Non-whitespace character
+
+        # Check for carriage return
+        if "cr-at-eol" in self.enabled_errors:
+            if line and line[-1:] == b"\r":
+                errors.append(("cr-at-eol", line_num))
+
+        return errors
+
+    def check_content(self, content: bytes) -> list[tuple[str, int]]:
+        """Check content for whitespace errors.
+
+        Args:
+            content: File content to check
+
+        Returns:
+            List of (error_type, line_number) tuples
+        """
+        errors = []
+        lines = content.split(b"\n")
+
+        # Handle CRLF line endings
+        for i, line in enumerate(lines):
+            if line.endswith(b"\r"):
+                lines[i] = line[:-1]
+
+        # Check each line
+        for i, line in enumerate(lines):
+            errors.extend(self.check_line(line, i + 1))
+
+        # Check for blank lines at end of file
+        if "blank-at-eof" in self.enabled_errors:
+            # Skip the last empty line if content ends with newline
+            check_lines = lines[:-1] if lines and lines[-1] == b"" else lines
+
+            if check_lines:
+                trailing_blank_count = 0
+                for i in range(len(check_lines) - 1, -1, -1):
+                    if check_lines[i] == b"":
+                        trailing_blank_count += 1
+                    else:
+                        break
+
+                if trailing_blank_count > 0:
+                    # Report the line number of the last non-empty line + 1
+                    errors.append(("blank-at-eof", len(check_lines) + 1))
+
+        return errors
+
+
+def fix_whitespace_errors(
+    content: bytes, errors: list[tuple[str, int]], fix_types: Optional[set[str]] = None
+) -> bytes:
+    """Fix whitespace errors in content.
+
+    Args:
+        content: Original content
+        errors: List of errors from WhitespaceChecker
+        fix_types: Set of error types to fix (None means fix all)
+
+    Returns:
+        Fixed content
+    """
+    if not errors:
+        return content
+
+    lines = content.split(b"\n")
+
+    # Handle CRLF line endings - we need to track which lines had them
+    has_crlf = []
+    for i, line in enumerate(lines):
+        if line.endswith(b"\r"):
+            has_crlf.append(i)
+            lines[i] = line[:-1]
+
+    # Group errors by line
+    errors_by_line: dict[int, list[str]] = {}
+    for error_type, line_num in errors:
+        if fix_types is None or error_type in fix_types:
+            if line_num not in errors_by_line:
+                errors_by_line[line_num] = []
+            errors_by_line[line_num].append(error_type)
+
+    # Fix errors
+    for line_num, error_types in errors_by_line.items():
+        if line_num > len(lines):
+            continue
+
+        line_idx = line_num - 1
+        line = lines[line_idx]
+
+        # Fix trailing whitespace
+        if "blank-at-eol" in error_types:
+            # Remove trailing spaces and tabs
+            while line and line[-1:] in (b" ", b"\t"):
+                line = line[:-1]
+            lines[line_idx] = line
+
+        # Fix carriage return - since we already stripped CRs, we just don't restore them
+        if "cr-at-eol" in error_types and line_idx in has_crlf:
+            has_crlf.remove(line_idx)
+
+    # Restore CRLF for lines that should keep them
+    for idx in has_crlf:
+        if idx < len(lines):
+            lines[idx] = lines[idx] + b"\r"
+
+    # Fix blank lines at end of file
+    if fix_types is None or "blank-at-eof" in fix_types:
+        # Remove trailing empty lines
+        while len(lines) > 1 and lines[-1] == b"" and lines[-2] == b"":
+            lines.pop()
+
+    return b"\n".join(lines)

--- a/tests/test_whitespace.py
+++ b/tests/test_whitespace.py
@@ -1,0 +1,274 @@
+# test_whitespace.py -- Tests for whitespace error detection
+# Copyright (C) 2025 Dulwich contributors
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Tests for whitespace error detection."""
+
+from dulwich.whitespace import (
+    DEFAULT_WHITESPACE_ERRORS,
+    WhitespaceChecker,
+    fix_whitespace_errors,
+    parse_whitespace_config,
+)
+
+from . import TestCase
+
+
+class WhitespaceConfigTests(TestCase):
+    """Test core.whitespace configuration parsing."""
+
+    def test_parse_default(self) -> None:
+        """Test default whitespace configuration."""
+        errors, tab_width = parse_whitespace_config(None)
+        self.assertEqual(errors, DEFAULT_WHITESPACE_ERRORS)
+        self.assertEqual(tab_width, 8)
+
+    def test_parse_empty(self) -> None:
+        """Test empty whitespace configuration."""
+        errors, tab_width = parse_whitespace_config("")
+        self.assertEqual(errors, set())
+        self.assertEqual(tab_width, 8)
+
+    def test_parse_single_error(self) -> None:
+        """Test single error type."""
+        errors, tab_width = parse_whitespace_config("blank-at-eol")
+        self.assertEqual(errors, {"blank-at-eol"})
+        self.assertEqual(tab_width, 8)
+
+    def test_parse_multiple_errors(self) -> None:
+        """Test multiple error types."""
+        errors, tab_width = parse_whitespace_config(
+            "blank-at-eol,space-before-tab,tab-in-indent"
+        )
+        self.assertEqual(errors, {"blank-at-eol", "space-before-tab", "tab-in-indent"})
+        self.assertEqual(tab_width, 8)
+
+    def test_parse_with_negation(self) -> None:
+        """Test negation of default errors."""
+        errors, tab_width = parse_whitespace_config("-blank-at-eol")
+        # Should have defaults minus blank-at-eol
+        expected = DEFAULT_WHITESPACE_ERRORS - {"blank-at-eol"}
+        self.assertEqual(errors, expected)
+        self.assertEqual(tab_width, 8)
+
+    def test_parse_trailing_space_alias(self) -> None:
+        """Test that trailing-space is an alias for blank-at-eol."""
+        errors, tab_width = parse_whitespace_config("trailing-space")
+        self.assertEqual(errors, {"blank-at-eol"})
+        self.assertEqual(tab_width, 8)
+
+    def test_parse_tabwidth(self) -> None:
+        """Test tabwidth setting."""
+        errors, tab_width = parse_whitespace_config("blank-at-eol,tabwidth=4")
+        self.assertEqual(errors, {"blank-at-eol"})
+        self.assertEqual(tab_width, 4)
+
+    def test_parse_invalid_tabwidth(self) -> None:
+        """Test invalid tabwidth defaults to 8."""
+        errors, tab_width = parse_whitespace_config("tabwidth=invalid")
+        self.assertEqual(tab_width, 8)
+
+        errors, tab_width = parse_whitespace_config("tabwidth=0")
+        self.assertEqual(tab_width, 8)
+
+
+class WhitespaceCheckerTests(TestCase):
+    """Test WhitespaceChecker functionality."""
+
+    def test_blank_at_eol(self) -> None:
+        """Test detection of trailing whitespace."""
+        checker = WhitespaceChecker({"blank-at-eol"})
+
+        # No trailing whitespace
+        errors = checker.check_line(b"normal line", 1)
+        self.assertEqual(errors, [])
+
+        # Trailing space
+        errors = checker.check_line(b"trailing space ", 1)
+        self.assertEqual(errors, [("blank-at-eol", 1)])
+
+        # Trailing tab
+        errors = checker.check_line(b"trailing tab\t", 1)
+        self.assertEqual(errors, [("blank-at-eol", 1)])
+
+        # Multiple trailing whitespace
+        errors = checker.check_line(b"multiple  \t ", 1)
+        self.assertEqual(errors, [("blank-at-eol", 1)])
+
+    def test_space_before_tab(self) -> None:
+        """Test detection of space before tab in indentation."""
+        checker = WhitespaceChecker({"space-before-tab"})
+
+        # No space before tab
+        errors = checker.check_line(b"\tindented", 1)
+        self.assertEqual(errors, [])
+
+        # Space before tab in indentation
+        errors = checker.check_line(b" \tindented", 1)
+        self.assertEqual(errors, [("space-before-tab", 1)])
+
+        # Space before tab not in indentation (should not trigger)
+        errors = checker.check_line(b"code \t comment", 1)
+        self.assertEqual(errors, [])
+
+    def test_indent_with_non_tab(self) -> None:
+        """Test detection of 8+ spaces at start of line."""
+        checker = WhitespaceChecker({"indent-with-non-tab"}, tab_width=8)
+
+        # Less than 8 spaces
+        errors = checker.check_line(b"    code", 1)
+        self.assertEqual(errors, [])
+
+        # Exactly 8 spaces
+        errors = checker.check_line(b"        code", 1)
+        self.assertEqual(errors, [("indent-with-non-tab", 1)])
+
+        # More than 8 spaces
+        errors = checker.check_line(b"         code", 1)
+        self.assertEqual(errors, [("indent-with-non-tab", 1)])
+
+        # Tab after spaces resets count
+        errors = checker.check_line(b"    \t    code", 1)
+        self.assertEqual(errors, [])
+
+        # Custom tab width
+        checker = WhitespaceChecker({"indent-with-non-tab"}, tab_width=4)
+        errors = checker.check_line(b"    code", 1)
+        self.assertEqual(errors, [("indent-with-non-tab", 1)])
+
+    def test_tab_in_indent(self) -> None:
+        """Test detection of tabs in indentation."""
+        checker = WhitespaceChecker({"tab-in-indent"})
+
+        # No tabs
+        errors = checker.check_line(b"    code", 1)
+        self.assertEqual(errors, [])
+
+        # Tab in indentation
+        errors = checker.check_line(b"\tcode", 1)
+        self.assertEqual(errors, [("tab-in-indent", 1)])
+
+        # Tab after non-whitespace (should not trigger)
+        errors = checker.check_line(b"code\tcomment", 1)
+        self.assertEqual(errors, [])
+
+    def test_cr_at_eol(self) -> None:
+        """Test detection of carriage return at end of line."""
+        checker = WhitespaceChecker({"cr-at-eol"})
+
+        # No CR
+        errors = checker.check_line(b"normal line", 1)
+        self.assertEqual(errors, [])
+
+        # CR at end
+        errors = checker.check_line(b"line\r", 1)
+        self.assertEqual(errors, [("cr-at-eol", 1)])
+
+    def test_blank_at_eof(self) -> None:
+        """Test detection of blank lines at end of file."""
+        checker = WhitespaceChecker({"blank-at-eof"})
+
+        # No trailing blank lines
+        content = b"line1\nline2\nline3"
+        errors = checker.check_content(content)
+        self.assertEqual(errors, [])
+
+        # One trailing blank line (normal for files ending with newline)
+        content = b"line1\nline2\nline3\n"
+        errors = checker.check_content(content)
+        self.assertEqual(errors, [])
+
+        # Multiple trailing blank lines
+        content = b"line1\nline2\n\n\n"
+        errors = checker.check_content(content)
+        self.assertEqual(errors, [("blank-at-eof", 5)])
+
+        # Only blank lines
+        content = b"\n\n\n"
+        errors = checker.check_content(content)
+        self.assertEqual(errors, [("blank-at-eof", 4)])
+
+    def test_multiple_errors(self) -> None:
+        """Test detection of multiple error types."""
+        checker = WhitespaceChecker(
+            {"blank-at-eol", "space-before-tab", "tab-in-indent"}
+        )
+
+        # Line with multiple errors
+        errors = checker.check_line(b" \tcode  ", 1)
+        error_types = {e[0] for e in errors}
+        self.assertEqual(
+            error_types, {"blank-at-eol", "space-before-tab", "tab-in-indent"}
+        )
+
+    def test_check_content_crlf(self) -> None:
+        """Test content checking with CRLF line endings."""
+        checker = WhitespaceChecker({"blank-at-eol", "cr-at-eol"})
+
+        # CRLF line endings
+        content = b"line1\r\nline2 \r\nline3\r\n"
+        errors = checker.check_content(content)
+        # Should detect trailing space on line 2 but not CR (since CRLF is handled)
+        self.assertEqual(errors, [("blank-at-eol", 2)])
+
+
+class WhitespaceFixTests(TestCase):
+    """Test whitespace error fixing."""
+
+    def test_fix_blank_at_eol(self) -> None:
+        """Test fixing trailing whitespace."""
+        content = b"line1  \nline2\t\nline3"
+        errors = [("blank-at-eol", 1), ("blank-at-eol", 2)]
+        fixed = fix_whitespace_errors(content, errors)
+        self.assertEqual(fixed, b"line1\nline2\nline3")
+
+    def test_fix_blank_at_eof(self) -> None:
+        """Test fixing blank lines at end of file."""
+        content = b"line1\nline2\n\n\n"
+        errors = [("blank-at-eof", 4)]
+        fixed = fix_whitespace_errors(content, errors)
+        self.assertEqual(fixed, b"line1\nline2\n")
+
+    def test_fix_cr_at_eol(self) -> None:
+        """Test fixing carriage returns."""
+        content = b"line1\r\nline2\r\nline3\r"
+        errors = [("cr-at-eol", 1), ("cr-at-eol", 2), ("cr-at-eol", 3)]
+        fixed = fix_whitespace_errors(content, errors)
+        # Our fix function removes all CRs when cr-at-eol errors are fixed
+        self.assertEqual(fixed, b"line1\nline2\nline3")
+
+    def test_fix_specific_types(self) -> None:
+        """Test fixing only specific error types."""
+        content = b"line1  \nline2\n\n\n"
+        errors = [("blank-at-eol", 1), ("blank-at-eof", 4)]
+
+        # Fix only blank-at-eol
+        fixed = fix_whitespace_errors(content, errors, fix_types={"blank-at-eol"})
+        self.assertEqual(fixed, b"line1\nline2\n\n\n")
+
+        # Fix only blank-at-eof
+        fixed = fix_whitespace_errors(content, errors, fix_types={"blank-at-eof"})
+        self.assertEqual(fixed, b"line1  \nline2\n")
+
+    def test_fix_no_errors(self) -> None:
+        """Test fixing with no errors returns original content."""
+        content = b"line1\nline2\nline3"
+        fixed = fix_whitespace_errors(content, [])
+        self.assertEqual(fixed, content)


### PR DESCRIPTION
* Add core.whitespace configuration support for whitespace error detection
* Add core.safecrlf configuration support for safe CRLF conversion checks
* Refactor LineEndingFilter with from_config classmethod for cleaner code

Fixes #1806