### PR TITLE
midx: Deduplicate objects across packs when writing

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+1.2.1	UNRELEASED
+
+ * Deduplicate objects when writing a multi-pack-index. Objects present
+   in multiple packs (e.g. after ``git gc`` creates a cruft pack) would
+   otherwise produce an OIDL chunk with repeated SHAs, causing ``git
+   multi-pack-index verify`` to fail with "oid lookup out of order".
+   (Jelmer Vernooĳ, #2152)
+
 1.2.0	2026-04-21
 
  * Expand ``log`` command options: add ``--oneline``, ``--abbrev-commit``,

--- a/dulwich/midx.py
+++ b/dulwich/midx.py
@@ -499,14 +499,23 @@ def write_midx(
     # Sort pack entries by pack name (required by Git)
     pack_index_entries_sorted = sorted(pack_index_entries, key=lambda x: x[0])
 
-    # Collect all objects from all packs
-    all_objects: list[tuple[RawObjectID, int, int]] = []  # (sha, pack_id, offset)
+    # Collect all objects from all packs, deduplicating objects that appear
+    # in multiple packs. Git's MIDX format requires strictly increasing OIDs
+    # in the OIDL chunk, so duplicates must be resolved. When the same object
+    # is in multiple packs, we keep the occurrence from the first pack (in
+    # pack-name order), matching how Git itself handles duplicates.
+    seen: dict[RawObjectID, tuple[int, int]] = {}  # sha -> (pack_id, offset)
     pack_names: list[str] = []
 
     for pack_id, (pack_name, entries) in enumerate(pack_index_entries_sorted):
         pack_names.append(pack_name)
         for sha, offset, _crc32 in entries:
-            all_objects.append((sha, pack_id, offset))
+            if sha not in seen:
+                seen[sha] = (pack_id, offset)
+
+    all_objects: list[tuple[RawObjectID, int, int]] = [
+        (sha, pack_id, offset) for sha, (pack_id, offset) in seen.items()
+    ]
 
     # Sort all objects by SHA
     all_objects.sort(key=lambda x: x[0])

--- a/tests/test_midx.py
+++ b/tests/test_midx.py
@@ -178,6 +178,51 @@ class MIDXWriteTests(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(large_offset, result[1])
 
+    def test_write_duplicate_objects_across_packs(self):
+        """Objects present in multiple packs must only appear once in OIDL.
+
+        Git's MIDX OIDL chunk requires strictly increasing OIDs; duplicates
+        cause 'oid lookup out of order' errors in ``git multi-pack-index
+        verify``. This happens in real repositories when cruft packs preserve
+        unreachable objects that also exist in other packs.
+        """
+        f = BytesIO()
+
+        shared_sha = b"\x05" * 20
+        pack_entries = [
+            (
+                "pack-aaa.idx",
+                [
+                    (b"\x01" * 20, 100, 0),
+                    (shared_sha, 200, 0),
+                ],
+            ),
+            (
+                "pack-bbb.idx",
+                [
+                    (shared_sha, 999, 0),
+                    (b"\x09" * 20, 50, 0),
+                ],
+            ),
+        ]
+
+        write_midx(f, pack_entries, HASH_ALGORITHM_SHA1)
+        f.seek(0)
+        midx = MultiPackIndex("test.midx", file=f, contents=f.read())
+
+        self.assertEqual(3, len(midx))
+
+        # Shared object should resolve to the first pack (pack-aaa sorts first)
+        result = midx.object_offset(shared_sha)
+        self.assertIsNotNone(result)
+        self.assertEqual("pack-aaa.idx", result[0])
+        self.assertEqual(200, result[1])
+
+        # OIDs must be strictly increasing (no duplicates)
+        entries = list(midx.iterentries())
+        shas = [e[0] for e in entries]
+        self.assertEqual(shas, sorted(set(shas)))
+
     def test_write_midx_file(self):
         """Test writing a MIDX file to disk."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Objects can be present in multiple packs (e.g. after git gc creates a cruft pack). The previous writer emitted the same SHA multiple times in the OIDL chunk, which Git rejects with "oid lookup out of order" since that chunk requires strictly increasing OIDs.

Keep the occurrence from the first pack in pack-name order, matching how Git itself resolves duplicates.

Fixes #2152