### PR TITLE
Add bundle URI support for faster clones and fetches

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,12 @@
    storage. Includes hash verification before writing to repository to prevent
    data corruption. (Jelmer Vernooĳ, #1794)
 
+ * Add bundle URI support for faster clones and fetches. The new
+   ``dulwich.bundle_uri`` module implements the Git bundle URI specification,
+   allowing clients to download pre-computed bundles from HTTP(S) URLs to
+   bootstrap repository data before fetching remaining objects.
+   (Jelmer Vernooĳ)
+
  * Support ``GIT_TRACE_PACKET`` in ``dulwich.cli``.
    (Jelmer Vernooĳ)
 

--- a/dulwich/bundle_uri.py
+++ b/dulwich/bundle_uri.py
@@ -1,0 +1,541 @@
+# bundle_uri.py -- Bundle URI support
+# Copyright (C) 2024 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Bundle URI support for faster clones and fetches.
+
+This module implements support for Git bundle URIs as specified in
+https://git-scm.com/docs/bundle-uri
+
+Bundle URIs allow Git servers to advertise locations where clients can
+download pre-computed bundles to speed up clones and fetches.
+"""
+
+__all__ = [
+    "BundleList",
+    "BundleListEntry",
+    "BundleURIError",
+    "fetch_bundle_uri",
+    "parse_bundle_list",
+]
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from io import BytesIO
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin, urlparse
+
+if TYPE_CHECKING:
+    from .bundle import Bundle
+    from .repo import BaseRepo
+
+# Bundle URI protocol v2 capability
+CAPABILITY_BUNDLE_URI = b"bundle-uri"
+
+
+class BundleURIError(Exception):
+    """Error related to bundle URI operations."""
+
+
+@dataclass
+class BundleListEntry:
+    """Represents a single bundle in a bundle list.
+
+    Attributes:
+        id: The bundle identifier (alphanumeric and dashes only)
+        uri: The URI to download the bundle from (absolute or relative)
+        filter: Object filter (e.g., "blob:none" for blobless clones)
+        creation_token: A non-negative integer for sorting bundles
+        location: Real-world location hint (e.g., "eastus", "europe")
+    """
+
+    id: str
+    uri: str
+    filter: str | None = None
+    creation_token: int | None = None
+    location: str | None = None
+
+
+@dataclass
+class BundleList:
+    """Represents a bundle list as defined in the bundle URI specification.
+
+    A bundle list contains metadata about available bundles that can be
+    downloaded to speed up clones and fetches.
+
+    Attributes:
+        version: Bundle list version (currently only 1 is supported)
+        mode: Either "all" (need all bundles) or "any" (any one suffices)
+        heuristic: Optional heuristic name (e.g., "creationToken")
+        entries: List of BundleListEntry objects
+    """
+
+    version: int = 1
+    mode: str = "all"
+    heuristic: str | None = None
+    entries: list[BundleListEntry] = field(default_factory=list)
+
+
+def parse_bundle_list(data: bytes, base_uri: str | None = None) -> BundleList:
+    """Parse a bundle list from Git config format.
+
+    Args:
+        data: The raw bundle list data in Git config format
+        base_uri: Base URI for resolving relative URIs in the bundle list
+
+    Returns:
+        A BundleList object representing the parsed bundle list
+
+    Raises:
+        BundleURIError: If the bundle list format is invalid
+    """
+    from .config import ConfigFile
+
+    try:
+        config = ConfigFile.from_file(BytesIO(data))
+    except Exception as e:
+        raise BundleURIError(f"Failed to parse bundle list as config: {e}") from e
+
+    # Parse bundle section
+    try:
+        version = int(config.get((b"bundle",), b"version").decode("utf-8"))
+    except KeyError:
+        raise BundleURIError("bundle.version is required")
+    except (ValueError, UnicodeDecodeError) as e:
+        raise BundleURIError(f"Invalid bundle.version: {e}") from e
+
+    if version != 1:
+        raise BundleURIError(f"Unsupported bundle list version: {version}")
+
+    try:
+        mode = config.get((b"bundle",), b"mode").decode("utf-8")
+    except KeyError:
+        raise BundleURIError("bundle.mode is required")
+    except UnicodeDecodeError as e:
+        raise BundleURIError(f"Invalid bundle.mode encoding: {e}") from e
+
+    if mode not in ("all", "any"):
+        raise BundleURIError(f"Invalid bundle.mode: {mode}")
+
+    heuristic = None
+    try:
+        heuristic = config.get((b"bundle",), b"heuristic").decode("utf-8")
+    except KeyError:
+        pass
+    except UnicodeDecodeError as e:
+        raise BundleURIError(f"Invalid bundle.heuristic encoding: {e}") from e
+
+    bundle_list = BundleList(version=version, mode=mode, heuristic=heuristic)
+
+    # Parse bundle entries (bundle.<id>.* sections)
+    seen_ids: set[str] = set()
+    for section_tuple in config.keys():
+        if len(section_tuple) != 2 or section_tuple[0] != b"bundle":
+            continue
+
+        bundle_id = section_tuple[1].decode("utf-8")
+        if bundle_id in seen_ids:
+            continue
+        seen_ids.add(bundle_id)
+
+        # Get the URI (required)
+        try:
+            uri = config.get(section_tuple, b"uri").decode("utf-8")
+        except KeyError:
+            # No URI means this is not a bundle entry
+            continue
+        except UnicodeDecodeError as e:
+            raise BundleURIError(
+                f"Invalid URI encoding for bundle {bundle_id}: {e}"
+            ) from e
+
+        # Resolve relative URIs
+        if base_uri and not _is_absolute_uri(uri):
+            uri = _resolve_relative_uri(base_uri, uri)
+
+        entry = BundleListEntry(id=bundle_id, uri=uri)
+
+        # Parse optional fields
+        try:
+            entry.filter = config.get(section_tuple, b"filter").decode("utf-8")
+        except KeyError:
+            pass
+        except UnicodeDecodeError as e:
+            raise BundleURIError(
+                f"Invalid filter encoding for bundle {bundle_id}: {e}"
+            ) from e
+
+        try:
+            token_str = config.get(section_tuple, b"creationToken").decode("utf-8")
+            entry.creation_token = int(token_str)
+            if entry.creation_token < 0:
+                raise BundleURIError(
+                    f"creationToken must be non-negative for bundle {bundle_id}"
+                )
+        except KeyError:
+            pass
+        except (ValueError, UnicodeDecodeError) as e:
+            raise BundleURIError(
+                f"Invalid creationToken for bundle {bundle_id}: {e}"
+            ) from e
+
+        try:
+            entry.location = config.get(section_tuple, b"location").decode("utf-8")
+        except KeyError:
+            pass
+        except UnicodeDecodeError as e:
+            raise BundleURIError(
+                f"Invalid location encoding for bundle {bundle_id}: {e}"
+            ) from e
+
+        bundle_list.entries.append(entry)
+
+    return bundle_list
+
+
+def _is_absolute_uri(uri: str) -> bool:
+    """Check if a URI is absolute (has a scheme)."""
+    parsed = urlparse(uri)
+    return bool(parsed.scheme)
+
+
+def _resolve_relative_uri(base_uri: str, relative_uri: str) -> str:
+    """Resolve a relative URI against a base URI.
+
+    Args:
+        base_uri: The base URI to resolve against
+        relative_uri: The relative URI to resolve
+
+    Returns:
+        The resolved absolute URI
+    """
+    if relative_uri.startswith("/"):
+        # Relative to domain root
+        parsed = urlparse(base_uri)
+        return f"{parsed.scheme}://{parsed.netloc}{relative_uri}"
+    else:
+        # Relative to base URI path
+        return urljoin(base_uri, relative_uri)
+
+
+def _is_bundle_file(data: bytes) -> bool:
+    """Check if data starts with a bundle file header."""
+    return data.startswith((b"# v2 git bundle\n", b"# v3 git bundle\n"))
+
+
+def fetch_bundle_uri(
+    uri: str,
+    progress: Callable[[bytes], None] | None = None,
+    timeout: float | None = None,
+) -> tuple["Bundle | None", "BundleList | None"]:
+    """Fetch content from a bundle URI.
+
+    The URI may point to either a bundle file or a bundle list.
+
+    Args:
+        uri: The URI to fetch from (HTTP/HTTPS)
+        progress: Optional callback for progress reporting
+        timeout: Optional timeout for the HTTP request
+
+    Returns:
+        A tuple of (Bundle, None) if the URI points to a bundle file,
+        or (None, BundleList) if the URI points to a bundle list.
+
+    Raises:
+        BundleURIError: If the fetch fails or the content is invalid
+    """
+    import urllib3
+
+    from .bundle import read_bundle
+
+    parsed = urlparse(uri)
+    if parsed.scheme not in ("http", "https"):
+        raise BundleURIError(f"Unsupported URI scheme: {parsed.scheme}")
+
+    http = urllib3.PoolManager(timeout=timeout)
+    try:
+        response = http.request("GET", uri)
+
+        if response.status != 200:
+            raise BundleURIError(f"HTTP error {response.status} fetching {uri}")
+
+        data = response.data
+    except urllib3.exceptions.HTTPError as e:
+        raise BundleURIError(f"HTTP error fetching {uri}: {e}") from e
+    finally:
+        http.clear()
+
+    if progress:
+        progress(f"Received {len(data)} bytes from {uri}".encode())
+
+    # Try to parse as a bundle first
+    if _is_bundle_file(data):
+        try:
+            bundle = read_bundle(BytesIO(data))
+            return bundle, None
+        except Exception as e:
+            raise BundleURIError(f"Failed to parse bundle from {uri}: {e}") from e
+
+    # Try to parse as a bundle list
+    try:
+        bundle_list = parse_bundle_list(data, base_uri=uri)
+        return None, bundle_list
+    except BundleURIError:
+        raise
+    except Exception as e:
+        raise BundleURIError(
+            f"Content at {uri} is neither a bundle nor a bundle list: {e}"
+        ) from e
+
+
+def apply_bundle_uri(
+    repo: "BaseRepo",
+    uri: str,
+    filter_spec: str | None = None,
+    stored_creation_token: int | None = None,
+    progress: Callable[[bytes], None] | None = None,
+) -> tuple[int | None, dict[bytes, bytes]]:
+    """Apply bundles from a bundle URI to a repository.
+
+    This function fetches bundles from the given URI and applies them
+    to the repository, potentially speeding up subsequent fetches.
+
+    Args:
+        repo: The target repository to apply bundles to
+        uri: The bundle URI to fetch from
+        filter_spec: Object filter to match (e.g., "blob:none")
+        stored_creation_token: Previously stored creation token to skip
+            bundles that have already been applied
+        progress: Optional callback for progress reporting
+
+    Returns:
+        A tuple of (``creation_token``, ``refs``) where:
+        - ``creation_token`` is the highest creation token seen (for
+          storing and skipping in future fetches), or None if not available
+        - ``refs`` is a dict mapping ref names to object IDs from the bundles
+
+    Raises:
+        BundleURIError: If fetching or applying bundles fails
+    """
+    bundle, bundle_list = fetch_bundle_uri(uri, progress=progress)
+
+    all_refs: dict[bytes, bytes] = {}
+
+    if bundle is not None:
+        # Single bundle case
+        try:
+            bundle.store_objects(
+                repo.object_store,
+                progress=lambda msg: progress(msg.encode("utf-8"))
+                if progress
+                else None,
+            )
+            for ref, sha in bundle.references.items():
+                all_refs[ref] = sha
+        finally:
+            bundle.close()
+        return None, all_refs
+
+    # Bundle list case
+    assert bundle_list is not None
+
+    if bundle_list.mode == "any":
+        # Pick any one bundle that matches our filter
+        matching_entries = _filter_bundle_entries(bundle_list.entries, filter_spec)
+        if not matching_entries:
+            if progress:
+                progress(b"No matching bundles found in bundle list")
+            return None, {}
+
+        # Try entries in order until one succeeds
+        for entry in matching_entries:
+            try:
+                entry_bundle, _ = fetch_bundle_uri(entry.uri, progress=progress)
+                if entry_bundle is not None:
+                    try:
+                        entry_bundle.store_objects(
+                            repo.object_store,
+                            progress=lambda msg: progress(msg.encode("utf-8"))
+                            if progress
+                            else None,
+                        )
+                        for ref, sha in entry_bundle.references.items():
+                            all_refs[ref] = sha
+                    finally:
+                        entry_bundle.close()
+                    return entry.creation_token, all_refs
+            except BundleURIError as e:
+                if progress:
+                    progress(f"Failed to fetch bundle {entry.id}: {e}".encode())
+                continue
+
+        raise BundleURIError("Failed to fetch any bundle from the bundle list")
+
+    # mode == "all" - need all bundles
+    matching_entries = _filter_bundle_entries(bundle_list.entries, filter_spec)
+
+    if not matching_entries:
+        if progress:
+            progress(b"No matching bundles found in bundle list")
+        return None, {}
+
+    # Sort by creation token if using that heuristic
+    if bundle_list.heuristic == "creationToken":
+        # Sort by creation token descending (newest first for downloading)
+        matching_entries = sorted(
+            matching_entries,
+            key=lambda e: e.creation_token if e.creation_token is not None else 0,
+            reverse=True,
+        )
+
+        # Filter out bundles we've already seen
+        if stored_creation_token is not None:
+            matching_entries = [
+                e
+                for e in matching_entries
+                if e.creation_token is not None
+                and e.creation_token > stored_creation_token
+            ]
+
+            if not matching_entries:
+                if progress:
+                    progress(b"All bundles already applied (based on creation token)")
+                return stored_creation_token, {}
+
+    # Download bundles
+    downloaded_bundles: list[tuple[BundleListEntry, Bundle]] = []
+    latest_token: int | None = None
+    failed_bundles = []
+
+    for entry in matching_entries:
+        try:
+            entry_bundle, nested_list = fetch_bundle_uri(entry.uri, progress=progress)
+            if entry_bundle is not None:
+                downloaded_bundles.append((entry, entry_bundle))
+                if entry.creation_token is not None:
+                    if latest_token is None or entry.creation_token > latest_token:
+                        latest_token = entry.creation_token
+            elif nested_list is not None:
+                # Nested bundle lists are not supported yet
+                if progress:
+                    progress(f"Skipping nested bundle list at {entry.uri}".encode())
+        except BundleURIError as e:
+            failed_bundles.append(entry.id)
+            if progress:
+                progress(f"Failed to fetch bundle {entry.id}: {e}".encode())
+
+    if not downloaded_bundles:
+        error_msg = "No bundles could be downloaded"
+        if failed_bundles:
+            error_msg += f" (failed: {', '.join(failed_bundles)})"
+        if progress:
+            progress(error_msg.encode())
+        return stored_creation_token, {}
+
+    # Sort bundles by creation token ascending for application (oldest first)
+    if bundle_list.heuristic == "creationToken":
+        downloaded_bundles.sort(
+            key=lambda x: x[0].creation_token if x[0].creation_token is not None else 0
+        )
+
+    # Apply bundles in order
+    for entry, entry_bundle in downloaded_bundles:
+        try:
+            # Check prerequisites
+            missing_prereqs = []
+            for prereq_sha, _ in entry_bundle.prerequisites:
+                if prereq_sha not in repo.object_store:
+                    missing_prereqs.append(prereq_sha)
+
+            if missing_prereqs:
+                if progress:
+                    progress(
+                        f"Bundle {entry.id} has missing prerequisites, skipping".encode()
+                    )
+                continue
+
+            entry_bundle.store_objects(
+                repo.object_store,
+                progress=lambda msg: progress(msg.encode("utf-8"))
+                if progress
+                else None,
+            )
+            for ref, sha in entry_bundle.references.items():
+                all_refs[ref] = sha
+
+            if progress:
+                progress(f"Applied bundle {entry.id}".encode())
+        finally:
+            entry_bundle.close()
+
+    return latest_token, all_refs
+
+
+def _filter_bundle_entries(
+    entries: list[BundleListEntry], filter_spec: str | None
+) -> list[BundleListEntry]:
+    """Filter bundle entries based on object filter specification.
+
+    Args:
+        entries: List of bundle entries to filter
+        filter_spec: Object filter to match (e.g., "blob:none"), or None
+            for full clones
+
+    Returns:
+        List of matching bundle entries
+    """
+    result = []
+    for entry in entries:
+        if filter_spec is None:
+            # Full clone - only include bundles without filters
+            if entry.filter is None:
+                result.append(entry)
+        else:
+            # Partial clone - match filter exactly
+            if entry.filter == filter_spec:
+                result.append(entry)
+    return result
+
+
+def parse_bundle_uri_advertisement(
+    capabilities: list[tuple[bytes, bytes | None]],
+) -> list[tuple[str, str | None]]:
+    """Parse bundle URI advertisement from protocol v2 capabilities.
+
+    Extracts bundle-uri related capabilities from a Git protocol v2
+    capability advertisement. The server may advertise bundle URIs
+    as part of its capabilities to allow clients to bootstrap clones.
+
+    Args:
+        capabilities: List of (key, value) capability pairs from the server
+
+    Returns:
+        List of (key, value) pairs where key starts with "bundle-uri".
+        The key is the capability name (e.g., "bundle-uri") and value
+        is the URI string or None if no value was provided. Returns
+        an empty list if no bundle URI capabilities are advertised.
+    """
+    result = []
+    for key, value in capabilities:
+        if key.startswith(b"bundle-uri"):
+            key_str = key.decode("utf-8")
+            value_str = value.decode("utf-8") if value else None
+            result.append((key_str, value_str))
+    return result

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -47,6 +47,8 @@ __all__ = [
     "UPLOAD_CAPABILITIES",
     "AbstractHttpGitClient",
     "BundleClient",
+    "BundleList",
+    "BundleURIError",
     "FetchPackResult",
     "GitClient",
     "HTTPProxyUnauthorized",
@@ -66,16 +68,19 @@ __all__ = [
     "TCPGitClient",
     "TraditionalGitClient",
     "Urllib3HttpGitClient",
+    "apply_bundle_uri",
     "check_for_proxy_bypass",
     "check_wants",
     "default_urllib3_manager",
     "default_user_agent_string",
+    "fetch_bundle_uri",
     "find_capability",
     "find_git_command",
     "get_credentials_from_store",
     "get_transport_and_path",
     "get_transport_and_path_from_url",
     "negotiate_protocol_version",
+    "parse_bundle_list",
     "parse_rsync_url",
     "read_pkt_refs_v1",
     "read_pkt_refs_v2",
@@ -156,6 +161,13 @@ if TYPE_CHECKING:
 
 
 from .bundle import Bundle
+from .bundle_uri import (
+    BundleList,
+    BundleURIError,
+    apply_bundle_uri,
+    fetch_bundle_uri,
+    parse_bundle_list,
+)
 from .config import Config, apply_instead_of, get_xdg_config_home_path
 from .credentials import match_partial_url, match_urls
 from .errors import GitProtocolError, HangupException, NotGitRepository, SendPackError
@@ -1253,17 +1265,40 @@ class GitClient:
         ref_prefix: Sequence[bytes] | None = None,
         filter_spec: bytes | None = None,
         protocol_version: int | None = None,
+        bundle_uri: str | None = None,
     ) -> Repo:
-        """Clone a repository."""
+        """Clone a repository.
+
+        Args:
+          path: Path to clone from
+          target_path: Local path to clone to
+          mkdir: Whether to create the target directory
+          bare: Whether to create a bare repository
+          origin: Name for the origin remote (default: "origin")
+          checkout: Whether to checkout HEAD after cloning
+          branch: Branch to checkout (default: remote HEAD)
+          progress: Optional callback for progress reporting
+          depth: Shallow clone depth
+          ref_prefix: List of ref prefixes to fetch
+          filter_spec: Partial clone filter specification
+          protocol_version: Git protocol version to use
+          bundle_uri: Optional bundle URI to bootstrap the clone from.
+            This can be a URL to a bundle file or a bundle list.
+            Using a bundle URI can speed up the clone by downloading
+            pre-computed pack data.
+
+        Returns:
+          The newly created Repo object
+        """
         if mkdir:
             os.mkdir(target_path)
 
+        target: Repo | None = None
         try:
             # For network clones, create repository with default SHA-1 format initially.
             # If remote uses a different format, fetch() will auto-change the repo's format
             # (since repo is empty at this point).
             # Subclasses (e.g., LocalGitClient) override to detect format first for efficiency.
-            target = None
             if not bare:
                 target = Repo.init(target_path)
                 if checkout is None:
@@ -1291,6 +1326,38 @@ class GitClient:
                     b"+refs/heads/*:refs/remotes/" + origin.encode("utf-8") + b"/*",
                 )
                 target_config.write_to_path()
+
+            # Apply bundle URI if provided (bootstrap before fetch)
+            if bundle_uri is not None:
+                from urllib.parse import urlparse
+
+                parsed = urlparse(bundle_uri)
+                if not parsed.scheme or parsed.scheme not in ("http", "https"):
+                    raise BundleURIError(
+                        f"Invalid bundle URI: {bundle_uri} "
+                        f"(must be http:// or https:// URL)"
+                    )
+
+                try:
+                    filter_str = filter_spec.decode("utf-8") if filter_spec else None
+                    _, bundle_refs = apply_bundle_uri(
+                        target,
+                        bundle_uri,
+                        filter_spec=filter_str,
+                        progress=progress,
+                    )
+                    if progress and bundle_refs:
+                        progress(
+                            f"Bundle URI applied {len(bundle_refs)} refs, "
+                            f"fetching remaining objects...".encode()
+                        )
+                    elif progress:
+                        progress(b"Bundle URI applied, fetching remaining objects...")
+                except BundleURIError as e:
+                    if progress:
+                        progress(
+                            f"Bundle URI failed: {e}, continuing with regular fetch".encode()
+                        )
 
             ref_message = b"clone: from " + encoded_path
             result = self.fetch(
@@ -1452,6 +1519,89 @@ class GitClient:
         target.update_shallow(result.new_shallow, result.new_unshallow)
         return result
 
+    def fetch_with_bundle_uri(
+        self,
+        path: bytes | str,
+        target: "BaseRepo",
+        bundle_uri: str,
+        determine_wants: "DetermineWantsFunc | None" = None,
+        progress: Callable[[bytes], None] | None = None,
+        depth: int | None = None,
+        ref_prefix: Sequence[bytes] | None = None,
+        filter_spec: bytes | None = None,
+        protocol_version: int | None = None,
+        shallow_since: str | None = None,
+        shallow_exclude: list[str] | None = None,
+        stored_creation_token: int | None = None,
+    ) -> tuple[FetchPackResult, int | None]:
+        """Fetch into a target repository, using bundle URIs for bootstrap.
+
+        This method first applies any available bundles from the bundle URI,
+        then fetches remaining objects from the remote server. This can
+        significantly speed up clones and fetches for large repositories.
+
+        If bundle URI fetch fails (e.g., network error, invalid bundle), the
+        error is reported via the progress callback and the method continues
+        with a regular fetch from the remote. The fetch will still succeed
+        as long as the remote fetch completes successfully.
+
+        Args:
+          path: Path to fetch from (as bytestring)
+          target: Target repository to fetch into
+          bundle_uri: Bundle URI to fetch from (URL to bundle or bundle list)
+          determine_wants: Optional function to determine what refs to fetch.
+            Receives dictionary of name->sha, should return
+            list of shas to fetch. Defaults to all shas.
+          progress: Optional progress function
+          depth: Depth to fetch at
+          ref_prefix: List of prefixes of desired references
+          filter_spec: A git-rev-list-style object filter spec
+          protocol_version: Desired Git protocol version
+          shallow_since: Deepen the history to include commits after this date
+          shallow_exclude: Deepen the history to exclude commits reachable from these refs
+          stored_creation_token: Previously stored creation token to skip
+            already-applied bundles (for incremental fetches)
+
+        Returns:
+          A tuple of (``FetchPackResult``, ``creation_token``) where:
+          - ``FetchPackResult`` contains refs and other fetch metadata
+          - ``creation_token`` is the highest creation token seen (for
+            storing and skipping in future fetches), or None if not available
+            or if bundle fetch failed
+        """
+        # First, try to apply bundles from the bundle URI
+        latest_token = stored_creation_token
+        try:
+            filter_str = filter_spec.decode("utf-8") if filter_spec else None
+            latest_token, bundle_refs = apply_bundle_uri(
+                target,
+                bundle_uri,
+                filter_spec=filter_str,
+                stored_creation_token=stored_creation_token,
+                progress=progress,
+            )
+            if progress and bundle_refs:
+                progress(f"Applied {len(bundle_refs)} refs from bundle URI".encode())
+        except BundleURIError as e:
+            if progress:
+                progress(f"Bundle URI fetch failed: {e}".encode())
+
+        # Then fetch remaining objects from the remote
+        result = self.fetch(
+            path,
+            target,
+            determine_wants=determine_wants,
+            progress=progress,
+            depth=depth,
+            ref_prefix=ref_prefix,
+            filter_spec=filter_spec,
+            protocol_version=protocol_version,
+            shallow_since=shallow_since,
+            shallow_exclude=shallow_exclude,
+        )
+
+        return result, latest_token
+
     def fetch_pack(
         self,
         path: bytes | str,
@@ -1551,12 +1701,16 @@ class GitClient:
                 def progress(x: bytes) -> None:
                     pass
 
+            pktline_parser: PktLineParser | None
             if CAPABILITY_REPORT_STATUS in capabilities:
                 assert self._report_status_parser is not None
                 pktline_parser = PktLineParser(self._report_status_parser.handle_packet)
+            else:
+                pktline_parser = None
             for chan, data in _read_side_band64k_data(proto.read_pkt_seq()):
                 if chan == SIDE_BAND_CHANNEL_DATA:
                     if CAPABILITY_REPORT_STATUS in capabilities:
+                        assert pktline_parser is not None
                         pktline_parser.parse(data)
                 elif chan == SIDE_BAND_CHANNEL_PROGRESS:
                     progress(data)
@@ -2392,7 +2546,7 @@ class SubprocessGitClient(TraditionalGitClient):
             include_tags=include_tags,
         )
 
-    git_command: str | None = None
+    git_command: list[str] | None = None
 
     def _connect(
         self,
@@ -2406,6 +2560,8 @@ class SubprocessGitClient(TraditionalGitClient):
             path = path.decode(self._remote_path_encoding)
         if self.git_command is None:
             git_command = find_git_command()
+        else:
+            git_command = self.git_command
         argv = [*git_command, service.decode("ascii"), path]
         p = subprocess.Popen(
             argv,
@@ -2751,12 +2907,17 @@ class LocalGitClient(GitClient):
         ref_prefix: Sequence[bytes] | None = None,
         filter_spec: bytes | None = None,
         protocol_version: int | None = None,
+        bundle_uri: str | None = None,
     ) -> Repo:
         """Clone a local repository.
 
         For local clones, we can detect the object format before creating
         the target repository.
+
+        Note: bundle_uri is accepted for API compatibility but ignored for
+        local clones since there's no benefit to using bundles for local operations.
         """
+        del bundle_uri  # unused for local clones
         # Detect the object format from the source repository
         with self._open_repo(path) as source_repo:
             object_format_name = source_repo.object_format.name
@@ -2764,9 +2925,9 @@ class LocalGitClient(GitClient):
         if mkdir:
             os.mkdir(target_path)
 
+        target: Repo | None = None
         try:
             # Create repository with the correct object format from the start
-            target = None
             if not bare:
                 target = Repo.init(target_path, object_format=object_format_name)
                 if checkout is None:
@@ -3648,6 +3809,7 @@ class AuthCallbackPoolManager:
         max_attempts = 3
         attempts = self._auth_attempts.get(url, 0)
 
+        response = None  # Will be set in the loop
         while attempts < max_attempts:
             response = self._pool_manager.request(method, url, *args, **kwargs)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -134,6 +134,7 @@ def self_test_suite() -> unittest.TestSuite:
         "bitmap",
         "blackbox",
         "bundle",
+        "bundle_uri",
         "client",
         "cloud_gcs",
         "commit_graph",

--- a/tests/compat/__init__.py
+++ b/tests/compat/__init__.py
@@ -29,6 +29,7 @@ def test_suite() -> unittest.TestSuite:
         "aiohttp",
         "bitmap",
         "bundle",
+        "bundle_uri",
         "check_ignore",
         "client",
         "commit_graph",

--- a/tests/compat/test_bundle_uri.py
+++ b/tests/compat/test_bundle_uri.py
@@ -1,0 +1,477 @@
+# test_bundle_uri.py -- test bundle URI compatibility with CGit
+# Copyright (C) 2025 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Tests for bundle URI compatibility with CGit.
+
+Bundle URIs were introduced in Git 2.38.
+"""
+
+import os
+import tempfile
+import threading
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+from dulwich.bundle import create_bundle_from_repo, write_bundle
+from dulwich.bundle_uri import parse_bundle_list
+from dulwich.client import BundleClient
+from dulwich.repo import MemoryRepo, Repo
+
+from .utils import CompatTestCase, rmtree_ro, run_git_or_fail
+
+
+class BundleURICompatTestCase(CompatTestCase):
+    """Test bundle URI compatibility with CGit.
+
+    Bundle URIs require Git 2.38 or later.
+    """
+
+    min_git_version = (2, 38, 0)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(rmtree_ro, self.test_dir)
+
+    def test_bundle_list_format_compat(self) -> None:
+        """Test that bundle list format is compatible with git's expectations."""
+        # Create a bundle list in the format git expects
+        bundle_list_content = b"""[bundle]
+\tversion = 1
+\tmode = all
+
+[bundle "main"]
+\turi = https://example.com/main.bundle
+\tcreationToken = 1700000000
+"""
+        # Parse with dulwich
+        bundle_list = parse_bundle_list(bundle_list_content)
+
+        # Verify parsed correctly
+        self.assertEqual(bundle_list.version, 1)
+        self.assertEqual(bundle_list.mode, "all")
+        self.assertEqual(len(bundle_list.entries), 1)
+        self.assertEqual(bundle_list.entries[0].id, "main")
+        self.assertEqual(bundle_list.entries[0].uri, "https://example.com/main.bundle")
+        self.assertEqual(bundle_list.entries[0].creation_token, 1700000000)
+
+    def test_bundle_list_any_mode_compat(self) -> None:
+        """Test bundle list with 'any' mode (geographic distribution)."""
+        bundle_list_content = b"""[bundle]
+\tversion = 1
+\tmode = any
+
+[bundle "us-east"]
+\turi = https://us-east.example.com/repo.bundle
+\tlocation = us-east
+
+[bundle "eu-west"]
+\turi = https://eu-west.example.com/repo.bundle
+\tlocation = eu-west
+"""
+        bundle_list = parse_bundle_list(bundle_list_content)
+
+        self.assertEqual(bundle_list.mode, "any")
+        self.assertEqual(len(bundle_list.entries), 2)
+
+        locations = {e.location for e in bundle_list.entries}
+        self.assertEqual(locations, {"us-east", "eu-west"})
+
+    def test_bundle_list_with_filter_compat(self) -> None:
+        """Test bundle list with partial clone filters."""
+        bundle_list_content = b"""[bundle]
+\tversion = 1
+\tmode = all
+
+[bundle "full"]
+\turi = https://example.com/full.bundle
+\tcreationToken = 1700000000
+
+[bundle "blobless"]
+\turi = https://example.com/blobless.bundle
+\tcreationToken = 1700000000
+\tfilter = blob:none
+"""
+        bundle_list = parse_bundle_list(bundle_list_content)
+
+        self.assertEqual(len(bundle_list.entries), 2)
+
+        full = next(e for e in bundle_list.entries if e.id == "full")
+        self.assertIsNone(full.filter)
+
+        blobless = next(e for e in bundle_list.entries if e.id == "blobless")
+        self.assertEqual(blobless.filter, "blob:none")
+
+    def test_bundle_list_with_heuristic_compat(self) -> None:
+        """Test bundle list with creationToken heuristic."""
+        bundle_list_content = b"""[bundle]
+\tversion = 1
+\tmode = all
+\theuristic = creationToken
+
+[bundle "2024-01-daily"]
+\turi = https://example.com/2024-01-daily.bundle
+\tcreationToken = 1704067200
+
+[bundle "2024-01-weekly"]
+\turi = https://example.com/2024-01-weekly.bundle
+\tcreationToken = 1703462400
+
+[bundle "base"]
+\turi = https://example.com/base.bundle
+\tcreationToken = 1700000000
+"""
+        bundle_list = parse_bundle_list(bundle_list_content)
+
+        self.assertEqual(bundle_list.heuristic, "creationToken")
+        self.assertEqual(len(bundle_list.entries), 3)
+
+        # Verify creation tokens are parsed correctly
+        tokens = {e.id: e.creation_token for e in bundle_list.entries}
+        self.assertEqual(tokens["2024-01-daily"], 1704067200)
+        self.assertEqual(tokens["2024-01-weekly"], 1703462400)
+        self.assertEqual(tokens["base"], 1700000000)
+
+    def test_bundle_from_git_fetch_with_bundle_client(self) -> None:
+        """Test fetching a bundle created by git using BundleClient."""
+        # Create a repository with git
+        repo_path = os.path.join(self.test_dir, "source_repo")
+        os.makedirs(repo_path)
+        run_git_or_fail(["init"], cwd=repo_path)
+        run_git_or_fail(["config", "user.name", "Test User"], cwd=repo_path)
+        run_git_or_fail(["config", "user.email", "test@example.com"], cwd=repo_path)
+
+        # Create some commits
+        test_file = os.path.join(repo_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("Hello, World!\n")
+        run_git_or_fail(["add", "test.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Initial commit"], cwd=repo_path)
+
+        with open(test_file, "a") as f:
+            f.write("More content\n")
+        run_git_or_fail(["add", "test.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Second commit"], cwd=repo_path)
+
+        # Create bundle with git
+        bundle_path = os.path.join(self.test_dir, "test.bundle")
+        run_git_or_fail(
+            ["bundle", "create", bundle_path, "HEAD", "master"], cwd=repo_path
+        )
+
+        # Use BundleClient to fetch from the bundle
+        client = BundleClient()
+        target_repo = MemoryRepo()
+        self.addCleanup(target_repo.close)
+
+        result = client.fetch(bundle_path, target_repo)
+
+        # Verify refs were fetched
+        self.assertIn(b"refs/heads/master", result.refs)
+
+        # Verify objects were fetched
+        master_sha = result.refs[b"refs/heads/master"]
+        self.assertIn(master_sha, target_repo.object_store)
+
+        # Verify commit content
+        commit = target_repo.object_store[master_sha]
+        self.assertEqual(commit.message, b"Second commit\n")
+
+    def test_dulwich_bundle_readable_by_git(self) -> None:
+        """Test that bundles created by dulwich can be read by git."""
+        # Create a repository with dulwich
+        repo_path = os.path.join(self.test_dir, "dulwich_repo")
+        repo = Repo.init(repo_path, mkdir=True)
+        self.addCleanup(repo.close)
+
+        # Create objects using git (easier for creating valid commits)
+        run_git_or_fail(["config", "user.name", "Test User"], cwd=repo_path)
+        run_git_or_fail(["config", "user.email", "test@example.com"], cwd=repo_path)
+
+        test_file = os.path.join(repo_path, "file.txt")
+        with open(test_file, "w") as f:
+            f.write("Test content\n")
+        run_git_or_fail(["add", "file.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Test commit"], cwd=repo_path)
+
+        # Re-open repo to pick up changes
+        repo.close()
+        repo = Repo(repo_path)
+        self.addCleanup(repo.close)
+
+        # Create bundle with dulwich
+        bundle_path = os.path.join(self.test_dir, "dulwich.bundle")
+        bundle = create_bundle_from_repo(repo)
+        self.addCleanup(bundle.close)
+
+        with open(bundle_path, "wb") as f:
+            write_bundle(f, bundle)
+
+        # Verify git can verify the bundle (run_git_or_fail will raise if it fails)
+        run_git_or_fail(["bundle", "verify", bundle_path], cwd=repo_path)
+
+        # Clone from the dulwich-created bundle using git - this is the real test
+        clone_path = os.path.join(self.test_dir, "git_clone")
+        run_git_or_fail(["clone", bundle_path, clone_path])
+
+        # Verify clone succeeded by checking the file content
+        cloned_file = os.path.join(clone_path, "file.txt")
+        with open(cloned_file) as f:
+            self.assertEqual(f.read(), "Test content\n")
+
+    def test_bundle_list_relative_uris(self) -> None:
+        """Test that relative URIs in bundle lists are resolved correctly."""
+        bundle_list_content = b"""[bundle]
+\tversion = 1
+\tmode = all
+
+[bundle "relative"]
+\turi = bundles/main.bundle
+\tcreationToken = 1700000000
+
+[bundle "absolute-path"]
+\turi = /repo/bundles/backup.bundle
+\tcreationToken = 1699000000
+"""
+        base_uri = "https://example.com/git/myrepo/"
+        bundle_list = parse_bundle_list(bundle_list_content, base_uri=base_uri)
+
+        relative_entry = next(e for e in bundle_list.entries if e.id == "relative")
+        self.assertEqual(
+            relative_entry.uri, "https://example.com/git/myrepo/bundles/main.bundle"
+        )
+
+        absolute_entry = next(e for e in bundle_list.entries if e.id == "absolute-path")
+        self.assertEqual(
+            absolute_entry.uri, "https://example.com/repo/bundles/backup.bundle"
+        )
+
+    def test_incremental_bundle_with_prerequisites(self) -> None:
+        """Test incremental bundles with prerequisites work correctly."""
+        # Create a repository with multiple commits
+        repo_path = os.path.join(self.test_dir, "incremental_repo")
+        os.makedirs(repo_path)
+        run_git_or_fail(["init"], cwd=repo_path)
+        run_git_or_fail(["config", "user.name", "Test User"], cwd=repo_path)
+        run_git_or_fail(["config", "user.email", "test@example.com"], cwd=repo_path)
+
+        # Create base commit
+        test_file = os.path.join(repo_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("Line 1\n")
+        run_git_or_fail(["add", "test.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Commit 1"], cwd=repo_path)
+
+        base_commit = run_git_or_fail(["rev-parse", "HEAD"], cwd=repo_path).strip()
+
+        # Create full bundle (base) - must include a ref
+        base_bundle_path = os.path.join(self.test_dir, "base.bundle")
+        run_git_or_fail(
+            ["bundle", "create", base_bundle_path, "HEAD", "master"], cwd=repo_path
+        )
+
+        # Create more commits for incremental bundle
+        with open(test_file, "a") as f:
+            f.write("Line 2\n")
+        run_git_or_fail(["add", "test.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Commit 2"], cwd=repo_path)
+
+        with open(test_file, "a") as f:
+            f.write("Line 3\n")
+        run_git_or_fail(["add", "test.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Commit 3"], cwd=repo_path)
+
+        # Create incremental bundle with prerequisite
+        incremental_bundle_path = os.path.join(self.test_dir, "incremental.bundle")
+        run_git_or_fail(
+            [
+                "bundle",
+                "create",
+                incremental_bundle_path,
+                f"{base_commit.decode()}..HEAD",
+            ],
+            cwd=repo_path,
+        )
+
+        # Clone using base bundle first, then apply incremental
+        clone_path = os.path.join(self.test_dir, "incremental_clone")
+        run_git_or_fail(["clone", base_bundle_path, clone_path])
+
+        # Fetch from incremental bundle
+        run_git_or_fail(["fetch", incremental_bundle_path, "HEAD"], cwd=clone_path)
+
+        # Verify both bundles were applied
+        output = run_git_or_fail(["log", "--oneline", "FETCH_HEAD"], cwd=clone_path)
+        # Parse log output - format is "<short-sha> <message>" per line
+        log_lines = output.strip().split(b"\n")
+        commit_messages = [line.split(b" ", 1)[1] for line in log_lines if b" " in line]
+        # Should have all 3 commits in reverse chronological order
+        self.assertEqual(commit_messages[0], b"Commit 3")
+        self.assertEqual(commit_messages[1], b"Commit 2")
+        self.assertEqual(commit_messages[2], b"Commit 1")
+
+
+class BundleURIHTTPCompatTestCase(CompatTestCase):
+    """Test bundle URI over HTTP compatibility."""
+
+    min_git_version = (2, 38, 0)
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(rmtree_ro, self.test_dir)
+        self.server = None
+        self.server_thread = None
+
+    def tearDown(self) -> None:
+        if self.server:
+            self.server.shutdown()
+        if self.server_thread:
+            self.server_thread.join(timeout=5)
+        super().tearDown()
+
+    def _start_http_server(self, serve_dir: str) -> str:
+        """Start a simple HTTP server and return its URL."""
+        import socket
+        import time
+
+        class QuietHandler(SimpleHTTPRequestHandler):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, directory=serve_dir, **kwargs)
+
+            def log_message(self, format, *args):
+                pass  # Suppress logging
+
+        self.server = HTTPServer(("127.0.0.1", 0), QuietHandler)
+        port = self.server.server_address[1]
+
+        self.server_thread = threading.Thread(target=self.server.serve_forever)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+        # Wait for server to be ready
+        url = f"http://127.0.0.1:{port}"
+        for _ in range(50):  # Try for up to 5 seconds
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(0.1)
+                sock.connect(("127.0.0.1", port))
+                sock.close()
+                break
+            except OSError:
+                time.sleep(0.1)
+        else:
+            raise RuntimeError("HTTP server failed to start")
+
+        return url
+
+    def test_fetch_bundle_from_http(self) -> None:
+        """Test fetching a bundle from HTTP URL."""
+        # Create a repository and bundle
+        repo_path = os.path.join(self.test_dir, "source")
+        os.makedirs(repo_path)
+        run_git_or_fail(["init"], cwd=repo_path)
+        run_git_or_fail(["config", "user.name", "Test User"], cwd=repo_path)
+        run_git_or_fail(["config", "user.email", "test@example.com"], cwd=repo_path)
+
+        test_file = os.path.join(repo_path, "README.md")
+        with open(test_file, "w") as f:
+            f.write("# Test Repository\n")
+        run_git_or_fail(["add", "README.md"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Initial commit"], cwd=repo_path)
+
+        # Create bundle
+        serve_dir = os.path.join(self.test_dir, "serve")
+        os.makedirs(serve_dir)
+        bundle_path = os.path.join(serve_dir, "repo.bundle")
+        run_git_or_fail(
+            ["bundle", "create", bundle_path, "HEAD", "master"], cwd=repo_path
+        )
+
+        # Start HTTP server
+        base_url = self._start_http_server(serve_dir)
+
+        # Fetch bundle using dulwich
+        from dulwich.bundle_uri import fetch_bundle_uri
+
+        bundle, bundle_list = fetch_bundle_uri(f"{base_url}/repo.bundle")
+
+        # Should return a bundle, not a bundle list
+        self.assertIsNotNone(bundle)
+        self.assertIsNone(bundle_list)
+        self.addCleanup(bundle.close)
+
+        # Verify bundle contents
+        self.assertIn(b"refs/heads/master", bundle.references)
+
+    def test_fetch_bundle_list_from_http(self) -> None:
+        """Test fetching a bundle list from HTTP URL."""
+        # Create serve directory with bundle list
+        serve_dir = os.path.join(self.test_dir, "serve")
+        os.makedirs(serve_dir)
+
+        # Create a simple repository and bundle
+        repo_path = os.path.join(self.test_dir, "source")
+        os.makedirs(repo_path)
+        run_git_or_fail(["init"], cwd=repo_path)
+        run_git_or_fail(["config", "user.name", "Test User"], cwd=repo_path)
+        run_git_or_fail(["config", "user.email", "test@example.com"], cwd=repo_path)
+
+        test_file = os.path.join(repo_path, "test.txt")
+        with open(test_file, "w") as f:
+            f.write("test\n")
+        run_git_or_fail(["add", "test.txt"], cwd=repo_path)
+        run_git_or_fail(["commit", "-m", "Test"], cwd=repo_path)
+
+        bundle_path = os.path.join(serve_dir, "main.bundle")
+        run_git_or_fail(
+            ["bundle", "create", bundle_path, "HEAD", "master"], cwd=repo_path
+        )
+
+        # Start HTTP server first to get URL
+        base_url = self._start_http_server(serve_dir)
+
+        # Create bundle list file
+        bundle_list_content = f"""[bundle]
+\tversion = 1
+\tmode = all
+
+[bundle "main"]
+\turi = {base_url}/main.bundle
+\tcreationToken = 1700000000
+"""
+        bundle_list_path = os.path.join(serve_dir, "bundle-list")
+        with open(bundle_list_path, "w") as f:
+            f.write(bundle_list_content)
+
+        # Fetch bundle list
+        from dulwich.bundle_uri import fetch_bundle_uri
+
+        bundle, bundle_list = fetch_bundle_uri(f"{base_url}/bundle-list")
+
+        # Should return a bundle list, not a bundle
+        self.assertIsNone(bundle)
+        self.assertIsNotNone(bundle_list)
+
+        # Verify bundle list contents
+        self.assertEqual(bundle_list.version, 1)
+        self.assertEqual(bundle_list.mode, "all")
+        self.assertEqual(len(bundle_list.entries), 1)
+        self.assertEqual(bundle_list.entries[0].id, "main")

--- a/tests/test_bundle_uri.py
+++ b/tests/test_bundle_uri.py
@@ -1,0 +1,325 @@
+# test_bundle_uri.py -- tests for bundle URI support
+# Copyright (C) 2024 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Tests for bundle URI support."""
+
+from dulwich.bundle_uri import (
+    BundleList,
+    BundleListEntry,
+    BundleURIError,
+    _filter_bundle_entries,
+    _is_absolute_uri,
+    _resolve_relative_uri,
+    parse_bundle_list,
+)
+
+from . import TestCase
+
+
+class BundleURIParsingTests(TestCase):
+    def test_parse_simple_bundle_list(self) -> None:
+        """Test parsing a simple bundle list."""
+        data = b"""[bundle]
+    version = 1
+    mode = all
+
+[bundle "bundle1"]
+    uri = https://example.com/bundle1.bundle
+
+[bundle "bundle2"]
+    uri = https://example.com/bundle2.bundle
+"""
+        bundle_list = parse_bundle_list(data)
+
+        self.assertEqual(bundle_list.version, 1)
+        self.assertEqual(bundle_list.mode, "all")
+        self.assertIsNone(bundle_list.heuristic)
+        self.assertEqual(len(bundle_list.entries), 2)
+
+        # Check entries
+        entry_ids = {e.id for e in bundle_list.entries}
+        self.assertIn("bundle1", entry_ids)
+        self.assertIn("bundle2", entry_ids)
+
+    def test_parse_bundle_list_with_heuristic(self) -> None:
+        """Test parsing a bundle list with creationToken heuristic."""
+        data = b"""[bundle]
+    version = 1
+    mode = all
+    heuristic = creationToken
+
+[bundle "daily-2024"]
+    uri = https://example.com/daily.bundle
+    creationToken = 1700000000
+
+[bundle "weekly-2024"]
+    uri = https://example.com/weekly.bundle
+    creationToken = 1699000000
+"""
+        bundle_list = parse_bundle_list(data)
+
+        self.assertEqual(bundle_list.heuristic, "creationToken")
+        self.assertEqual(len(bundle_list.entries), 2)
+
+        # Find daily entry
+        daily = next(e for e in bundle_list.entries if e.id == "daily-2024")
+        self.assertEqual(daily.creation_token, 1700000000)
+
+        weekly = next(e for e in bundle_list.entries if e.id == "weekly-2024")
+        self.assertEqual(weekly.creation_token, 1699000000)
+
+    def test_parse_bundle_list_any_mode(self) -> None:
+        """Test parsing a bundle list with 'any' mode."""
+        data = b"""[bundle]
+    version = 1
+    mode = any
+
+[bundle "eastus"]
+    uri = https://eastus.example.com/bundle.bundle
+    location = eastus
+
+[bundle "westus"]
+    uri = https://westus.example.com/bundle.bundle
+    location = westus
+"""
+        bundle_list = parse_bundle_list(data)
+
+        self.assertEqual(bundle_list.mode, "any")
+        self.assertEqual(len(bundle_list.entries), 2)
+
+        eastus = next(e for e in bundle_list.entries if e.id == "eastus")
+        self.assertEqual(eastus.location, "eastus")
+
+    def test_parse_bundle_list_with_filter(self) -> None:
+        """Test parsing a bundle list with object filters."""
+        data = b"""[bundle]
+    version = 1
+    mode = all
+
+[bundle "full"]
+    uri = https://example.com/full.bundle
+
+[bundle "blobless"]
+    uri = https://example.com/blobless.bundle
+    filter = blob:none
+"""
+        bundle_list = parse_bundle_list(data)
+
+        full = next(e for e in bundle_list.entries if e.id == "full")
+        self.assertIsNone(full.filter)
+
+        blobless = next(e for e in bundle_list.entries if e.id == "blobless")
+        self.assertEqual(blobless.filter, "blob:none")
+
+    def test_parse_bundle_list_missing_version(self) -> None:
+        """Test that missing version raises error."""
+        data = b"""[bundle]
+    mode = all
+"""
+        with self.assertRaises(BundleURIError) as cm:
+            parse_bundle_list(data)
+        self.assertIn("version", str(cm.exception))
+
+    def test_parse_bundle_list_missing_mode(self) -> None:
+        """Test that missing mode raises error."""
+        data = b"""[bundle]
+    version = 1
+"""
+        with self.assertRaises(BundleURIError) as cm:
+            parse_bundle_list(data)
+        self.assertIn("mode", str(cm.exception))
+
+    def test_parse_bundle_list_invalid_mode(self) -> None:
+        """Test that invalid mode raises error."""
+        data = b"""[bundle]
+    version = 1
+    mode = invalid
+"""
+        with self.assertRaises(BundleURIError) as cm:
+            parse_bundle_list(data)
+        self.assertIn("mode", str(cm.exception))
+
+    def test_parse_bundle_list_unsupported_version(self) -> None:
+        """Test that unsupported version raises error."""
+        data = b"""[bundle]
+    version = 2
+    mode = all
+"""
+        with self.assertRaises(BundleURIError) as cm:
+            parse_bundle_list(data)
+        self.assertIn("version", str(cm.exception).lower())
+
+    def test_parse_bundle_list_relative_uri(self) -> None:
+        """Test parsing bundle list with relative URIs."""
+        data = b"""[bundle]
+    version = 1
+    mode = all
+
+[bundle "relative"]
+    uri = daily.bundle
+
+[bundle "absolute-path"]
+    uri = /bundles/weekly.bundle
+"""
+        base_uri = "https://example.com/git/repo/"
+        bundle_list = parse_bundle_list(data, base_uri=base_uri)
+
+        relative = next(e for e in bundle_list.entries if e.id == "relative")
+        self.assertEqual(relative.uri, "https://example.com/git/repo/daily.bundle")
+
+        absolute_path = next(e for e in bundle_list.entries if e.id == "absolute-path")
+        self.assertEqual(absolute_path.uri, "https://example.com/bundles/weekly.bundle")
+
+
+class URIResolutionTests(TestCase):
+    def test_is_absolute_uri(self) -> None:
+        """Test absolute URI detection."""
+        self.assertTrue(_is_absolute_uri("https://example.com/bundle.bundle"))
+        self.assertTrue(_is_absolute_uri("http://example.com/bundle.bundle"))
+        self.assertFalse(_is_absolute_uri("/bundles/bundle.bundle"))
+        self.assertFalse(_is_absolute_uri("daily.bundle"))
+        self.assertFalse(_is_absolute_uri("../bundle.bundle"))
+
+    def test_resolve_relative_uri_simple(self) -> None:
+        """Test resolving simple relative URIs."""
+        base = "https://example.com/git/repo/"
+        self.assertEqual(
+            _resolve_relative_uri(base, "daily.bundle"),
+            "https://example.com/git/repo/daily.bundle",
+        )
+
+    def test_resolve_relative_uri_absolute_path(self) -> None:
+        """Test resolving absolute path URIs."""
+        base = "https://example.com/git/repo/"
+        self.assertEqual(
+            _resolve_relative_uri(base, "/bundles/daily.bundle"),
+            "https://example.com/bundles/daily.bundle",
+        )
+
+    def test_resolve_relative_uri_parent(self) -> None:
+        """Test resolving parent-relative URIs."""
+        base = "https://example.com/git/repo/"
+        self.assertEqual(
+            _resolve_relative_uri(base, "../other/daily.bundle"),
+            "https://example.com/git/other/daily.bundle",
+        )
+
+
+class BundleFilteringTests(TestCase):
+    def test_filter_entries_full_clone(self) -> None:
+        """Test filtering entries for full clone (no filter)."""
+        entries = [
+            BundleListEntry(id="full", uri="https://example.com/full.bundle"),
+            BundleListEntry(
+                id="blobless",
+                uri="https://example.com/blobless.bundle",
+                filter="blob:none",
+            ),
+        ]
+
+        filtered = _filter_bundle_entries(entries, filter_spec=None)
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].id, "full")
+
+    def test_filter_entries_partial_clone(self) -> None:
+        """Test filtering entries for partial clone with filter."""
+        entries = [
+            BundleListEntry(id="full", uri="https://example.com/full.bundle"),
+            BundleListEntry(
+                id="blobless",
+                uri="https://example.com/blobless.bundle",
+                filter="blob:none",
+            ),
+            BundleListEntry(
+                id="treeless",
+                uri="https://example.com/treeless.bundle",
+                filter="tree:0",
+            ),
+        ]
+
+        filtered = _filter_bundle_entries(entries, filter_spec="blob:none")
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].id, "blobless")
+
+    def test_filter_entries_no_match(self) -> None:
+        """Test filtering when no entries match."""
+        entries = [
+            BundleListEntry(
+                id="blobless",
+                uri="https://example.com/blobless.bundle",
+                filter="blob:none",
+            ),
+        ]
+
+        filtered = _filter_bundle_entries(entries, filter_spec=None)
+        self.assertEqual(len(filtered), 0)
+
+
+class BundleListEntryTests(TestCase):
+    def test_entry_defaults(self) -> None:
+        """Test BundleListEntry default values."""
+        entry = BundleListEntry(id="test", uri="https://example.com/test.bundle")
+        self.assertEqual(entry.id, "test")
+        self.assertEqual(entry.uri, "https://example.com/test.bundle")
+        self.assertIsNone(entry.filter)
+        self.assertIsNone(entry.creation_token)
+        self.assertIsNone(entry.location)
+
+    def test_entry_all_fields(self) -> None:
+        """Test BundleListEntry with all fields set."""
+        entry = BundleListEntry(
+            id="test",
+            uri="https://example.com/test.bundle",
+            filter="blob:none",
+            creation_token=1700000000,
+            location="eastus",
+        )
+        self.assertEqual(entry.id, "test")
+        self.assertEqual(entry.uri, "https://example.com/test.bundle")
+        self.assertEqual(entry.filter, "blob:none")
+        self.assertEqual(entry.creation_token, 1700000000)
+        self.assertEqual(entry.location, "eastus")
+
+
+class BundleListTests(TestCase):
+    def test_bundle_list_defaults(self) -> None:
+        """Test BundleList default values."""
+        bundle_list = BundleList()
+        self.assertEqual(bundle_list.version, 1)
+        self.assertEqual(bundle_list.mode, "all")
+        self.assertIsNone(bundle_list.heuristic)
+        self.assertEqual(bundle_list.entries, [])
+
+    def test_bundle_list_custom(self) -> None:
+        """Test BundleList with custom values."""
+        entries = [
+            BundleListEntry(id="test", uri="https://example.com/test.bundle"),
+        ]
+        bundle_list = BundleList(
+            version=1,
+            mode="any",
+            heuristic="creationToken",
+            entries=entries,
+        )
+        self.assertEqual(bundle_list.version, 1)
+        self.assertEqual(bundle_list.mode, "any")
+        self.assertEqual(bundle_list.heuristic, "creationToken")
+        self.assertEqual(len(bundle_list.entries), 1)


### PR DESCRIPTION
The new ``dulwich.bundle_uri`` module implements the Git bundle URI specification, allowing clients to download pre-computed bundles from HTTP(S) URLs to bootstrap repository data before fetching remaining objects.