### PR TITLE
Add Git protocol v2 packfile-uris client support

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.0.1	UNRELEASED
 
+ * Add client-side support for Git protocol v2 ``packfile-uris`` capability,
+   allowing servers to offload packfile distribution to CDNs or external
+   storage. Includes hash verification before writing to repository to prevent
+   data corruption. (Jelmer Vernooĳ, #1794)
+
  * Support ``GIT_TRACE_PACKET`` in ``dulwich.cli``.
    (Jelmer Vernooĳ)
 

--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -179,6 +179,7 @@ CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT = b"allow-reachable-sha1-in-want"
 CAPABILITY_FETCH = b"fetch"
 CAPABILITY_FILTER = b"filter"
 CAPABILITY_OBJECT_FORMAT = b"object-format"
+CAPABILITY_PACKFILE_URIS = b"packfile-uris"
 
 # Magic ref that is used to attach capabilities to when
 # there are no refs. Should always be ste to ZERO_SHA.
@@ -207,6 +208,7 @@ KNOWN_UPLOAD_CAPABILITIES = set(
         CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT,
         CAPABILITY_FETCH,
         CAPABILITY_FILTER,
+        CAPABILITY_PACKFILE_URIS,
     ]
 )
 KNOWN_RECEIVE_CAPABILITIES = set(


### PR DESCRIPTION
Implement client-side support for the packfile-uris capability in Git protocol v2, which allows servers to offload packfile distribution to CDNs or external storage (e.g., Google Cloud Storage, AWS S3).

Fixes #1794