### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET=10.12 for x86_64 wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,4 +183,4 @@ skip = """\
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
-environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_BUILD_TARGET="x86_64-apple-darwin", ARCHFLAGS="-arch x86_64"}
+environment = {PATH="$HOME/.cargo/bin:$PATH", CARGO_BUILD_TARGET="x86_64-apple-darwin", ARCHFLAGS="-arch x86_64", MACOSX_DEPLOYMENT_TARGET="10.12"}


### PR DESCRIPTION
The Rust-compiled .so files have a minimum macOS target of 10.12, but the wheel was tagged as macosx_10_9, causing delocate-wheel to fail with a version mismatch error.