### PR TITLE
Add support for core.precomposeunicode configuration option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,10 @@
    the grace period before unreachable objects are pruned during garbage
    collection. (Jelmer Vernooĳ, #1859)
 
+ * Add support for ``core.precomposeunicode`` configuration option
+   for normalizing NFD Unicode paths from macOS filesystems to NFC
+   form. (Jelmer Vernooĳ, #1804)
+
  * Add support for ``core.maxStat`` configuration option, which limits
    the number of stat operations performed when checking for unstaged
    changes. This improves performance on slow filesystems or very large

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -1587,6 +1587,7 @@ def add(
         config = r.get_config_stack()
         preload_index = config.get_boolean(b"core", b"preloadIndex", False)
         trust_ctime = config.get_boolean(b"core", b"trustctime", True)
+        precompose_unicode = config.get_boolean(b"core", b"precomposeunicode", False)
 
         all_unstaged_paths = list(
             get_unstaged_changes(
@@ -1642,6 +1643,7 @@ def add(
                         str(resolved_path),
                         str(repo_path),
                         index,
+                        precompose_unicode=precompose_unicode,
                     )
                 )
                 for untracked_path in current_untracked:
@@ -3259,6 +3261,7 @@ def status(
             max_stat = int(config.get(b"core", b"maxStat"))
         except KeyError:
             max_stat = None
+        precompose_unicode = config.get_boolean(b"core", b"precomposeunicode", False)
 
         unstaged_changes_tree = list(
             get_unstaged_changes(
@@ -3277,6 +3280,7 @@ def status(
             index,
             exclude_ignored=not ignored,
             untracked_files=untracked_files,
+            precompose_unicode=precompose_unicode,
         )
 
         # Convert all paths to filesystem encoding
@@ -3340,10 +3344,23 @@ def shortlog(
         return items
 
 
+def _precompose_unicode_path(path: str) -> str:
+    """Normalize a filesystem path to NFC (precomposed) Unicode form.
+
+    On macOS, HFS+/APFS filesystems return filenames in NFD (decomposed)
+    form. This function normalizes them to NFC so they match the paths
+    stored in the git index.
+    """
+    import unicodedata
+
+    return unicodedata.normalize("NFC", path)
+
+
 def _walk_working_dir_paths(
     frompath: str | bytes | os.PathLike[str],
     basepath: str | bytes | os.PathLike[str],
     prune_dirnames: Callable[[str, list[str]], list[str]] | None = None,
+    precompose_unicode: bool = False,
 ) -> Iterator[tuple[str | bytes, bool]]:
     """Get path, is_dir for files in working dir from frompath.
 
@@ -3352,6 +3369,7 @@ def _walk_working_dir_paths(
       basepath: Path to compare to
       prune_dirnames: Optional callback to prune dirnames during os.walk
         dirnames will be set to result of prune_dirnames(dirpath, dirnames)
+      precompose_unicode: If True, normalize paths to NFC Unicode form
     """
     # Convert paths to strings for os.walk compatibility
 
@@ -3366,6 +3384,11 @@ def _walk_working_dir_paths(
             filenames.remove(".git")
             if dirpath != basepath:
                 continue
+
+        if precompose_unicode and isinstance(dirpath, str):
+            dirpath = _precompose_unicode_path(dirpath)
+            dirnames[:] = [_precompose_unicode_path(d) for d in dirnames]
+            filenames = [_precompose_unicode_path(f) for f in filenames]
 
         if dirpath != frompath:
             yield dirpath, True  # type: ignore[misc]
@@ -3384,6 +3407,7 @@ def get_untracked_paths(
     index: Index,
     exclude_ignored: bool = False,
     untracked_files: str = "all",
+    precompose_unicode: bool = False,
 ) -> Iterator[str]:
     """Get untracked paths.
 
@@ -3396,6 +3420,8 @@ def get_untracked_paths(
         - "no": return an empty list
         - "all": return all files in untracked directories
         - "normal": return untracked directories without listing their contents
+      precompose_unicode: If True, normalize filesystem paths to NFC Unicode
+        form. This is needed on macOS where the filesystem returns NFD paths.
 
     Note: ignored directories will never be walked for performance reasons.
       If exclude_ignored is False, only the path to an ignored directory will
@@ -3484,7 +3510,10 @@ def get_untracked_paths(
     # For "all" mode, use the original behavior
     if untracked_files == "all":
         for ap, is_dir in _walk_working_dir_paths(
-            frompath_str, basepath_str, prune_dirnames=prune_dirnames
+            frompath_str,
+            basepath_str,
+            prune_dirnames=prune_dirnames,
+            precompose_unicode=precompose_unicode,
         ):
             # frompath_str and basepath_str are both str, so ap must be str
             assert isinstance(ap, str)
@@ -3498,7 +3527,10 @@ def get_untracked_paths(
     else:  # "normal" mode
         # Walk directories, handling both files and directories
         for ap, is_dir in _walk_working_dir_paths(
-            frompath_str, basepath_str, prune_dirnames=prune_dirnames
+            frompath_str,
+            basepath_str,
+            prune_dirnames=prune_dirnames,
+            precompose_unicode=precompose_unicode,
         ):
             # frompath_str and basepath_str are both str, so ap must be str
             assert isinstance(ap, str)

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -3387,8 +3387,12 @@ def _walk_working_dir_paths(
 
         if precompose_unicode and isinstance(dirpath, str):
             dirpath = _precompose_unicode_path(dirpath)
-            dirnames[:] = [_precompose_unicode_path(d) for d in dirnames]
-            filenames = [_precompose_unicode_path(f) for f in filenames]
+            dirnames[:] = [
+                _precompose_unicode_path(d) for d in dirnames if isinstance(d, str)
+            ]
+            filenames = [
+                _precompose_unicode_path(f) for f in filenames if isinstance(f, str)
+            ]
 
         if dirpath != frompath:
             yield dirpath, True  # type: ignore[misc]

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -601,6 +601,11 @@ class BaseRepo:
         if symlinks is False:
             cf.set("core", "symlinks", symlinks)
 
+        # On macOS, set precomposeunicode to true since HFS+/APFS
+        # returns filenames in NFD (decomposed) Unicode form
+        if sys.platform == "darwin":
+            cf.set("core", "precomposeunicode", True)
+
         cf.set("core", "bare", bare)
         cf.set("core", "logallrefupdates", True)
 

--- a/status.yaml
+++ b/status.yaml
@@ -32,3 +32,7 @@ configuration:
     status: supported
   - key: core.symlinks
     status: supported
+  - key: core.precomposeunicode
+    status: supported
+  - key: core.sharedRepository
+    status: supported

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4164,6 +4164,10 @@ class ConfigCommandTest(DulwichCliTestCase):
             symlinks = config.get((b"core",), b"symlinks")
         except KeyError:
             symlinks = None
+        try:
+            precomposeunicode = config.get((b"core",), b"precomposeunicode")
+        except KeyError:
+            precomposeunicode = None
 
         # List all values
         result, stdout, _stderr = self._run_cli("config", "--list")
@@ -4174,6 +4178,8 @@ class ConfigCommandTest(DulwichCliTestCase):
         expected += f"core.filemode={filemode.decode('utf-8')}\n"
         if symlinks is not None:
             expected += f"core.symlinks={symlinks.decode('utf-8')}\n"
+        if precomposeunicode is not None:
+            expected += f"core.precomposeunicode={precomposeunicode.decode('utf-8')}\n"
         expected += (
             "core.bare=false\n"
             "core.logallrefupdates=true\n"

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -7445,6 +7445,73 @@ class StatusTests(PorcelainTestCase):
             "Top-level file 'sample.txt' should be in status.untracked",
         )
 
+    def test_get_untracked_paths_precompose_unicode(self) -> None:
+        """Test that precompose_unicode normalizes NFD paths to NFC."""
+        import unicodedata
+
+        # NFC (precomposed) and NFD (decomposed) forms of "ä"
+        nfc_name = unicodedata.normalize("NFC", "t\u00e4st.txt")
+        nfd_name = unicodedata.normalize("NFD", "t\u00e4st.txt")
+
+        # Create a file with NFC name, add and commit it
+        fullpath = os.path.join(self.repo.path, nfc_name)
+        with open(fullpath, "w") as f:
+            f.write("content\n")
+        porcelain.add(self.repo.path, paths=[fullpath])
+        porcelain.commit(
+            repo=self.repo.path,
+            message=b"Add unicode file",
+            author=b"Test <test@example.com>",
+        )
+
+        # Now rename the file to NFD form (simulating what macOS HFS+/APFS does)
+        nfd_path = os.path.join(self.repo.path, nfd_name)
+        if nfc_name != nfd_name:
+            # Only rename if the filesystem actually distinguishes NFC/NFD
+            try:
+                os.rename(fullpath, nfd_path)
+            except OSError:
+                # Filesystem normalizes names (e.g., macOS) — skip rename test
+                return
+
+            if not os.path.exists(nfd_path):
+                return
+
+            # Without precompose_unicode, the NFD file should appear as untracked
+            # (since the index has the NFC version)
+            index = self.repo.open_index()
+            untracked_without = set(
+                porcelain.get_untracked_paths(
+                    self.repo.path,
+                    self.repo.path,
+                    index,
+                    precompose_unicode=False,
+                )
+            )
+            self.assertIn(nfd_name, untracked_without)
+
+            # With precompose_unicode, the NFD file should be recognized as tracked
+            untracked_with = set(
+                porcelain.get_untracked_paths(
+                    self.repo.path,
+                    self.repo.path,
+                    index,
+                    precompose_unicode=True,
+                )
+            )
+            self.assertNotIn(nfd_name, untracked_with)
+            self.assertNotIn(nfc_name, untracked_with)
+
+    def test_status_precompose_unicode_config(self) -> None:
+        """Test that status reads core.precomposeunicode from config."""
+        config = self.repo.get_config()
+        config.set(b"core", b"precomposeunicode", b"true")
+        config.write_to_path()
+
+        # Verify the config is read (status should not error)
+        results = porcelain.status(self.repo)
+        self.assertIsNotNone(results)
+
 
 # TODO(jelmer): Add test for dulwich.porcelain.daemon
 


### PR DESCRIPTION
On macOS, HFS+/APFS filesystems return filenames in NFD (decomposed) Unicode form. When core.precomposeunicode is true, normalize filesystem paths to NFC before comparing with index entries, preventing tracked files from appearing as untracked.

Fixes #1804