### PR TITLE
Fix cloning of SHA-256 repositories with protocol v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "diff-tree-py"
-version = "0.25.2"
+version = "1.0.0"
 dependencies = [
  "pyo3",
 ]
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "objects-py"
-version = "0.25.2"
+version = "1.0.0"
 dependencies = [
  "memchr",
  "pyo3",
@@ -67,7 +67,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pack-py"
-version = "0.25.2"
+version = "1.0.0"
 dependencies = [
  "memchr",
  "pyo3",

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,10 @@
  * Support ``GIT_TRACE_PACKET`` in ``dulwich.cli``.
    (Jelmer Vernooĳ)
 
+ * Fix cloning of SHA-256 repositories by including ``object-format`` and
+   ``agent`` capabilities in Git protocol v2 ``ls-refs`` and ``fetch``
+   commands. (Jelmer Vernooĳ)
+
 1.0.0	2026-01-17
 
  * Release of 1.0!


### PR DESCRIPTION
Fixes cloning from SHA-256 repositories like:
  dulwich clone https://codeberg.org/jfch/test-sha256.git

Fixes #2072