### PR TITLE
Improve error message when read_info_refs fails to parse server response

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,10 @@
  * Add ``apply`` command and ``porcelain.apply_patch()`` for applying
    unified diffs. (Jelmer Vernooĳ, #1784)
 
+ * Improve error message in ``read_info_refs()`` to show the actual line
+   content when parsing fails, making it easier to diagnose issues with
+   malformed server responses. (Jelmer Vernooĳ, #2103)
+
 1.1.0	2026-02-17
 
  * Add support for ``core.commentChar`` configuration option in commit message

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -1437,8 +1437,15 @@ def read_info_refs(f: BinaryIO) -> dict[Ref, ObjectID]:
       Dictionary mapping ref names to SHA1s
     """
     ret: dict[Ref, ObjectID] = {}
-    for line in f.readlines():
-        (sha, name) = line.rstrip(b"\r\n").split(b"\t", 1)
+    for line_no, line in enumerate(f.readlines(), 1):
+        stripped = line.rstrip(b"\r\n")
+        parts = stripped.split(b"\t", 1)
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid info/refs format at line {line_no}: "
+                f"expected '<sha>\\t<refname>', got {stripped[:100]!r}"
+            )
+        (sha, name) = parts
         ret[Ref(name)] = ObjectID(sha)
     return ret
 


### PR DESCRIPTION
When read_info_refs encounters a malformed line (e.g., missing tab separator), the error now includes the line number and first 100 bytes of the problematic line. This makes it much easier to diagnose issues with server responses.