### PR TITLE
Sequoia instead of "gpg"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -64,6 +64,10 @@
    parallel stat operations when checking for unstaged changes. This improves
    performance on slow filesystems like NFS. (Jelmer Vernooĳ, #1851)
 
+ * Use Sequoia for tag signing and verification instead of GnuPG. The
+   API remains the same but uses the "sq" tool to accomplish OpenPGP
+   operations (instead of importing "gpg" as before). (meejah, #1369)
+
 0.24.1	2025-08-01
 
  * Require ``typing_extensions`` on Python 3.10.

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1046,8 +1046,7 @@ class Tag(ShaFile):
     signature = serializable_property("signature", "Optional detached GPG signature")
 
     def sign(self, keyid: Optional[str] = None) -> None:
-        """
-        Sign this tag with an OpenPGP key.
+        """Sign this tag with an OpenPGP key.
 
         Args:
           keyid: Optional OpenPGP key ID (aka fingerprint) to use for signing.
@@ -1075,7 +1074,8 @@ class Tag(ShaFile):
             proc.stdin.write(data_to_sign)
             proc.stdin.close()
             if proc.wait() != 0:
-                raise RuntimeError("Signature failed: {}".format(proc.stderr.read()))
+                errmsg = proc.stderr.read().decode("utf8")
+                raise RuntimeError(f"Signature failed: {errmsg}")
             self.signature = proc.stdout.read()  # bytes
         finally:
             proc.terminate()

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -26,11 +26,13 @@ import binascii
 import os
 import posixpath
 import stat
+import subprocess
 import sys
 import zlib
 from collections.abc import Callable, Iterable, Iterator
 from hashlib import sha1
 from io import BufferedIOBase, BytesIO
+from tempfile import NamedTemporaryFile
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -1044,25 +1046,39 @@ class Tag(ShaFile):
     signature = serializable_property("signature", "Optional detached GPG signature")
 
     def sign(self, keyid: Optional[str] = None) -> None:
-        """Sign this tag with a GPG key.
+        """
+        Sign this tag with an OpenPGP key.
 
         Args:
-          keyid: Optional GPG key ID to use for signing. If not specified,
-                 the default GPG key will be used.
+          keyid: Optional OpenPGP key ID (aka fingerprint) to use for signing.
+                 If not specified, the default key will be used.
         """
-        import gnupg
-        gpg = gnupg.GPG()
-
-        sig = gpg.sign(
-            self.as_raw_string(),
-            keyid=keyid,
-            clearsign=True,
-            detach=True,
-        )
-        if not sig:
-            raise RuntimeError("signing failed")
+        data_to_sign = self.as_raw_string()
+        args = [
+            "sq", "sign",
+            "--signature-file", "-",
+        ]
+        if keyid is None:
+            args.append("--signer-self")
         else:
-            self.signature = str(sig).encode("utf8")
+            # there's also --signer-userid, --signer-email etc
+            args.append("--signer")
+            args.append(str(keyid))
+
+        proc = subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        try:
+            proc.stdin.write(data_to_sign)
+            proc.stdin.close()
+            if proc.wait() != 0:
+                raise RuntimeError("Signature failed: {}".format(proc.stderr.read()))
+            self.signature = proc.stdout.read()  # bytes
+        finally:
+            proc.terminate()
 
     def raw_without_sig(self) -> bytes:
         """Return raw string serialization without the GPG/SSH signature.
@@ -1075,7 +1091,7 @@ class Tag(ShaFile):
         return ret
 
     def verify(self, keyids: Optional[Iterable[str]] = None) -> None:
-        """Verify GPG signature for this tag (if it is signed).
+        """Verify OpenPGP signature for this tag (if it is signed).
 
         Args:
           keyids: Optional iterable of trusted keyids for this tag.
@@ -1084,35 +1100,40 @@ class Tag(ShaFile):
             has a valid signature.
 
         Raises:
-          gpg.errors.BadSignatures: if GPG signature verification fails
-          gpg.errors.MissingSignatures: if tag was not signed by a key
-            specified in keyids
+          RuntimeError: if anything fails verifying the signature
         """
         if self._signature is None:
             return
 
-        import gnupg
-        gpg = gnupg.GPG()
+        # the signature cannot be provided via stdin (unless we tried
+        # to "build our own" clearsigned message from the pieces)
+        with NamedTemporaryFile(delete_on_close=False) as sigfile:
+            sigfile.write(self._signature)
+            sigfile.close()
+            args = [
+                "sq", "verify",
+                "--signature-file", sigfile.name,
+            ]
+            if keyids is not None:
+                for keyid in keyids:
+                    args.append("--signer")
+                    args.append(keyid)
 
-        # no way to confirm with in-memory signature AND file (nor in
-        # Isis Lovecruft's version)
-
-        import tempfile
-        from io import BytesIO
-        datafname = tempfile.mktemp()
-        with open(datafname, 'wb') as f:
-            f.write(self.raw_without_sig())
-        verified = gpg.verify_file(BytesIO(self._signature), datafname)
-        if not verified:
-            raise RuntimeError("Bad signature")
-
-        if keyids:
-            available_keys = gpg.list_keys(keys=keyids)
-            for sig in verified.sig_info.values():
-                if sig["fingerprint"] in available_keys or \
-                   sig["pubkey_fingerprint"] in available_keys:
-                    return
-            raise RuntimeError("No valid signatures from specified keys")
+            proc = subprocess.Popen(
+                args,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            try:
+                # deliver the data to be verified
+                proc.stdin.write(self.raw_without_sig())
+                proc.stdin.close()
+                if proc.wait() != 0:
+                    raise RuntimeError("Verify failed: {}".format(proc.stderr.read().decode("utf8")))
+            finally:
+                proc.terminate()
+        return True
 
 
 class TreeEntry(NamedTuple):


### PR DESCRIPTION
Fixes #1369 

This replaces the use of "gpg" library with sequoia. This branch does this by shelling out to "sq".

I'd rather be using a Python library here, but `pysequoia` doesn't seem to be able to do most of what we get from using "sq" directly. I do have an attempt at that, too, but `pysequoia.verify()` wants a "store" argument -- but `pysequoia.Store` was removed in 0.1.24.

In addition "`sq`" seems to do fairly well at interacting with a `gpg-agent`, so the "shell out" implementation lets the API stay basically the same, and deal with key-id's ("fingerprints" to match sequoia).