### PR TITLE
Add support for core.trustctime configuration option

### DIFF
--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -1102,8 +1102,14 @@ def commit(
             else:
                 filter_callback = None
 
+            # Read config once for filesystem compatibility options
+            config = r.get_config_stack()
+            trust_ctime = config.get_boolean(b"core", b"trustctime", True)
+
             unstaged_changes = list(
-                get_unstaged_changes(index, r.path, filter_callback)
+                get_unstaged_changes(
+                    index, r.path, filter_callback, trust_ctime=trust_ctime
+                )
             )
 
             if unstaged_changes:
@@ -1563,12 +1569,15 @@ def add(
         else:
             filter_callback = None
 
-        # Check if core.preloadIndex is enabled
+        # Read config once for filesystem compatibility options
         config = r.get_config_stack()
         preload_index = config.get_boolean(b"core", b"preloadIndex", False)
+        trust_ctime = config.get_boolean(b"core", b"trustctime", True)
 
         all_unstaged_paths = list(
-            get_unstaged_changes(index, r.path, filter_callback, preload_index)
+            get_unstaged_changes(
+                index, r.path, filter_callback, preload_index, trust_ctime
+            )
         )
 
         if paths is None:
@@ -3032,12 +3041,15 @@ def status(
         else:
             filter_callback = None
 
-        # Check if core.preloadIndex is enabled
+        # Read config once for filesystem compatibility options
         config = r.get_config_stack()
         preload_index = config.get_boolean(b"core", b"preloadIndex", False)
+        trust_ctime = config.get_boolean(b"core", b"trustctime", True)
 
         unstaged_changes_tree = list(
-            get_unstaged_changes(index, r.path, filter_callback, preload_index)
+            get_unstaged_changes(
+                index, r.path, filter_callback, preload_index, trust_ctime
+            )
         )
 
         untracked_paths = get_untracked_paths(

--- a/status.yaml
+++ b/status.yaml
@@ -28,3 +28,7 @@ configuration:
     status: supported
   - key: core.ignorecase
     status: supported
+  - key: core.trustctime
+    status: supported
+  - key: core.symlinks
+    status: supported

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -6372,6 +6372,10 @@ class StatusTests(PorcelainTestCase):
         os.utime(file_path, ns=(mtime_nsec, mtime_nsec))
 
         c = self.repo.get_config()
+        # Set trustctime=false because os.utime() updates ctime, which would
+        # break stat matching. This test verifies that stat matching optimization
+        # works with mtime+size matching (ignoring ctime changes from utime).
+        c.set("core", "trustctime", "false")
         c.set("core", "autocrlf", "input")
         c.write_to_path()
 


### PR DESCRIPTION
Implement the core.trustctime Git config option which controls whether ctime (change time) is used as part of file change detection. When set to false, ctime differences are ignored, which is useful on filesystems where ctime is unreliable (e.g., due to backup systems or file crawlers).