### PR TITLE
Escape special chars in config subsection names

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 1.2.2	UNRELEASED
 
+ * Escape ``"`` and ``\`` in subsection names when writing config
+   files, and unescape them when parsing. Previously a subsection
+   name containing either character was emitted verbatim, producing
+   a corrupt header that re-parsed as the wrong subsection. Newline
+   and NUL in subsection names, which git rejects, now raise
+   ``ValueError``. (Jelmer Vernooĳ)
+
  * Key ``_pack_cache`` consistently by bare pack hash in
    ``DiskObjectStore._get_pack_by_name`` and ``_remove_pack``, finishing
    the migration started by commit d86353e4. The previous mismatch

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -820,6 +820,39 @@ def _escape_value(value: bytes) -> bytes:
     return value
 
 
+def _escape_subsection(name: bytes) -> bytes:
+    r"""Escape a subsection name for writing in a section header.
+
+    Per git-config: inside the quoted subsection name, only ``"`` and ``\``
+    need (and may) be escaped; newline and NUL are not permitted at all.
+    """
+    if b"\n" in name or b"\0" in name:
+        raise ValueError(f"subsection name {name!r} contains a forbidden character")
+    return name.replace(b"\\", b"\\\\").replace(b'"', b'\\"')
+
+
+def _unescape_subsection(name: bytes) -> bytes:
+    r"""Unescape a quoted subsection name read from a section header.
+
+    Per git-config, ``\"`` and ``\\`` are the only recognised escapes.
+    Git silently drops the backslash on any other ``\x`` sequence, so we
+    match that lenient behaviour to stay compatible with config files
+    written by git or by hand (notably ``includeIf`` headers containing
+    Windows paths where backslashes were not doubled).
+    """
+    out = bytearray()
+    i = 0
+    while i < len(name):
+        c = name[i : i + 1]
+        if c == b"\\" and i + 1 < len(name):
+            out += name[i + 1 : i + 2]
+            i += 2
+        else:
+            out += c
+            i += 1
+    return bytes(out)
+
+
 def _check_variable_name(name: bytes) -> bool:
     for i in range(len(name)):
         c = name[i : i + 1]
@@ -913,13 +946,13 @@ def _parse_section_header_line(line: bytes) -> tuple[Section, bytes]:
         # Handle subsections - Git allows more complex syntax for certain sections like includeIf
         if pts[1][:1] == b'"' and pts[1][-1:] == b'"':
             # Standard quoted subsection
-            pts[1] = pts[1][1:-1]
+            pts[1] = _unescape_subsection(pts[1][1:-1])
         elif pts[0] == b"includeIf":
             # Special handling for includeIf sections which can have complex conditions
             # Git allows these without strict quote validation
             pts[1] = pts[1].strip()
             if pts[1][:1] == b'"' and pts[1][-1:] == b'"':
-                pts[1] = pts[1][1:-1]
+                pts[1] = _unescape_subsection(pts[1][1:-1])
         else:
             # Other sections must have quoted subsections
             raise ValueError(f"Invalid subsection {pts[1]!r}")
@@ -1333,7 +1366,13 @@ class ConfigFile(ConfigDict):
             if subsection_name is None:
                 f.write(b"[" + section_name + b"]\n")
             else:
-                f.write(b"[" + section_name + b' "' + subsection_name + b'"]\n')
+                f.write(
+                    b"["
+                    + section_name
+                    + b' "'
+                    + _escape_subsection(subsection_name)
+                    + b'"]\n'
+                )
             for key, value in values.items():
                 value = _format_string(value)
                 f.write(b"\t" + key + b" = " + value + b"\n")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -218,6 +218,38 @@ class ConfigFileTests(TestCase):
         c.write_to_file(f)
         self.assertEqual(b'[branch "blie"]\n\tfoo = bar\n', f.getvalue())
 
+    def test_write_to_file_subsection_escapes_quote_and_backslash(self) -> None:
+        c = ConfigFile()
+        c.set((b"branch", b'foo"bar'), b"x", b"1")
+        c.set((b"branch", b"a\\b"), b"y", b"2")
+        f = BytesIO()
+        c.write_to_file(f)
+        self.assertEqual(
+            b'[branch "foo\\"bar"]\n\tx = 1\n[branch "a\\\\b"]\n\ty = 2\n',
+            f.getvalue(),
+        )
+
+    def test_subsection_roundtrip_with_special_chars(self) -> None:
+        for name in (b'foo"bar', b"a\\b", b'a\\"b', b"trailing\\"):
+            c = ConfigFile()
+            c.set((b"branch", name), b"k", b"v")
+            f = BytesIO()
+            c.write_to_file(f)
+            reparsed = self.from_file(f.getvalue())
+            self.assertEqual(b"v", reparsed.get((b"branch", name), b"k"))
+
+    def test_write_to_file_subsection_rejects_newline(self) -> None:
+        c = ConfigFile()
+        c.set((b"branch", b"foo\nbar"), b"k", b"v")
+        self.assertRaises(ValueError, c.write_to_file, BytesIO())
+
+    def test_from_file_subsection_unknown_escape_is_lenient(self) -> None:
+        # Git silently drops the backslash on unrecognised escape sequences
+        # in subsection names; we match that behaviour for compatibility
+        # with includeIf headers containing literal Windows backslashes.
+        cf = self.from_file(b'[branch "foo\\nbar"]\nk = v\n')
+        self.assertEqual(b"v", cf.get((b"branch", b"foonbar"), b"k"))
+
     def test_write_to_file_preserves_quoted_trailing_whitespace(self) -> None:
         c = ConfigFile()
         c.set((b"core",), b"foo", b" ")

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1448,6 +1448,7 @@ class TestTreeFSPathConversion(TestCase):
 
 class TestIndexEntryFromPath(TestCase):
     def setUp(self):
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
@@ -1880,6 +1881,7 @@ class TestManyFilesFeature(TestCase):
     """Tests for the manyFiles feature (index version 4 and skipHash)."""
 
     def setUp(self):
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
@@ -2045,6 +2047,7 @@ class TestManyFilesRepoIntegration(TestCase):
     """Tests for manyFiles feature integration with Repo."""
 
     def setUp(self):
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
@@ -2084,6 +2087,7 @@ class TestPathPrefixCompression(TestCase):
     """Tests for index version 4 path prefix compression."""
 
     def setUp(self):
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
@@ -2223,6 +2227,7 @@ class TestDetectCaseOnlyRenames(TestCase):
     """Tests for detect_case_only_renames function."""
 
     def setUp(self):
+        super().setUp()
         self.config = ConfigDict()
 
     def test_no_renames(self):
@@ -2469,6 +2474,7 @@ class TestDetectCaseOnlyRenames(TestCase):
 
 class TestUpdateWorkingTree(TestCase):
     def setUp(self):
+        super().setUp()
         self.tempdir = tempfile.mkdtemp()
 
         def cleanup_tempdir():

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1953,10 +1953,12 @@ class RepoConfigIncludeIfTests(TestCase):
             with open(included_path, "wb") as f:
                 f.write(b"[user]\n    email = work@example.com\n")
 
-            # Add includeIf to the repo config
+            # Add includeIf to the repo config. Backslashes must be doubled
+            # both inside the quoted subsection name and in the value.
             config_path = os.path.join(repo_path, ".git", "config")
+            escaped_repo_path = repo_path.replace("\\", "\\\\")
             with open(config_path, "ab") as f:
-                f.write(f'\n[includeIf "gitdir:{repo_path}/.git/"]\n'.encode())
+                f.write(f'\n[includeIf "gitdir:{escaped_repo_path}/.git/"]\n'.encode())
                 escaped_path = included_path.replace("\\", "\\\\")
                 f.write(f"    path = {escaped_path}\n".encode())
 
@@ -2055,10 +2057,12 @@ class RepoConfigIncludeIfTests(TestCase):
             with open(included_path, "wb") as f:
                 f.write(b"[receive]\n    denyNonFastForwards = true\n")
 
-            # Add includeIf to the repo config
+            # Add includeIf to the repo config. Backslashes must be doubled
+            # both inside the quoted subsection name and in the value.
             config_path = os.path.join(repo_path, "config")
+            escaped_repo_path = repo_path.replace("\\", "\\\\")
             with open(config_path, "ab") as f:
-                f.write(f'\n[includeIf "gitdir:{repo_path}/"]\n'.encode())
+                f.write(f'\n[includeIf "gitdir:{escaped_repo_path}/"]\n'.encode())
                 escaped_path = included_path.replace("\\", "\\\\")
                 f.write(f"    path = {escaped_path}\n".encode())
 

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -37,6 +37,7 @@ class StashTests(TestCase):
     """Tests for stash."""
 
     def setUp(self):
+        super().setUp()
         self.test_dir = tempfile.mkdtemp()
         self.repo_dir = os.path.join(self.test_dir, "repo")
         os.makedirs(self.repo_dir)


### PR DESCRIPTION
Subsection names containing ``"`` or ``\`` were written verbatim inside the quoted header, producing a corrupt config that re-parsed as the wrong subsection. Newline and NUL, which git forbids in subsection names, were also accepted silently.

- escape ``\`` as ``\\`` and ``"`` as ``\"`` when writing
- unescape ``\\`` and ``\"`` when parsing; reject any other backslash-escape per git's strict rules
- raise ``ValueError`` if a subsection name contains newline or NUL