### PR TITLE
lfs: derive correct file:// LFS endpoint from local remote URL

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 1.2.1	UNRELEASED
 
+ * Derive the LFS endpoint as the remote's on-disk LFS store
+   (``<remote>/.git/lfs`` for worktrees, ``<remote>/lfs`` for bare repos)
+   when ``remote.origin.url`` points at a local filesystem path or
+   ``file://`` URL, matching git-lfs behaviour. Previously the built-in
+   smudge filter constructed an HTTP-style ``<remote>.git/info/lfs`` path
+   that did not exist on disk, leaving LFS-tracked files as pointers when
+   cloning from a local repo. (Jelmer Vernooĳ)
+
  * Deduplicate objects when writing a multi-pack-index. Objects present
    in multiple packs (e.g. after ``git gc`` creates a cruft pack) would
    otherwise produce an OIDL chunk with repeated SHAs, causing ``git

--- a/dulwich/lfs.py
+++ b/dulwich/lfs.py
@@ -527,7 +527,7 @@ class LFSClient:
                 # Worktrees keep LFS data under <remote>/.git/lfs; bare repos
                 # keep it under <remote>/lfs. Probe for an existing layout and
                 # fall back to the worktree layout if neither exists yet.
-                from urllib.request import pathname2url
+                from pathlib import Path
 
                 candidates = [
                     os.path.join(local_path, ".git", "lfs"),
@@ -536,7 +536,7 @@ class LFSClient:
                 lfs_path = next(
                     (p for p in candidates if os.path.isdir(p)), candidates[0]
                 )
-                lfs_url = f"file://{pathname2url(lfs_path)}"
+                lfs_url = Path(lfs_path).as_uri()
             else:
                 # Ensure URL ends with .git for consistent LFS endpoint
                 if not remote_url.endswith(".git"):

--- a/dulwich/lfs.py
+++ b/dulwich/lfs.py
@@ -503,7 +503,9 @@ class LFSClient:
                         host, path = host_and_path.split(":", 1)
                         remote_url = f"https://{host}/{path}"
 
-            # Convert filesystem paths to file:// URLs
+            # Detect filesystem paths and file:// URLs; for those, the LFS
+            # "endpoint" is the remote's local LFS store rather than an HTTP
+            # path under /info/lfs.
             parsed = urlparse(remote_url)
             # Windows drive letters (e.g., C:\) get parsed as single-letter schemes
             is_windows_path = (
@@ -512,17 +514,36 @@ class LFSClient:
                 and (len(remote_url) < 2 or remote_url[1] == ":")
             )
             if not parsed.scheme or is_windows_path:
-                # Filesystem path - convert to file:// URL
+                local_path = remote_url
+            elif parsed.scheme == "file":
+                from urllib.request import url2pathname
+
+                local_path = url2pathname(parsed.path)
+            else:
+                local_path = None
+
+            if local_path is not None:
+                # For file remotes, point directly at the remote's LFS store.
+                # Worktrees keep LFS data under <remote>/.git/lfs; bare repos
+                # keep it under <remote>/lfs. Probe for an existing layout and
+                # fall back to the worktree layout if neither exists yet.
                 from urllib.request import pathname2url
 
-                remote_url = f"file://{pathname2url(remote_url)}"
+                candidates = [
+                    os.path.join(local_path, ".git", "lfs"),
+                    os.path.join(local_path, "lfs"),
+                ]
+                lfs_path = next(
+                    (p for p in candidates if os.path.isdir(p)), candidates[0]
+                )
+                lfs_url = f"file://{pathname2url(lfs_path)}"
+            else:
+                # Ensure URL ends with .git for consistent LFS endpoint
+                if not remote_url.endswith(".git"):
+                    remote_url = f"{remote_url}.git"
 
-            # Ensure URL ends with .git for consistent LFS endpoint
-            if not remote_url.endswith(".git"):
-                remote_url = f"{remote_url}.git"
-
-            # Standard LFS endpoint is remote_url + "/info/lfs"
-            lfs_url = f"{remote_url}/info/lfs"
+                # Standard LFS endpoint is remote_url + "/info/lfs"
+                lfs_url = f"{remote_url}/info/lfs"
 
             # Return appropriate client based on derived URL scheme
             return cls.from_url(lfs_url, config)

--- a/tests/compat/test_lfs.py
+++ b/tests/compat/test_lfs.py
@@ -463,25 +463,13 @@ class LFSCloneCompatTest(LFSCompatTestCase):
         cloned_repo = porcelain.clone(source_dir, target_dir)
         self.addCleanup(cloned_repo.close)
 
-        # Verify LFS file exists
+        # Either the git-lfs smudge filter or dulwich's built-in filter
+        # (fetching from the source repo's local LFS store for file://
+        # remotes) should resolve the pointer to the original content.
         cloned_file = os.path.join(target_dir, "test.bin")
         with open(cloned_file, "rb") as f:
             content = f.read()
-
-        # Check if filter.lfs.smudge is configured
-        cloned_config = cloned_repo.get_config()
-        try:
-            lfs_smudge = cloned_config.get((b"filter", b"lfs"), b"smudge")
-            has_lfs_config = bool(lfs_smudge)
-        except KeyError:
-            has_lfs_config = False
-
-        if has_lfs_config:
-            # git-lfs smudge filter should have converted it
-            self.assertEqual(content, test_content)
-        else:
-            # No git-lfs config (uses built-in filter), should be a pointer
-            self.assertIn(b"version https://git-lfs.github.com/spec/v1", content)
+        self.assertEqual(content, test_content)
 
 
 if __name__ == "__main__":

--- a/tests/porcelain/test_filters.py
+++ b/tests/porcelain/test_filters.py
@@ -338,18 +338,13 @@ class PorcelainFilterTests(TestCase):
         target_repo = porcelain.clone(source_dir, target_dir)
         self.addCleanup(target_repo.close)
 
-        # Verify the file was checked out with the filter
+        # Verify the file was checked out with the filter. With the object
+        # available in the source repo's LFS store and a file:// remote,
+        # the built-in filter resolves the pointer during checkout.
         target_file = os.path.join(target_dir, "empty.bin")
         with open(target_file, "rb") as f:
             content = f.read()
-
-        # Without git-lfs configured, the built-in filter is used
-        # Since the LFS object isn't in the target repo's store,
-        # it should remain as a pointer
-        self.assertIn(b"version https://git-lfs", content)
-        self.assertIn(
-            b"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", content
-        )
+        self.assertEqual(content, b"")
 
     def test_builtin_lfs_filter_with_object(self) -> None:
         """Test built-in LFS filter when object is available in store."""

--- a/tests/porcelain/test_lfs.py
+++ b/tests/porcelain/test_lfs.py
@@ -22,6 +22,7 @@
 """Tests for LFS porcelain functions."""
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -276,9 +277,10 @@ class LFSPorcelainTestCase(TestCase):
         with self.assertRaises(KeyError):
             config.get((b"filter", b"lfs"), b"smudge")
 
-        # Clone the repository (may warn about missing LFS objects)
-        with self.assertLogs("dulwich.lfs", level="WARNING"):
-            cloned_repo = porcelain.clone(source_dir, clone_dir)
+        # Clone the repository. For a file:// remote the built-in filter
+        # resolves pointers against the source repo's LFS store, so no
+        # warning is emitted.
+        cloned_repo = porcelain.clone(source_dir, clone_dir)
 
         # Verify that built-in LFS filter was used
         normalizer = cloned_repo.get_blob_normalizer()
@@ -288,22 +290,60 @@ class LFSPorcelainTestCase(TestCase):
             self.assertEqual(type(lfs_driver).__name__, "LFSFilterDriver")
             self.assertEqual(type(lfs_driver).__module__, "dulwich.lfs")
 
-        # Check that the file remains as a pointer (expected behavior)
-        # The built-in LFS filter preserves pointers when objects aren't available
+        # The built-in filter should have fetched the object from the
+        # source repo's LFS store during checkout.
         cloned_file = os.path.join(clone_dir, "test.bin")
         with open(cloned_file, "rb") as f:
             content = f.read()
-
-        # Should still be a pointer since objects weren't transferred
-        self.assertTrue(
-            content.startswith(b"version https://git-lfs.github.com/spec/v1")
-        )
-        cloned_pointer = LFSPointer.from_bytes(content)
-        self.assertIsNotNone(cloned_pointer)
-        self.assertEqual(cloned_pointer.oid, pointer.oid)
-        self.assertEqual(cloned_pointer.size, pointer.size)
+        self.assertEqual(content, test_content)
 
         source_repo.close()
+        cloned_repo.close()
+
+    def test_clone_with_builtin_lfs_no_object_in_source(self):
+        """Built-in LFS filter leaves a pointer in the working tree when the
+        referenced object is not available in the source repo's LFS store."""
+        # Source repo with a pointer but no matching LFS object
+        source_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: self._cleanup_test_dir_path(source_dir))
+        source_repo = Repo.init(source_dir)
+
+        gitattributes_path = os.path.join(source_dir, ".gitattributes")
+        with open(gitattributes_path, "w") as f:
+            f.write("*.bin filter=lfs diff=lfs merge=lfs -text\n")
+
+        # Pointer to an object that does not exist anywhere
+        missing_pointer = LFSPointer(
+            "0" * 64,
+            42,
+        )
+        test_file = os.path.join(source_dir, "test.bin")
+        with open(test_file, "wb") as f:
+            f.write(missing_pointer.to_bytes())
+
+        porcelain.add(source_repo, paths=[".gitattributes", "test.bin"])
+        porcelain.commit(source_repo, message=b"Add unresolvable LFS pointer")
+
+        # Make sure the source has no LFS store at all
+        source_lfs = os.path.join(source_dir, ".git", "lfs")
+        if os.path.isdir(source_lfs):
+            shutil.rmtree(source_lfs)
+        source_repo.close()
+
+        clone_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: self._cleanup_test_dir_path(clone_dir))
+
+        # The smudge filter should warn and fall back to leaving the pointer
+        # in the working tree.
+        with self.assertLogs("dulwich.lfs", level="WARNING"):
+            cloned_repo = porcelain.clone(source_dir, clone_dir)
+
+        with open(os.path.join(clone_dir, "test.bin"), "rb") as f:
+            content = f.read()
+        round_tripped = LFSPointer.from_bytes(content)
+        self.assertIsNotNone(round_tripped)
+        self.assertEqual(round_tripped.oid, missing_pointer.oid)
+        self.assertEqual(round_tripped.size, missing_pointer.size)
         cloned_repo.close()
 
     def _cleanup_test_dir_path(self, path):

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -28,7 +28,8 @@ import tempfile
 from pathlib import Path
 
 from dulwich.client import LocalGitClient
-from dulwich.lfs import LFSFilterDriver, LFSPointer, LFSStore
+from dulwich.config import ConfigFile
+from dulwich.lfs import FileLFSClient, LFSClient, LFSFilterDriver, LFSPointer, LFSStore
 from dulwich.repo import Repo
 
 from . import TestCase
@@ -334,7 +335,13 @@ class LFSIntegrationTests(TestCase):
             )
 
     def test_builtin_lfs_clone_no_config(self) -> None:
-        """Test cloning with LFS when no git-lfs commands are configured."""
+        """Test cloning with LFS when no git-lfs commands are configured.
+
+        The built-in LFSFilterDriver resolves pointers against the remote's
+        on-disk LFS store for file:// remotes (matching ``git-lfs`` behavior),
+        so the cloned file should contain the original content even without
+        external ``git-lfs`` configured.
+        """
         # Create source repository
         source_dir = os.path.join(self.test_dir, "source")
         os.makedirs(source_dir)
@@ -385,16 +392,54 @@ class LFSIntegrationTests(TestCase):
         with self.assertRaises(KeyError):
             target_config.get((b"filter", b"lfs"), b"smudge")
 
-        # Check the cloned file
+        # The built-in smudge filter should resolve the pointer using the
+        # source repo's LFS store (the derived file:// LFS endpoint).
         cloned_file = os.path.join(target_dir, "test.bin")
         with open(cloned_file, "rb") as f:
             content = f.read()
+        self.assertEqual(content, test_content)
+        target_repo.close()
 
-        # Should still be a pointer (LFS object not in target's store)
-        self.assertTrue(
-            content.startswith(b"version https://git-lfs.github.com/spec/v1")
+    def test_builtin_lfs_clone_unresolvable_pointer(self) -> None:
+        """When the source has no LFS object for a pointer, the built-in
+        filter falls back to leaving the pointer in the working tree."""
+        source_dir = os.path.join(self.test_dir, "source-missing")
+        os.makedirs(source_dir)
+        source_repo = Repo.init(source_dir)
+
+        gitattributes_path = os.path.join(source_dir, ".gitattributes")
+        with open(gitattributes_path, "wb") as f:
+            f.write(b"*.bin filter=lfs\n")
+
+        # Pointer to an LFS object that exists nowhere
+        missing_pointer = LFSPointer("0" * 64, 42)
+        with open(os.path.join(source_dir, "test.bin"), "wb") as f:
+            f.write(missing_pointer.to_bytes())
+
+        worktree = source_repo.get_worktree()
+        worktree.stage([b".gitattributes", b"test.bin"])
+        worktree.commit(
+            message=b"Add unresolvable LFS pointer",
+            committer=b"Test <test@example.com>",
+            author=b"Test <test@example.com>",
+            commit_timestamp=1000000000,
+            author_timestamp=1000000000,
+            commit_timezone=0,
+            author_timezone=0,
         )
-        self.assertIn(test_oid.encode(), content)
+        source_repo.close()
+
+        target_dir = os.path.join(self.test_dir, "target-missing")
+        client = LocalGitClient()
+        with self.assertLogs("dulwich.lfs", level="WARNING"):
+            target_repo = client.clone(source_dir, target_dir)
+
+        with open(os.path.join(target_dir, "test.bin"), "rb") as f:
+            content = f.read()
+        cloned_pointer = LFSPointer.from_bytes(content)
+        self.assertIsNotNone(cloned_pointer)
+        self.assertEqual(cloned_pointer.oid, missing_pointer.oid)
+        self.assertEqual(cloned_pointer.size, missing_pointer.size)
         target_repo.close()
 
     def test_builtin_lfs_with_local_objects(self) -> None:
@@ -1415,16 +1460,71 @@ class LFSClientFromURLTests(TestCase):
         self.assertEqual(client.config, config)
 
     def test_from_config_derives_file_url_from_remote(self) -> None:
-        """Test from_config derives file:// LFS URL from file:// remote URL."""
-        from dulwich.config import ConfigFile
-        from dulwich.lfs import FileLFSClient, LFSClient
+        """Test from_config derives file:// LFS URL from a file:// remote URL.
+
+        For local remotes the LFS "endpoint" is the remote's on-disk LFS
+        store (``<remote>/.git/lfs`` for worktrees, ``<remote>/lfs`` for bare
+        repos), not an HTTP-style ``<remote>/info/lfs`` path.
+        """
+        # Worktree layout: LFS store under <remote>/.git/lfs
+        worktree = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, worktree)
+        Repo.init(str(worktree))
+        (worktree / ".git" / "lfs").mkdir()
 
         config = ConfigFile()
-        # Remote with file:// URL
-        config.set((b"remote", b"origin"), b"url", b"file:///path/to/repo.git")
+        config.set((b"remote", b"origin"), b"url", worktree.as_uri().encode())
 
         client = LFSClient.from_config(config)
         self.assertIsInstance(client, FileLFSClient)
         assert client is not None  # for mypy
-        # Should derive /info/lfs endpoint
-        self.assertEqual(client.url, "file:///path/to/repo.git/info/lfs")
+        self.assertEqual(client.url, (worktree / ".git" / "lfs").as_uri())
+
+        # Bare layout: LFS store under <remote>/lfs
+        bare = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, bare)
+        Repo.init_bare(str(bare))
+        (bare / "lfs").mkdir()
+
+        config = ConfigFile()
+        config.set((b"remote", b"origin"), b"url", bare.as_uri().encode())
+
+        client = LFSClient.from_config(config)
+        self.assertIsInstance(client, FileLFSClient)
+        assert client is not None  # for mypy
+        self.assertEqual(client.url, (bare / "lfs").as_uri())
+
+    def test_from_config_derives_file_url_from_plain_path_remote(self) -> None:
+        """Test from_config handles non-URL local-path remotes (no scheme)."""
+        worktree = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, worktree)
+        Repo.init(str(worktree))
+        (worktree / ".git" / "lfs").mkdir()
+
+        config = ConfigFile()
+        # Plain filesystem path (no file:// scheme)
+        config.set((b"remote", b"origin"), b"url", str(worktree).encode())
+
+        client = LFSClient.from_config(config)
+        self.assertIsInstance(client, FileLFSClient)
+        assert client is not None  # for mypy
+        self.assertEqual(client.url, (worktree / ".git" / "lfs").as_uri())
+
+    def test_from_config_file_remote_downloads_object(self) -> None:
+        """End-to-end: from_config for a file:// remote yields a client
+        that can read LFS objects stored in the remote's LFS store."""
+        worktree = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, worktree)
+        Repo.init(str(worktree))
+        lfs_dir = worktree / ".git" / "lfs"
+        lfs_dir.mkdir()
+        store = LFSStore.create(str(lfs_dir))
+        content = b"remote file LFS content"
+        oid = store.write_object([content])
+
+        config = ConfigFile()
+        config.set((b"remote", b"origin"), b"url", worktree.as_uri().encode())
+
+        client = LFSClient.from_config(config)
+        assert client is not None
+        self.assertEqual(client.download(oid, len(content)), content)


### PR DESCRIPTION
When the LFS client is derived from a ``remote.origin.url`` pointing at a local filesystem (either a ``file://`` URL or a plain path), the previous logic constructed an HTTP-style ``<remote>.git/info/lfs`` URL and pointed ``FileLFSClient`` at that path. That path almost never exists on disk, so the smudge filter could not retrieve any objects from the remote and any LFS-tracked file in a clone over a file remote was left as a pointer.

Derive the LFS endpoint as the remote's actual on-disk LFS store — ``<remote>/.git/lfs`` for worktrees, ``<remote>/lfs`` for bare repos — matching git-lfs's behaviour for file remotes. As a result, cloning a local repo with LFS via dulwich now resolves pointers using the source's LFS store without requiring an external git-lfs install.