### PR TITLE
Fix tests failing if "build" in project absolute path

### DIFF
--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -82,7 +82,7 @@ class SourceCodeComplianceTests(unittest.TestCase):
         python_files = []
         for root, dirs, files in os.walk(dulwich_dir):
             # Skip build directories
-            if root.endswith("build") or root.endswith("__pycache__"):
+            if root.endswith(("build", "__pycache__")):
                 continue
 
             for file in files:


### PR DESCRIPTION
For Arch Linux package builds, the source is checked out in a path like:

    /build/python-dulwich/src/dulwich

This causes `test_source.py::SourceCodeComplianceTests::_get_dulwich_python_files()` to return no Python files, and subsequently the following to tests to fail:

- `tests/test_source.py::SourceCodeComplianceTests::test_all_files_have_preamble`
- `tests/test_source.py::SourceCodeComplianceTests::test_os_environ_usage_restricted`

The root cause of this is that the check for `build` and `__pycache__` are to broad and will skip any roots with these words anywhere in the path - which is the case for us (/build...).