### PR TITLE
avoid signing commits in stash

### DIFF
--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -310,6 +310,7 @@ class Stash:
             message=b"Index stash",
             merge_heads=[self._repo.head()],
             no_verify=True,
+            sign=False,
             ref=None,  # Don't update any ref
             **commit_kwargs,
         )
@@ -342,6 +343,7 @@ class Stash:
             message=message,
             merge_heads=[index_commit_id],
             no_verify=True,
+            sign=False,
             **commit_kwargs,
         )
 


### PR DESCRIPTION
git does not sign commits made in stash (it uses `commit_tree()` that does not have signing capability).
Do the same in dulwich.

Fixes https://github.com/treeverse/dvc/issues/10912.