### PR TITLE
Move peeled tags protocol functions to dulwich.protocol

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 0.25.0	UNRELEASED
 
+ * Move protocol-level peeled tags functions (``serialize_refs()``,
+   ``write_info_refs()``, ``split_peeled_refs()``, ``strip_peeled_refs()``)
+   from ``dulwich.refs`` to ``dulwich.protocol``. The ``^{}`` peeled tags syntax
+   is now properly isolated to protocol-level code. Remove ``InfoRefsContainer``
+   class (functionality inlined into ``SwiftInfoRefsContainer``).
+   (Jelmer Vernooĳ, #2009)
+
  * Fix ``get_unstaged_changes()`` to correctly pass Blob objects to filter
    callbacks instead of raw bytes. This fixes crashes when using ``.gitattributes``
    files with filter callbacks like ``checkin_normalize``.

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -164,6 +164,7 @@ from .protocol import (
     parse_capability,
     pkt_line,
     pkt_seq,
+    split_peeled_refs,
 )
 from .refs import (
     HEADREF,
@@ -175,7 +176,6 @@ from .refs import (
     _set_origin_head,
     filter_ref_prefix,
     read_info_refs,
-    split_peeled_refs,
 )
 from .repo import BaseRepo, Repo
 

--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -44,7 +44,8 @@ from .objects import (
     sha_to_hex,
 )
 from .pack import Pack, PackData, PackIndex, UnpackedObject, load_pack_index_file
-from .refs import Ref, read_info_refs, split_peeled_refs
+from .protocol import split_peeled_refs
+from .refs import Ref, read_info_refs
 
 
 class DumbHTTPObjectStore(BaseObjectStore):

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -118,8 +118,9 @@ from .protocol import (
     format_shallow_line,
     format_unshallow_line,
     symref_capabilities,
+    write_info_refs,
 )
-from .refs import Ref, RefsContainer, write_info_refs
+from .refs import Ref, RefsContainer
 from .repo import Repo
 
 logger = log_utils.getLogger(__name__)


### PR DESCRIPTION
Remove InfoRefsContainer class, inlining its functionality into SwiftInfoRefsContainer in dulwich.contrib.swift.

This properly isolates the ^{} protocol syntax to protocol-level code, which is a bit of an architectural leak.

Fixes #2009