### PR TITLE
Add support for GIT_FLUSH environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "diff-tree-py"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "pyo3",
 ]
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "objects-py"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "memchr",
  "pyo3",
@@ -64,7 +64,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pack-py"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "memchr",
  "pyo3",

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@
    Implements Git's namespace feature for isolating refs within a single
    repository using the ``refs/namespaces/`` prefix. (Jelmer Vernooĳ, #1809)
 
+ * Add support for GIT_FLUSH environment variable to control output buffering
+   in CLI commands. When GIT_FLUSH=1, output is flushed after each write for
+   real-time visibility. (Jelmer Vernooĳ, #1810)
+
 0.24.7	2025-10-23
 
  * Add sparse index support for improved performance with large repositories.


### PR DESCRIPTION
When GIT_FLUSH=1, output is flushed after each write operation, enabling real-time output visibility for CI/CD systems and scripts that parse Git output as it's generated.

When GIT_FLUSH=0, output uses completely buffered I/O.

When GIT_FLUSH is not set, the behavior is auto-detected based on whether stdout/stderr are connected to a TTY (no flush) or redirected to a pipe/file (flush enabled).

Fixes #1810