### PR TITLE
Improve error handling when trying to remove non-empty directory

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -2125,7 +2125,7 @@ def _remove_empty_parents(path: bytes, stop_at: bytes) -> None:
             # Directory doesn't exist - stop trying
             break
         except OSError as e:
-            if e.errno == errno.ENOTEMPTY:
+            if e.errno in (errno.ENOTEMPTY, errno.EEXIST):
                 # Directory not empty - stop trying
                 break
             raise
@@ -2314,7 +2314,7 @@ def _transition_to_file(
             try:
                 os.rmdir(full_path)
             except OSError as e:
-                if e.errno == errno.ENOTEMPTY:
+                if e.errno in (errno.ENOTEMPTY, errno.EEXIST):
                     raise IsADirectoryError(
                         f"Cannot replace non-empty directory with file: {full_path!r}"
                     )


### PR DESCRIPTION
Some systems (this happened to me on Oracle Solaris) might raise `errno.EEXIST` rather than `errno.ENOTEMPTY` when trying to remove a non-empty directory with `os.rmdir`.

I see that similar check is already present in https://github.com/jelmer/dulwich/blob/master/dulwich/index.py#L2366 (all added with https://github.com/jelmer/dulwich/commit/c6ce5cc181ec2a1fb132c2b9e878d22c84ca213d), so this isn't a new thing.
