### PR TITLE
Implement GPG signing and verification support for commits and tags

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -46,7 +46,7 @@ jobs:
           # Install build-time dependencies
           python -m pip install --upgrade "setuptools>=77"
           python -m pip install --upgrade pip
-          pip install --upgrade ".[merge,fastimport,paramiko,https]"  setuptools-rust
+          pip install --upgrade ".[merge,fastimport,paramiko,https,patiencediff,colordiff]"  setuptools-rust
       - name: Install gpg on supported platforms
         run: pip install --upgrade ".[pgp]"
         if: "matrix.os != 'windows-latest' && matrix.python-version != 'pypy3'"

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1172,7 +1172,7 @@ class Tag(ShaFile):
             if keyids:
                 keys = [ctx.get_key(key) for key in keyids]
                 for key in keys:
-                    for subkey in keys:
+                    for subkey in key.subkeys:
                         for sig in result.signatures:
                             if subkey.can_sign and subkey.fpr == sig.fpr:
                                 return
@@ -1919,7 +1919,7 @@ class Commit(ShaFile):
             if keyids:
                 keys = [ctx.get_key(key) for key in keyids]
                 for key in keys:
-                    for subkey in keys:
+                    for subkey in key.subkeys:
                         for sig in result.signatures:
                             if subkey.can_sign and subkey.fpr == sig.fpr:
                                 return

--- a/tests/compat/test_porcelain.py
+++ b/tests/compat/test_porcelain.py
@@ -109,7 +109,7 @@ class CommitCreateSignTestCase(PorcelainGpgTestCase, CompatTestCase):
             self.repo.path,
             b"messy message messiah",
             b"foo <foo@b.ar>",
-            signoff=True,
+            sign=True,
         )
 
         run_git_or_fail(


### PR DESCRIPTION
This implements support for GPG signing and verification as requested in
#1790. Changes include:

- Fix bug in verify() methods where key.subkeys was incorrectly iterated
- Add support for commit.gpgsign and tag.gpgsign config options
- Add support for user.signingkey config option
- Add 'sign' parameter to porcelain.commit() for GPG signing commits
- Update porcelain.tag_create() to properly handle GPG signing with config
- Add verify_commit() and verify_tag() functions to porcelain module
- Update worktree.commit() to support config-based signing
- Clarify that 'signoff' is for DCO Signed-off-by, separate from GPG signing