### PR TITLE
Add support for atomic push operations (--atomic)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
    command and ``porcelain.push()``, enabling AGit flow and other server-side
    push option workflows. (Jelmer Vernooĳ)
 
+ * Add support for atomic push operations (``--atomic``). When enabled,
+   either all ref updates succeed or none are applied. Both client and
+   server now negotiate the ``atomic`` capability.
+   (Jelmer Vernooĳ, #1781)
+
 1.1.0	2026-02-17
 
  * Add support for ``core.commentChar`` configuration option in commit message

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -3662,6 +3662,11 @@ class cmd_push(Command):
         parser = argparse.ArgumentParser()
         parser.add_argument("-f", "--force", action="store_true", help="Force")
         parser.add_argument(
+            "--atomic",
+            action="store_true",
+            help="Request atomic push (all refs update or none do)",
+        )
+        parser.add_argument(
             "-o",
             "--push-option",
             action="append",
@@ -3680,6 +3685,7 @@ class cmd_push(Command):
                 args.refspec or None,
                 force=args.force,
                 push_options=args.push_options or None,
+                atomic=args.atomic,
             )
         except porcelain.DivergedBranches:
             sys.stderr.write("Diverged branches; specify --force to override")

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -2689,6 +2689,7 @@ def push(
     errstream: BinaryIO | RawIOBase = default_bytes_err_stream,
     force: bool = False,
     push_options: list[str] | None = None,
+    atomic: bool = False,
     **kwargs: object,
 ) -> SendPackResult:
     """Remote push with dulwich via dulwich.client.
@@ -2702,6 +2703,7 @@ def push(
       force: Force overwriting refs
       push_options: Optional list of push options to send to the server
         (e.g. for AGit flow: ["topic=my-branch", "title=My PR"])
+      atomic: If True, request atomic push (all refs update or none do)
       **kwargs: Additional keyword arguments for the client
     """
     # Open the repo
@@ -2815,6 +2817,7 @@ def push(
                 generate_pack_data=generate_pack_data_wrapper,
                 progress=lambda data: (errstream.write(data), None)[1],
                 push_options=push_options_bytes,
+                atomic=atomic,
             )
         except SendPackError as exc:
             raise Error(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -2313,7 +2313,9 @@ class PushCommandTest(DulwichCliTestCase):
     @patch("dulwich.porcelain.push")
     def test_push_force(self, mock_push):
         _result, _stdout, _stderr = self._run_cli("push", "-f", "origin")
-        mock_push.assert_called_with(".", "origin", None, force=True, push_options=None)
+        mock_push.assert_called_with(
+            ".", "origin", None, force=True, push_options=None, atomic=False
+        )
 
     @patch("dulwich.porcelain.push")
     def test_push_option_single(self, mock_push):
@@ -2321,7 +2323,12 @@ class PushCommandTest(DulwichCliTestCase):
             "push", "-o", "topic=my-feature", "origin"
         )
         mock_push.assert_called_with(
-            ".", "origin", None, force=False, push_options=["topic=my-feature"]
+            ".",
+            "origin",
+            None,
+            force=False,
+            push_options=["topic=my-feature"],
+            atomic=False,
         )
 
     @patch("dulwich.porcelain.push")
@@ -2340,6 +2347,7 @@ class PushCommandTest(DulwichCliTestCase):
             None,
             force=False,
             push_options=["topic=my-feature", "title=My PR"],
+            atomic=False,
         )
 
 

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -7145,8 +7145,8 @@ class ReceivePackTests(PorcelainTestCase):
         outlines = outf.getvalue().splitlines()
         self.assertEqual(
             [
-                b"00a4319b56ce3aee2d489f759736a79cc552c9bb86d9 HEAD\x00 report-status "
-                b"delete-refs quiet ofs-delta side-band-64k "
+                b"00ab319b56ce3aee2d489f759736a79cc552c9bb86d9 HEAD\x00 report-status "
+                b"delete-refs quiet atomic ofs-delta side-band-64k "
                 b"no-done object-format=sha1 symref=HEAD:refs/heads/master",
                 b"003f319b56ce3aee2d489f759736a79cc552c9bb86d9 refs/heads/master",
                 b"0000",


### PR DESCRIPTION
When enabled, either all ref updates in a push succeed or none are applied. Both client and server now negotiate the "atomic" capability per the Git protocol specification.

Closes #1781