### PR TITLE
Work around typing module bug in Python 3.9.0/3.9.1

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@
    collapse operations, and the 'sdir' extension.
    (Jelmer Vernooĳ, #1797)
 
+ * Work around typing module bug in Python 3.9.0 and 3.9.1 by using string
+   annotation for Callable type in reflog.py. (Jelmer Vernooĳ, #1948)
+
  * Fix passing ssh_command, password, and key_filename parameters to the SSH
    vendor. Regression from 0.24.2.  (Jelmer Vernooĳ, #1945)
 

--- a/dulwich/reflog.py
+++ b/dulwich/reflog.py
@@ -205,7 +205,9 @@ def expire_reflog(
     f: BinaryIO,
     expire_time: Optional[int] = None,
     expire_unreachable_time: Optional[int] = None,
-    reachable_checker: Optional[Callable[[bytes], bool]] = None,
+    # String annotation to work around typing module bug in Python 3.9.0/3.9.1
+    # See: https://github.com/jelmer/dulwich/issues/1948
+    reachable_checker: "Optional[Callable[[bytes], bool]]" = None,
 ) -> int:
     """Expire reflog entries based on age and reachability.
 


### PR DESCRIPTION
Use string annotation for Callable type in reflog.py to avoid triggering a bug in Python 3.9.0 and 3.9.1's typing module that fails when processing Callable[[bytes], bool] annotations.

Fixes #1948