### PR TITLE
Cross-compile macOS x86_64 wheels on arm64 runners

### DIFF
--- a/.github/workflows/python-distributions.yml
+++ b/.github/workflows/python-distributions.yml
@@ -55,7 +55,7 @@ jobs:
         id: json-identifiers
         run: |
           echo "linux=$(echo -n '${{ steps.select-build-identifiers.outputs.linux }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: "ubuntu-latest", "build-identifier": .}]')" >> $GITHUB_OUTPUT
-          echo "macos=$(echo -n '${{ steps.select-build-identifiers.outputs.macos }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: (if test("x86_64") then "macos-latest-large" else "macos-latest" end), "build-identifier": .}]')" >> $GITHUB_OUTPUT
+          echo "macos=$(echo -n '${{ steps.select-build-identifiers.outputs.macos }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: "macos-latest", "build-identifier": .}]')" >> $GITHUB_OUTPUT
           echo "windows=$(echo -n '${{ steps.select-build-identifiers.outputs.windows }}' | jq -R -s -c 'split(" ") | map(select(length > 0)) | [.[] | {os: "windows-latest", "build-identifier": .}]')" >> $GITHUB_OUTPUT
       - name: Merge build identifiers
         id: merged-identifiers

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,3 +180,7 @@ before-all = "rustup target add x86_64-apple-darwin aarch64-apple-darwin"
 skip = """\
     cp*-macosx_universal2 \
     """
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_x86_64"
+environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_BUILD_TARGET="x86_64-apple-darwin", ARCHFLAGS="-arch x86_64"}


### PR DESCRIPTION
`macos-latest-large` (Intel) runners require a paid plan, causing billing failures. Cross-compile x86_64 wheels on the free arm64 `macos-latest` runner instead

Follow-up to #2136.