### PR TITLE
Fix commit graph parsing with incomplete extra edges data

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@
  * Fix AssertionError when accessing ref names with length matching binary
    hash length (e.g., 32 bytes for SHA-256). (Jelmer Vernooĳ, #2040)
 
+ * Fix commit graph parsing failure when processing commits with 3+ parents
+   (octopus merges) with incomplete EXTRA_EDGE_LIST chunk data.
+   (Jelmer Vernooĳ, #2054)
+
  * Add ``parse_commit_broken`` function to parse broken commits.
    (Valentin Lorentz, Jelmer Vernooĳ)
 

--- a/dulwich/commit_graph.py
+++ b/dulwich/commit_graph.py
@@ -324,7 +324,7 @@ class CommitGraph:
         edge_data = self.chunks[CHUNK_EXTRA_EDGE_LIST].data
         parents = []
 
-        while offset < len(edge_data):
+        while offset + 4 <= len(edge_data):
             parent_pos = struct.unpack(">L", edge_data[offset : offset + 4])[0]
             offset += 4
 


### PR DESCRIPTION
Fixes parsing failure when EXTRA_EDGE_LIST chunk has less than 4 bytes remaining. This occurred with commits having 3+ parents (octopus merges) when the chunk data was incomplete or malformed.

Fixes #2054 