### PR TITLE
Add support for parsing commits with broken author/committer lines

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+0.25.1	UNRELEASED
+
+ * Add ``parse_commit_broken`` function to parse broken commits.
+   (Valentin Lorentz, Jelmer Vernooĳ)
+
 0.25.0	2025-12-17
 
 **PLEASE NOTE**: This release makes quite a lot of changes to public APIs. This


### PR DESCRIPTION
This adds parse_commit_broken() to handle various broken formats found in real-world Git repositories:
- Missing angle brackets around email addresses
- Unsigned timezones (e.g., "0000" instead of "+0000")
- Double-negative timezones (e.g., "--700")
- Negative timestamps
- Long/short/nonsensical timezone values

The function returns a Commit object but includes a warning in the docstring that commits parsed this way may not round-trip correctly through serialization.

Based on PR #927 by Valentin Lorentz with real examples from broken commits.