### PR TITLE
Restore pool_manager parameter to transport functions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,10 @@
    credentials to git config, allowing subsequent push operations to succeed.
    (Jelmer Vernooĳ, #1925)
 
+ * Restore ``pool_manager`` parameter to ``get_transport_and_path`` and
+   ``get_transport_and_path_from_url`` functions that was accidentally removed
+   during type annotation refactoring. (Jelmer Vernooĳ, #1928)
+
 0.24.4	2025-10-14
 
  * Add compatibility for Python 3.14.  (Jelmer Vernooĳ)

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3842,6 +3842,7 @@ class AbstractHttpGitClient(GitClient):
         username: Optional[str] = None,
         password: Optional[str] = None,
         config: Optional[Config] = None,
+        pool_manager: Optional["urllib3.PoolManager"] = None,
     ) -> "AbstractHttpGitClient":
         """Create an AbstractHttpGitClient from a parsed URL.
 
@@ -3855,6 +3856,7 @@ class AbstractHttpGitClient(GitClient):
           username: Optional username for authentication
           password: Optional password for authentication
           config: Configuration object
+          pool_manager: Optional urllib3 PoolManager for HTTP(S) connections
 
         Returns:
           An AbstractHttpGitClient instance
@@ -3888,6 +3890,7 @@ class AbstractHttpGitClient(GitClient):
                 username=final_username,
                 password=final_password,
                 config=config,
+                pool_manager=pool_manager,
             )
         else:
             # Base class now supports credentials in constructor
@@ -4079,6 +4082,7 @@ def get_transport_and_path_from_url(
     password: Optional[str] = None,
     key_filename: Optional[str] = None,
     ssh_command: Optional[str] = None,
+    pool_manager: Optional["urllib3.PoolManager"] = None,
 ) -> tuple[GitClient, str]:
     """Obtain a git client from a URL.
 
@@ -4094,6 +4098,7 @@ def get_transport_and_path_from_url(
       password: Optional password for authentication
       key_filename: Optional SSH key file
       ssh_command: Optional custom SSH command
+      pool_manager: Optional urllib3 PoolManager for HTTP(S) connections
 
     Returns:
       Tuple with client instance and relative path.
@@ -4114,6 +4119,7 @@ def get_transport_and_path_from_url(
         password=password,
         key_filename=key_filename,
         ssh_command=ssh_command,
+        pool_manager=pool_manager,
     )
 
 
@@ -4129,6 +4135,7 @@ def _get_transport_and_path_from_url(
     password: Optional[str] = None,
     key_filename: Optional[str] = None,
     ssh_command: Optional[str] = None,
+    pool_manager: Optional["urllib3.PoolManager"] = None,
 ) -> tuple[GitClient, str]:
     parsed = urlparse(url)
     if parsed.scheme == "git":
@@ -4164,6 +4171,7 @@ def _get_transport_and_path_from_url(
                 report_activity=report_activity,
                 quiet=quiet,
                 include_tags=include_tags,
+                pool_manager=pool_manager,
             ),
             parsed.path,
         )
@@ -4220,6 +4228,7 @@ def get_transport_and_path(
     password: Optional[str] = None,
     key_filename: Optional[str] = None,
     ssh_command: Optional[str] = None,
+    pool_manager: Optional["urllib3.PoolManager"] = None,
 ) -> tuple[GitClient, str]:
     """Obtain a git client from a URL.
 
@@ -4235,6 +4244,7 @@ def get_transport_and_path(
       password: Optional password for authentication
       key_filename: Optional SSH key file
       ssh_command: Optional custom SSH command
+      pool_manager: Optional urllib3 PoolManager for HTTP(S) connections
 
     Returns:
       Tuple with client instance and relative path.
@@ -4257,6 +4267,7 @@ def get_transport_and_path(
             password=password,
             key_filename=key_filename,
             ssh_command=ssh_command,
+            pool_manager=pool_manager,
         )
     except ValueError:
         pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1717,6 +1717,30 @@ class HttpGitClientTests(TestCase):
         self.assertNotIn(password, url)
         self.assertEqual("https://github.com/jelmer/dulwich", url)
 
+    def test_pool_manager_parameter(self) -> None:
+        """Test that pool_manager parameter is properly passed through."""
+        import urllib3
+
+        # Create a custom pool manager
+        custom_pool_manager = urllib3.PoolManager()
+
+        # Test with get_transport_and_path_from_url
+        url = "https://github.com/jelmer/dulwich"
+        client, _path = get_transport_and_path_from_url(
+            url, pool_manager=custom_pool_manager
+        )
+
+        # Verify the client is an HTTP client and has our custom pool manager
+        self.assertIsInstance(client, HttpGitClient)
+        self.assertIs(client.pool_manager, custom_pool_manager)
+
+        # Test with get_transport_and_path
+        client2, _path2 = get_transport_and_path(url, pool_manager=custom_pool_manager)
+
+        # Verify the client is an HTTP client and has our custom pool manager
+        self.assertIsInstance(client2, HttpGitClient)
+        self.assertIs(client2.pool_manager, custom_pool_manager)
+
 
 class TCPGitClientTests(TestCase):
     def test_get_url(self) -> None:


### PR DESCRIPTION
The pool_manager parameter was accidentally removed from get_transport_and_path and get_transport_and_path_from_url during type annotation refactoring in commit 0b0fed6. This restores the parameter to maintain backward compatibility.

Fixes #1928