### PR TITLE
Fix timezone roundtrip with negative marker

### DIFF
--- a/.github/workflows/pythontest.yml
+++ b/.github/workflows/pythontest.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Property-based tests
         run: |
           pip install --upgrade ".[hypothesis]"
-          python -m unittest property_tests.test_config
+          python -m unittest discover property_tests
         env:
           HYPOTHESIS_PROFILE: ci
       - name: Run contrib tests

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -142,7 +142,7 @@ them explicitly. Their default Hypothesis profile is deterministic.
 .. code:: console
 
    $ pip install -e ".[hypothesis]"
-   $ python -m unittest property_tests.test_config
+   $ python -m unittest discover property_tests
 
 testr and tox configuration is also present.
 

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1724,12 +1724,16 @@ def format_timezone(offset: int, unnecessary_negative_timezone: bool = False) ->
     """
     if offset % 60 != 0:
         raise ValueError("Unable to handle non-minute offset.")
-    if offset < 0 or unnecessary_negative_timezone:
+    negative = offset < 0
+    sign = "+"
+    if negative:
         sign = "-"
         offset = -offset
-    else:
-        sign = "+"
-    return ("%c%02d%02d" % (sign, offset / 3600, (offset / 60) % 60)).encode("ascii")  # noqa: UP031
+    timezone = (offset // 3600) * 100 + (offset // 60) % 60
+    if unnecessary_negative_timezone and not negative:
+        sign = "-"
+        timezone = -timezone
+    return ("%c%04d" % (sign, timezone)).encode("ascii")  # noqa: UP031
 
 
 def parse_time_entry(

--- a/property_tests/test_objects.py
+++ b/property_tests/test_objects.py
@@ -1,0 +1,77 @@
+# test_objects.py -- property tests for objects.py
+# Copyright (C) 2026 The Dulwich contributors
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Property tests for Git objects."""
+
+import os
+from unittest import SkipTest
+
+from dulwich.objects import format_timezone, parse_timezone
+from tests import TestCase
+
+try:
+    from hypothesis import given, settings
+    from hypothesis import strategies as st
+except ImportError:
+    HYPOTHESIS_AVAILABLE = False
+else:
+    HYPOTHESIS_AVAILABLE = True
+
+
+if HYPOTHESIS_AVAILABLE:
+    settings.register_profile(
+        "deterministic", max_examples=50, deadline=None, derandomize=True
+    )
+    settings.register_profile("ci", max_examples=50, deadline=None, derandomize=True)
+    settings.register_profile(
+        "local-deep", max_examples=1000, deadline=None, derandomize=True
+    )
+    settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "deterministic"))
+
+    @st.composite
+    def timezone_infos(draw) -> tuple[int, bool]:
+        """Generate timezone offsets and compatible negative-marker flags."""
+        offset_minutes = draw(st.integers(min_value=-(14 * 60), max_value=14 * 60))
+        offset = offset_minutes * 60
+        unnecessary_negative_timezone = draw(st.booleans()) if offset >= 0 else False
+        return offset, unnecessary_negative_timezone
+
+
+class ObjectPropertyTests(TestCase):
+    """Property tests for object helpers."""
+
+    if not HYPOTHESIS_AVAILABLE:
+
+        def test_hypothesis_available(self) -> None:
+            """Skip these tests when Hypothesis is unavailable."""
+            raise SkipTest("hypothesis is not available")
+
+    else:
+
+        @given(timezone_infos())
+        def test_timezone_format_parse_roundtrip(
+            self, timezone_info: tuple[int, bool]
+        ) -> None:
+            """Check that formatted timezones parse back to their inputs."""
+            self.assertEqual(
+                timezone_info,
+                parse_timezone(format_timezone(*timezone_info)),
+            )

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -1861,6 +1861,9 @@ class TimezoneTests(TestCase):
     def test_format_timezone_double_negative(self) -> None:
         self.assertEqual(b"--700", format_timezone(((7 * 60) * 60), True))
 
+    def test_format_timezone_double_negative_sub_hour(self) -> None:
+        self.assertEqual((60, True), parse_timezone(format_timezone(60, True)))
+
     def test_parse_timezone_pdt_half(self) -> None:
         self.assertEqual((((-4 * 60) - 40) * 60, False), parse_timezone(b"-0440"))
 


### PR DESCRIPTION
Follow-up to the property-test work.

The timezone parse/format round-trip property exposed a case where `format_timezone()` does not round-trip positive sub-hour offsets when `unnecessary_negative_timezone=True`.

`format_timezone(60, True)` should produce a value that parses back to `(60, True)`, matching the existing double-negative behavior covered for whole-hour offsets such as `--700`.

This updates the timezone formatting arithmetic to build the HHMM value from the absolute offset before applying the negative marker.

Also included:

- a focused regression test for the minimized case
- an objects property test for timezone parse/format round-trips
- CI/docs update to discover all modules under `property_tests`