### PR TITLE
Preserve quoted trailing whitespace in config values

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -793,7 +793,10 @@ def _parse_string(value: bytes) -> bytes:
             # the rest of the line is a comment
             break
         elif c in _WHITESPACE_CHARS:
-            whitespace.append(c)
+            if in_quotes:
+                ret.append(c)
+            else:
+                whitespace.append(c)
         else:
             if whitespace:
                 ret.extend(whitespace)

--- a/property_tests/test_config.py
+++ b/property_tests/test_config.py
@@ -76,19 +76,15 @@ if HYPOTHESIS_AVAILABLE:
         max_size=12,
     ).map(lambda value: value.encode("ascii"))
 
-    values = (
-        st.text(
-            alphabet=(
-                "abcdefghijklmnopqrstuvwxyz"
-                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                "0123456789"
-                ' -_./:#\t\n\\"'
-            ),
-            max_size=32,
-        )
-        .map(lambda value: value.encode("ascii"))
-        .filter(lambda value: not value.endswith((b" ", b"\t")))
-    )
+    values = st.text(
+        alphabet=(
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "0123456789"
+            ' -_./:#\t\n\\"'
+        ),
+        max_size=32,
+    ).map(lambda value: value.encode("ascii"))
 
     sections = st.tuples(
         section_names,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,6 +218,17 @@ class ConfigFileTests(TestCase):
         c.write_to_file(f)
         self.assertEqual(b'[branch "blie"]\n\tfoo = bar\n', f.getvalue())
 
+    def test_write_to_file_preserves_quoted_trailing_whitespace(self) -> None:
+        c = ConfigFile()
+        c.set((b"core",), b"foo", b" ")
+        c.set((b"core",), b"bar", b"\t")
+
+        f = BytesIO()
+        c.write_to_file(f)
+        reparsed = self.from_file(f.getvalue())
+
+        self.assertEqual(c, reparsed)
+
     def test_same_line(self) -> None:
         cf = self.from_file(b"[branch.foo] foo = bar\n")
         self.assertEqual(b"bar", cf.get((b"branch", b"foo"), b"foo"))
@@ -1001,7 +1012,9 @@ class FormatStringTests(TestCase):
 class ParseStringTests(TestCase):
     def test_quoted(self) -> None:
         self.assertEqual(b" foo", _parse_string(b'" foo"'))
+        self.assertEqual(b"foo ", _parse_string(b'"foo "'))
         self.assertEqual(b"\tfoo", _parse_string(b'"\\tfoo"'))
+        self.assertEqual(b"foo\t", _parse_string(b'"foo\\t"'))
 
     def test_not_quoted(self) -> None:
         self.assertEqual(b"foo", _parse_string(b"foo"))


### PR DESCRIPTION
Follow-up to #2144.

The initial Hypothesis config round-trip property exposed a case where quoted trailing whitespace was not preserved when reading config values back.

For example, a value like `b" "` is written as a quoted config value, but parsing discarded the whitespace because `_parse_string` buffered whitespace even while inside quotes.

This changes `_parse_string` so spaces and tabs inside quotes are preserved immediately, while trailing whitespace outside quotes is still ignored.

Also included:

- a focused regression test for round-tripping quoted trailing space and tab values
- removal of the temporary property-test filter that excluded values ending in space or tab