### PR TITLE
Fix config file leakage in compat tests

### DIFF
--- a/tests/compat/utils.py
+++ b/tests/compat/utils.py
@@ -140,6 +140,12 @@ def run_git(
     env["LC_ALL"] = env["LANG"] = "C"
     env["PATH"] = os.getenv("PATH")
 
+    # Isolate from system and user git config to prevent config leakage
+    # This prevents issues like Apple Git's system-wide init.defaultBranch=main
+    # from affecting test behavior (see issue #1188)
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = "/dev/null"
+
     # Preserve Git identity environment variables if they exist, otherwise set dummy values
     git_env_defaults = {
         "GIT_AUTHOR_NAME": "Test User",
@@ -247,7 +253,7 @@ class CompatTestCase(TestCase):
     min_git_version.
     """
 
-    min_git_version: tuple[int, ...] = (1, 5, 0)
+    min_git_version: tuple[int, ...] = (2, 32, 0)
 
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
On systems with Apple Git (macOS with Xcode Command Line Tools), the system-wide git config sets init.defaultBranch=main in: /Library/Developer/CommandLineTools/usr/share/git-core/gitconfig

This causes compat tests to fail with "KeyError: b'HEAD'" because:
1. git init --bare creates HEAD pointing to refs/heads/main
2. git fast-import with test exports creates refs/heads/master
3. HEAD points to non-existent refs/heads/main
4. Dulwich fails when trying to resolve HEAD

The fix isolates tests from system and user git configuration by setting:
- GIT_CONFIG_NOSYSTEM=1 to ignore system-wide config
- GIT_CONFIG_GLOBAL=/dev/null to ignore user's ~/.gitconfig

This requires git 2.32.0+ (released June 2021) for GIT_CONFIG_GLOBAL support, so the minimum git version for compat tests is updated from 1.5.0 to 2.32.0.

Fixes #1188