### PR TITLE
Fix BlackboxTestCase to respect Python venv path

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -34,6 +34,7 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
 import tempfile
 
 # If Python itself provides an exception, use that
@@ -70,7 +71,7 @@ class BlackboxTestCase(TestCase):
 
     # TODO(jelmer): Include more possible binary paths.
     bin_directories: ClassVar[list[str]] = [
-        os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "bin")),
+        sysconfig.get_path("scripts"),
         "/usr/bin",
         "/usr/local/bin",
     ]


### PR DESCRIPTION
Fix BlackboxTestCase to include `sysconfig.get_path("scripts")` in binary paths, which corresponds to the binary directory used in the current virtual environment.  This ensures that the tests use the correct dulwich executables rather than the (possibly older) version installed to `/usr/bin`.

The test previously attempted to reconstruct the `bin` path relatively to the test file.  However, that logic stopped working correctly when tests were moved out of the package in 245331a60d743b7b73ba3a8b15e6f4648273369f.  I suspect that the problem may have went unnoticed for a time, since the tests are skipped when the binaries can't be found.  While it is technically possible to fix the reconstruction logic to use the `dulwich` module path, using `sysconfig` ensures we are using the correct path rather than guessing.