### PR TITLE
simplify FileLocked

### DIFF
--- a/dulwich/file.py
+++ b/dulwich/file.py
@@ -145,7 +145,7 @@ class FileLocked(Exception):
 
     def __init__(
         self,
-        filename: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        filename: str | bytes,
         lockfilename: str | bytes,
     ) -> None:
         """Initialize FileLocked.
@@ -224,7 +224,7 @@ class _GitFile(IO[bytes]):
                 mask,
             )
         except FileExistsError as exc:
-            raise FileLocked(filename, self._lockfilename) from exc
+            raise FileLocked(self._filename, self._lockfilename) from exc
         self._file = os.fdopen(fd, mode, bufsize)
         self._closed = False
 


### PR DESCRIPTION
Making callers handle `str | bytes` is already an annoyance; having them handle `str | bytes | os.PathLike[str] | os.PathLike[bytes]` is really making life harder than it need be