### PR TITLE
Restore macOS x86_64 wheel builds

### DIFF
--- a/.github/workflows/python-distributions.yml
+++ b/.github/workflows/python-distributions.yml
@@ -44,14 +44,18 @@ jobs:
             echo 'macos=${{ steps.all-build-identifiers.outputs.macos }}' >> $GITHUB_OUTPUT
           else
             echo "linux=$(echo -n '${{ steps.all-build-identifiers.outputs.linux }}' | awk '{print $NF}')" >> $GITHUB_OUTPUT
-            echo "macos=$(echo -n '${{ steps.all-build-identifiers.outputs.macos }}' | awk '{print $NF}')" >> $GITHUB_OUTPUT
+            # Select the last identifier overall plus the last x86_64 one, to ensure we test both architectures
+            macos_all='${{ steps.all-build-identifiers.outputs.macos }}'
+            macos_last=$(echo -n "$macos_all" | awk '{print $NF}')
+            macos_x86=$(echo -n "$macos_all" | tr ' ' '\n' | grep x86_64 | tail -1)
+            echo "macos=$(echo $macos_last $macos_x86 | tr ' ' '\n' | sort -u | tr '\n' ' ')" >> $GITHUB_OUTPUT
             echo "windows=$(echo -n '${{ steps.all-build-identifiers.outputs.windows }}' | awk '{print $NF}')" >> $GITHUB_OUTPUT
           fi
       - name: Output build identifiers
         id: json-identifiers
         run: |
           echo "linux=$(echo -n '${{ steps.select-build-identifiers.outputs.linux }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: "ubuntu-latest", "build-identifier": .}]')" >> $GITHUB_OUTPUT
-          echo "macos=$(echo -n '${{ steps.select-build-identifiers.outputs.macos }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: "macos-latest", "build-identifier": .}]')" >> $GITHUB_OUTPUT
+          echo "macos=$(echo -n '${{ steps.select-build-identifiers.outputs.macos }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: (if test("x86_64") then "macos-13" else "macos-latest" end), "build-identifier": .}]')" >> $GITHUB_OUTPUT
           echo "windows=$(echo -n '${{ steps.select-build-identifiers.outputs.windows }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: "windows-latest", "build-identifier": .}]')" >> $GITHUB_OUTPUT
       - name: Merge build identifiers
         id: merged-identifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,5 +178,5 @@ before-build = "pip install -U setuptools-rust && curl https://sh.rustup.rs -sSf
 archs = ["auto", "universal2", "x86_64", "arm64"]
 before-all = "rustup target add x86_64-apple-darwin aarch64-apple-darwin"
 skip = """\
-    cp*-macosx_x86_64 cp*-macosx_universal2 \
+    cp*-macosx_universal2 \
     """

--- a/setup.py
+++ b/setup.py
@@ -8,24 +8,6 @@ import sys
 
 from setuptools import setup
 
-if sys.platform == "darwin" and os.path.exists("/usr/bin/xcodebuild"):
-    # XCode 4.0 dropped support for ppc architecture, which is hardcoded in
-    # distutils.sysconfig
-    import subprocess
-
-    p = subprocess.Popen(
-        ["/usr/bin/xcodebuild", "-version"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        env={},
-    )
-    out, err = p.communicate()
-    for line in out.splitlines():
-        line = line.decode("utf8")
-        # Also parse only first digit, because 3.2.1 can't be parsed nicely
-        if line.startswith("Xcode") and int(line.split()[1].split(".")[0]) >= 4:
-            os.environ["ARCHFLAGS"] = ""
-
 tests_require = ["fastimport"]
 
 


### PR DESCRIPTION
Remove obsolete ARCHFLAGS ppc workaround from setup.py that could interfere with architecture-specific compilation

Fixes #1303