### PR TITLE
client: relax check to support subclasses of Urllib3HttpGitClient

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -4020,8 +4020,8 @@ class AbstractHttpGitClient(GitClient):
             base_parsed = base_parsed._replace(netloc=f"{hostname}:{parsedurl.port}")
 
         # Pass credentials to constructor if it's a subclass that supports them
-        if cls is Urllib3HttpGitClient:
-            client = cls(  # type: ignore[call-arg]
+        if issubclass(cls, Urllib3HttpGitClient):
+            client: AbstractHttpGitClient = cls(
                 urlunparse(base_parsed),
                 dumb=dumb,
                 thin_packs=thin_packs,


### PR DESCRIPTION
## Problem

We extend `Urllib3HttpGitClient` to save credentials to a `git-credential-store` in dvc/scmrepo.

See
https://github.com/iterative/scmrepo/blob/c15ffb7e36f947ea39de0c26c7ed8480a3e7a893/src/scmrepo/git/backend/dulwich/client.py#L9.

The previous implementation was passing all the kwargs, but after 0b0fed6ee6e75797fd50e8d5db7183b182784059, the extended class does not receive `Config` object anymore, and goes through a separate code path.


## Fix

Relax check to also accept subclasses of `Urllib3HttpGitClient`.
