### PR TITLE
Re-enable Android wheels build

### DIFF
--- a/.github/workflows/python-distributions.yml
+++ b/.github/workflows/python-distributions.yml
@@ -88,30 +88,27 @@ jobs:
           name: artifact-${{ matrix.build-identifier }}
           path: ./wheelhouse/*.whl
 
-  # Android wheels build disabled due to HTTP 403 Forbidden error when downloading
-  # Python 3.13.7 for Android from Maven repository (python-3.13.7-aarch64-linux-android.tar.gz)
-  # The download from https://repo.maven.apache.org fails during cibuildwheel setup
-  # build-android-wheels:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v5.0.0
-  #     - uses: actions/setup-python@v6
-  #       with:
-  #         cache: pip
-  #     - name: Install dependencies
-  #       run: |
-  #         python -m pip install --upgrade pip
-  #         pip install setuptools wheel cibuildwheel setuptools-rust
-  #     - name: Build Android wheels
-  #       run: python -m cibuildwheel --output-dir wheelhouse
-  #       env:
-  #         CIBW_PLATFORM: android
-  #         CIBW_ARCHS_ANDROID: arm64_v8a x86_64
-  #     - name: Upload Android wheels
-  #       uses: actions/upload-artifact@v4.6.2
-  #       with:
-  #         name: artifact-android
-  #         path: ./wheelhouse/*.whl
+  build-android-wheels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-python@v6
+        with:
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel cibuildwheel setuptools-rust
+      - name: Build Android wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_PLATFORM: android
+          CIBW_ARCHS_ANDROID: arm64_v8a x86_64
+      - name: Upload Android wheels
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: artifact-android
+          path: ./wheelhouse/*.whl
 
   build-pure-wheels:
     runs-on: ubuntu-latest
@@ -175,7 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-wheels
-      # - build-android-wheels
+      - build-android-wheels
       - build-sdist
       - build-pure-wheels
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/dulwich-')


### PR DESCRIPTION
Reverts #1892.

I'm not sure why [GitHub Actions was unable to access Maven Central](https://github.com/pypa/cibuildwheel/pull/2607#issuecomment-3355342017), but it looks like it's OK now.