### PR TITLE
fix typing

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1157,7 +1157,7 @@ class GitClient:
 
     def fetch(
         self,
-        path: bytes,
+        path: bytes | str,
         target: BaseRepo,
         determine_wants: "DetermineWantsFunc | None" = None,
         progress: Callable[[bytes], None] | None = None,
@@ -1239,7 +1239,7 @@ class GitClient:
 
     def fetch_pack(
         self,
-        path: bytes,
+        path: bytes | str,
         determine_wants: "DetermineWantsFunc",
         graph_walker: GraphWalker,
         pack_data: Callable[[bytes], int],
@@ -1598,7 +1598,7 @@ class TraditionalGitClient(GitClient):
 
     def fetch_pack(
         self,
-        path: bytes,
+        path: bytes | str,
         determine_wants: "DetermineWantsFunc",
         graph_walker: GraphWalker,
         pack_data: Callable[[bytes], int],
@@ -2350,7 +2350,7 @@ class LocalGitClient(GitClient):
 
     def fetch(
         self,
-        path: bytes,
+        path: bytes | str,
         target: BaseRepo,
         determine_wants: "DetermineWantsFunc | None" = None,
         progress: Callable[[bytes], None] | None = None,
@@ -2680,7 +2680,7 @@ class BundleClient(GitClient):
 
     def fetch(
         self,
-        path: bytes,
+        path: bytes | str,
         target: BaseRepo,
         determine_wants: "DetermineWantsFunc | None" = None,
         progress: Callable[[bytes], None] | None = None,


### PR DESCRIPTION
Sorry for just creating a PR, but I thought it is easier to reason about than if I had to describe it in an issue.

When updating from dulwich 0.24.1 to 0.24.10, I encountered some mypy errors. In our code we call `dulwich.client.get_transport_and_path()`, which returns the path as `str` and pass it to `dulwich.client.GitClient.fetch()`, which seems to work well but according the type hint only accepts `bytes`. I followed all usages of `path` and it seems like they finally all accept `str | bytes` so that being more permissive in the top level method seems fine. This PR adapts the type hints to match the implementation.