### PR TITLE
Move GIT_SSH/GIT_SSH_COMMAND env lookup from client.py to cli.py

### DIFF
--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -99,6 +99,25 @@ from .stripspace import stripspace
 logger = logging.getLogger(__name__)
 
 
+def _ssh_command_from_env() -> str | None:
+    """Return the ssh command requested via ``GIT_SSH_COMMAND`` / ``GIT_SSH``.
+
+    ``GIT_SSH_COMMAND`` wins over ``GIT_SSH``, matching git's own precedence.
+    Returns ``None`` when neither is set, so callers can fall through to the
+    ``core.sshCommand`` config or the transport default.
+
+    Env lookup lives here in the CLI layer rather than in the transport
+    library so that :mod:`dulwich.client` stays process-environment-free.
+    """
+    env_ssh_command = os.environ.get("GIT_SSH_COMMAND")
+    if env_ssh_command:
+        return env_ssh_command
+    env_ssh = os.environ.get("GIT_SSH")
+    if env_ssh:
+        return env_ssh
+    return None
+
+
 def to_display_str(value: bytes | str) -> str:
     """Convert a bytes or string value to a display string.
 
@@ -1113,7 +1132,9 @@ class cmd_archive(Command):
         parser.add_argument("committish", type=str, nargs="?")
         parsed_args = parser.parse_args(args)
         if parsed_args.remote:
-            client, path = get_transport_and_path(parsed_args.remote)
+            client, path = get_transport_and_path(
+                parsed_args.remote, ssh_command=_ssh_command_from_env()
+            )
 
             def stdout_write(data: bytes) -> None:
                 sys.stdout.buffer.write(data)
@@ -1255,7 +1276,9 @@ class cmd_fetch_pack(Command):
         parser.add_argument("location", nargs="?", type=str)
         parser.add_argument("refs", nargs="*", type=str)
         args = parser.parse_args(argv)
-        client, path = get_transport_and_path(args.location)
+        client, path = get_transport_and_path(
+            args.location, ssh_command=_ssh_command_from_env()
+        )
         r = Repo(".")
         if args.all:
             determine_wants = r.object_store.determine_wants_all
@@ -2069,6 +2092,7 @@ class cmd_clone(Command):
                 filter_spec=parsed_args.filter_spec,
                 protocol_version=parsed_args.protocol,
                 recurse_submodules=parsed_args.recurse_submodules,
+                ssh_command=_ssh_command_from_env(),
             )
         except GitProtocolError as e:
             logging.exception(e)
@@ -3741,6 +3765,7 @@ class cmd_pull(Command):
             refspecs=parsed_args.refspec or None,
             filter_spec=parsed_args.filter,
             protocol_version=parsed_args.protocol or None,
+            ssh_command=_ssh_command_from_env(),
         )
 
 

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3859,9 +3859,7 @@ class SSHGitClient(TraditionalGitClient):
             try:
                 config_ssh_command = config.get((b"core",), b"sshCommand")
                 self.ssh_command = (
-                    config_ssh_command.decode()
-                    if config_ssh_command
-                    else "ssh"
+                    config_ssh_command.decode() if config_ssh_command else "ssh"
                 )
             except KeyError:
                 self.ssh_command = "ssh"

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3849,32 +3849,24 @@ class SSHGitClient(TraditionalGitClient):
         self.username = username
         self.password = password
         self.key_filename = key_filename
-        # Priority: ssh_command parameter, then env vars, then core.sshCommand config
+        # Priority: ssh_command parameter, then core.sshCommand config.
+        # GIT_SSH_COMMAND / GIT_SSH env vars are read at the CLI layer
+        # (see dulwich.cli._ssh_command_from_env) so the transport library
+        # stays free of process-environment reads.
         if ssh_command:
             self.ssh_command = ssh_command
+        elif config is not None:
+            try:
+                config_ssh_command = config.get((b"core",), b"sshCommand")
+                self.ssh_command = (
+                    config_ssh_command.decode()
+                    if config_ssh_command
+                    else "ssh"
+                )
+            except KeyError:
+                self.ssh_command = "ssh"
         else:
-            # Check environment variables first
-            env_ssh_command = os.environ.get("GIT_SSH_COMMAND")
-            if env_ssh_command:
-                self.ssh_command = env_ssh_command
-            else:
-                env_ssh = os.environ.get("GIT_SSH")
-                if env_ssh:
-                    self.ssh_command = env_ssh
-                else:
-                    # Fall back to config if no environment variable set
-                    if config is not None:
-                        try:
-                            config_ssh_command = config.get((b"core",), b"sshCommand")
-                            self.ssh_command = (
-                                config_ssh_command.decode()
-                                if config_ssh_command
-                                else "ssh"
-                            )
-                        except KeyError:
-                            self.ssh_command = "ssh"
-                    else:
-                        self.ssh_command = "ssh"
+            self.ssh_command = "ssh"
 
         super().__init__(
             path_encoding=path_encoding,

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -1442,6 +1442,7 @@ def clone(
     filter_spec: str | None = None,
     protocol_version: int | None = None,
     recurse_submodules: bool = False,
+    ssh_command: str | None = None,
     **kwargs: str | bytes | Sequence[str | bytes],
 ) -> Repo:
     """Clone a local or remote git repository.
@@ -1464,6 +1465,7 @@ def clone(
       protocol_version: desired Git protocol version. By default the highest
         mutually supported protocol version will be used.
       recurse_submodules: Whether to initialize and clone submodules
+      ssh_command: Optional custom SSH command
       **kwargs: Additional keyword arguments including refspecs to fetch.
         Can be a bytestring, a string, or a list of bytestring/string.
 
@@ -1509,6 +1511,8 @@ def clone(
     else:
         source_str = source.decode() if isinstance(source, bytes) else source
         transport_kwargs = _filter_transport_kwargs(**kwargs)
+        if ssh_command is not None:
+            transport_kwargs["ssh_command"] = ssh_command
         (client, path) = get_transport_and_path(
             source_str, config=config, **transport_kwargs
         )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -38,6 +38,7 @@ from dulwich.cli import (
     AutoFlushBinaryIOWrapper,
     AutoFlushTextIOWrapper,
     _should_auto_flush,
+    _ssh_command_from_env,
     detect_terminal_width,
     format_bytes,
     launch_editor,
@@ -5175,6 +5176,36 @@ class DiagnoseCommandTest(DulwichCliTestCase):
 
             # Check that at least core dependencies are listed
             self.assertIn("urllib3:", log_output)
+
+
+class SshCommandFromEnvTest(TestCase):
+    """Tests for :func:`dulwich.cli._ssh_command_from_env`.
+
+    GIT_SSH_COMMAND / GIT_SSH are read here in the CLI layer so the transport
+    library stays free of process-environment reads. GIT_SSH_COMMAND wins over
+    GIT_SSH, matching git's own precedence.
+    """
+
+    def test_both_unset_returns_none(self):
+        self.overrideEnv("GIT_SSH_COMMAND", None)
+        self.overrideEnv("GIT_SSH", None)
+        self.assertIsNone(_ssh_command_from_env())
+
+    def test_git_ssh_command_wins(self):
+        self.overrideEnv("GIT_SSH_COMMAND", "/usr/bin/ssh -v")
+        self.overrideEnv("GIT_SSH", "/path/to/ssh")
+        self.assertEqual(_ssh_command_from_env(), "/usr/bin/ssh -v")
+
+    def test_git_ssh_alone(self):
+        self.overrideEnv("GIT_SSH_COMMAND", None)
+        self.overrideEnv("GIT_SSH", "/path/to/ssh")
+        self.assertEqual(_ssh_command_from_env(), "/path/to/ssh")
+
+    def test_empty_git_ssh_command_falls_back(self):
+        # An empty string is effectively unset; fall back to GIT_SSH.
+        self.overrideEnv("GIT_SSH_COMMAND", "")
+        self.overrideEnv("GIT_SSH", "/path/to/ssh")
+        self.assertEqual(_ssh_command_from_env(), "/path/to/ssh")
 
 
 if __name__ == "__main__":

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1134,23 +1134,23 @@ class SSHGitClientTests(TestCase):
             proto.close()
 
     def test_ssh_command_precedence(self) -> None:
+        # GIT_SSH / GIT_SSH_COMMAND are read at the CLI layer
+        # (dulwich.cli._ssh_command_from_env); SSHGitClient itself should
+        # not consult them. Setting the env var should have no effect when
+        # no ssh_command parameter is passed.
         self.overrideEnv("GIT_SSH", "/path/to/ssh")
-        test_client = SSHGitClient("git.samba.org")
-        self.assertEqual(test_client.ssh_command, "/path/to/ssh")
-
         self.overrideEnv("GIT_SSH_COMMAND", "/path/to/ssh -o Option=Value")
         test_client = SSHGitClient("git.samba.org")
-        self.assertEqual(test_client.ssh_command, "/path/to/ssh -o Option=Value")
+        self.assertEqual(test_client.ssh_command, "ssh")
 
         test_client = SSHGitClient("git.samba.org", ssh_command="ssh -o Option1=Value1")
         self.assertEqual(test_client.ssh_command, "ssh -o Option1=Value1")
 
     def test_ssh_command_config(self) -> None:
-        # Test core.sshCommand config setting
+        # Test core.sshCommand config setting. Env vars are read at the CLI
+        # layer, so this test asserts the config / parameter precedence only.
 
-        # No config, no environment - should default to "ssh"
-        self.overrideEnv("GIT_SSH", None)
-        self.overrideEnv("GIT_SSH_COMMAND", None)
+        # No config, no ssh_command parameter - default to "ssh"
         test_client = SSHGitClient("git.samba.org")
         self.assertEqual(test_client.ssh_command, "ssh")
 
@@ -1166,10 +1166,12 @@ class SSHGitClientTests(TestCase):
         )
         self.assertEqual(test_client.ssh_command, "custom-ssh")
 
-        # Environment variables take precedence over config when no ssh_command parameter
+        # Env vars set in the process do NOT override config at the library
+        # layer - the CLI is responsible for translating them into an explicit
+        # ssh_command argument.
         self.overrideEnv("GIT_SSH_COMMAND", "/usr/bin/ssh -v")
         test_client = SSHGitClient("git.samba.org", config=config)
-        self.assertEqual(test_client.ssh_command, "/usr/bin/ssh -v")
+        self.assertEqual(test_client.ssh_command, "ssh -o StrictHostKeyChecking=no")
 
     def test_ssh_kwargs_passed_to_vendor(self) -> None:
         # Test that ssh_command and other kwargs are actually passed to the SSH vendor


### PR DESCRIPTION
Follow-up to #2149 (review comment from @jelmer: "PRs to move them to dulwich.cli would be great").

Lifts the GIT_SSH_COMMAND / GIT_SSH env lookup out of `SSHGitClient.__init__` and into a new `dulwich.cli._ssh_command_from_env()` helper, matching the pattern already used for `GIT_PROTOCOL` in #2149. The CLI entry points (`cmd_archive`, `cmd_fetch_pack`, `cmd_clone`, `cmd_pull`) now pass the resolved value down; `SSHGitClient` itself only consults the explicit `ssh_command` parameter and `core.sshCommand` config.

Behavior:
- GIT_SSH_COMMAND wins over GIT_SSH (matches git).
- Empty `GIT_SSH_COMMAND` falls back to `GIT_SSH`.
- Library callers (anything using `SSHGitClient`/`porcelain` directly without passing `ssh_command`) no longer pick up these env vars. This is the intended behavior change.

Tests:
- Updated `tests/test_client.py` `test_ssh_command_precedence` / `test_ssh_command_config` so they assert the library-layer precedence only (config + explicit param).
- Added `tests/cli/test_cli.py::SshCommandFromEnvTest` covering GIT_SSH_COMMAND wins, GIT_SSH fallback, empty GIT_SSH_COMMAND fallback, both-unset.

Verified: `pytest tests/test_client.py tests/cli/test_cli.py` -> 503 passed, 2 skipped.

Depends on the same policy established in #2149 but touches disjoint code, so ordering against #2149 shouldn't matter.