### PR TITLE
pack: recover from concurrent pack removals during lazy load

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,14 @@
 
 1.2.1	2026-04-29
 
+ * Recover from concurrent pack removals (e.g. a racing ``git repack`` or
+   ``git gc --auto``) instead of raising spurious ``KeyError`` /
+   ``FileNotFoundError``. ``Pack.index`` and ``Pack.data`` now translate
+   ``FileNotFoundError`` during lazy load into ``PackFileDisappeared``,
+   and ``PackBasedObjectStore`` evicts the stale pack and rescans the
+   pack directory before retrying — equivalent to git's
+   ``reprepare_packed_git()``. (Jelmer Vernooĳ, #2159)
+
  * Derive the LFS endpoint as the remote's on-disk LFS store
    (``<remote>/.git/lfs`` for worktrees, ``<remote>/lfs`` for bare repos)
    when ``remote.origin.url`` points at a local filesystem path or

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -67,6 +67,7 @@ from typing import (
     TYPE_CHECKING,
     BinaryIO,
     Protocol,
+    TypeVar,
     cast,
 )
 
@@ -121,7 +122,15 @@ if TYPE_CHECKING:
     from .commit_graph import CommitGraph
     from .config import Config
     from .diff_tree import RenameDetector
-    from .pack import Pack
+    from .pack import FilePackIndex, Pack
+
+
+# Maximum number of times to rescan the pack directory after a pack file
+# disappears between snapshot and lazy open (e.g. concurrent repack).
+# Mirrors git's bounded reprepare_packed_git() retry.
+_MAX_PACK_RESCAN_ATTEMPTS = 3
+
+_T = TypeVar("_T")
 
 
 class GraphWalker(Protocol):
@@ -944,13 +953,16 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
 
         This does not check alternates.
         """
-        for pack in self.packs:
-            try:
-                if sha in pack:
-                    return True
-            except PackFileDisappeared:
-                pass
-        return False
+
+        def lookup(p: "Pack") -> bool:
+            if sha in p:
+                return True
+            raise KeyError
+
+        try:
+            return self._lookup_in_packs(lookup)
+        except KeyError:
+            return False
 
     def __contains__(self, sha: ObjectID | RawObjectID) -> bool:
         """Check if a particular object is present by SHA1.
@@ -1040,7 +1052,66 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
                 del self._pack_cache[oldest]
 
     def _iter_cached_packs(self) -> Iterator[Pack]:
-        return iter(self._pack_cache.values())
+        return iter(list(self._pack_cache.values()))
+
+    def _evict_pack(self, pack: "Pack | FilePackIndex") -> None:
+        """Evict a pack from the cache after its backing file disappeared.
+
+        ``pack`` may be a :class:`Pack` or a :class:`FilePackIndex`; in the
+        latter case the index's owning ``Pack`` is matched via the cached
+        pack's ``_idx`` reference.
+        """
+        for key, cached in list(self._pack_cache.items()):
+            if cached is pack or cached._idx is pack:
+                del self._pack_cache[key]
+                try:
+                    self._pack_access_order.remove(key)
+                except ValueError:
+                    pass
+                try:
+                    cached.close()
+                except OSError:
+                    pass
+                break
+
+    def _lookup_in_packs(self, lookup: "Callable[[Pack], _T]") -> "_T":
+        """Run ``lookup(pack)`` against each cached pack and return the first hit.
+
+        ``lookup`` should raise ``KeyError`` if the pack does not contain the
+        target. ``PackFileDisappeared`` from a concurrent ``git repack`` /
+        ``gc --auto`` is caught: the stale pack is evicted, the pack
+        directory is rescanned, and the search retries — bounded, mirroring
+        git's ``reprepare_packed_git()``. If no cached pack has the object
+        the pack directory is rescanned once to pick up any newly-arrived
+        packs (e.g. another writer just landed one). ``KeyError`` is raised
+        if no pack — old or new — has the object.
+        """
+        rescanned = False
+        for _attempt in range(_MAX_PACK_RESCAN_ATTEMPTS):
+            disappeared = False
+            for pack_hash, pack in list(self._pack_cache.items()):
+                try:
+                    result = lookup(pack)
+                except KeyError:
+                    continue
+                except PackFileDisappeared as exc:
+                    self._evict_pack(exc.obj)
+                    disappeared = True
+                    continue
+                self._mark_pack_used(pack_hash)
+                self._enforce_packed_git_limit()
+                return result
+            if disappeared:
+                self._update_pack_cache()
+                rescanned = True
+                continue
+            if not rescanned:
+                # Maybe another process just landed a pack with the object.
+                if self._update_pack_cache():
+                    rescanned = True
+                    continue
+            break
+        raise KeyError
 
     def _update_pack_cache(self) -> list[Pack]:
         raise NotImplementedError(self._update_pack_cache)
@@ -1219,8 +1290,8 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
         for pack in self._iter_cached_packs():
             try:
                 yield from pack
-            except PackFileDisappeared:
-                pass
+            except PackFileDisappeared as exc:
+                self._evict_pack(exc.obj)
         yield from self._iter_loose_objects()
         yield from self._iter_alternate_objects()
 
@@ -1247,27 +1318,15 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
             hexsha = None
         else:
             raise AssertionError(f"Invalid object name {name!r}")
-        for pack_hash, pack in self._pack_cache.items():
-            try:
-                result = pack.get_raw(sha)
-            except (KeyError, PackFileDisappeared):
-                pass
-            else:
-                self._mark_pack_used(pack_hash)
-                self._enforce_packed_git_limit()
-                return result
+        try:
+            return self._lookup_in_packs(lambda p: p.get_raw(sha))
+        except KeyError:
+            pass
         if hexsha is None:
             hexsha = sha_to_hex(sha)
         ret = self._get_loose_object(hexsha)
         if ret is not None:
             return ret.type_num, ret.as_raw_string()
-        # Maybe something else has added a pack with the object
-        # in the mean time?
-        for pack in self._update_pack_cache():
-            try:
-                return pack.get_raw(sha)
-            except KeyError:
-                pass
         for alternate in self.alternates:
             try:
                 return alternate.get_raw(hexsha)
@@ -1298,27 +1357,33 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
         """
         todo: set[ObjectID | RawObjectID] = set(shas)
         for p in self._iter_cached_packs():
-            for unpacked in p.iter_unpacked_subset(
-                todo,
-                include_comp=include_comp,
-                allow_missing=True,
-                convert_ofs_delta=convert_ofs_delta,
-            ):
-                yield unpacked
-                hexsha = sha_to_hex(unpacked.sha())
-                todo.remove(hexsha)
+            try:
+                for unpacked in p.iter_unpacked_subset(
+                    todo,
+                    include_comp=include_comp,
+                    allow_missing=True,
+                    convert_ofs_delta=convert_ofs_delta,
+                ):
+                    yield unpacked
+                    hexsha = sha_to_hex(unpacked.sha())
+                    todo.remove(hexsha)
+            except PackFileDisappeared as exc:
+                self._evict_pack(exc.obj)
         # Maybe something else has added a pack with the object
         # in the mean time?
         for p in self._update_pack_cache():
-            for unpacked in p.iter_unpacked_subset(
-                todo,
-                include_comp=include_comp,
-                allow_missing=True,
-                convert_ofs_delta=convert_ofs_delta,
-            ):
-                yield unpacked
-                hexsha = sha_to_hex(unpacked.sha())
-                todo.remove(hexsha)
+            try:
+                for unpacked in p.iter_unpacked_subset(
+                    todo,
+                    include_comp=include_comp,
+                    allow_missing=True,
+                    convert_ofs_delta=convert_ofs_delta,
+                ):
+                    yield unpacked
+                    hexsha = sha_to_hex(unpacked.sha())
+                    todo.remove(hexsha)
+            except PackFileDisappeared as exc:
+                self._evict_pack(exc.obj)
         for alternate in self.alternates:
             assert isinstance(alternate, PackBasedObjectStore)
             for unpacked in alternate.iter_unpacked_subset(
@@ -1350,15 +1415,21 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
         """
         todo: set[ObjectID] = set(shas)
         for p in self._iter_cached_packs():
-            for o in p.iterobjects_subset(todo, allow_missing=True):
-                yield o
-                todo.remove(o.id)
+            try:
+                for o in p.iterobjects_subset(todo, allow_missing=True):
+                    yield o
+                    todo.remove(o.id)
+            except PackFileDisappeared as exc:
+                self._evict_pack(exc.obj)
         # Maybe something else has added a pack with the object
         # in the mean time?
         for p in self._update_pack_cache():
-            for o in p.iterobjects_subset(todo, allow_missing=True):
-                yield o
-                todo.remove(o.id)
+            try:
+                for o in p.iterobjects_subset(todo, allow_missing=True):
+                    yield o
+                    todo.remove(o.id)
+            except PackFileDisappeared as exc:
+                self._evict_pack(exc.obj)
         for alternate in self.alternates:
             for o in alternate.iterobjects_subset(todo, allow_missing=True):
                 yield o
@@ -1387,20 +1458,14 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
             hexsha = None
         else:
             raise AssertionError(f"Invalid object sha1 {sha1!r}")
-        for pack in self._iter_cached_packs():
-            try:
-                return pack.get_unpacked_object(sha, include_comp=include_comp)
-            except (KeyError, PackFileDisappeared):
-                pass
+        try:
+            return self._lookup_in_packs(
+                lambda p: p.get_unpacked_object(sha, include_comp=include_comp)
+            )
+        except KeyError:
+            pass
         if hexsha is None:
             hexsha = sha_to_hex(sha)
-        # Maybe something else has added a pack with the object
-        # in the mean time?
-        for pack in self._update_pack_cache():
-            try:
-                return pack.get_unpacked_object(sha, include_comp=include_comp)
-            except KeyError:
-                pass
         for alternate in self.alternates:
             assert isinstance(alternate, PackBasedObjectStore)
             try:
@@ -2378,23 +2443,19 @@ class DiskObjectStore(PackBasedObjectStore):
         """
         from .midx import write_midx_file
 
-        # Get all pack files
-        packs = self.packs
-        if not packs:
-            # No packs to index
-            return b"\x00" * 20
-
-        # Collect entries from all packs
-        pack_entries: list[tuple[str, list[tuple[RawObjectID, int, int | None]]]] = []
-
-        for pack in packs:
-            # Git stores .idx extension in MIDX, not .pack
-            pack_name = os.path.basename(pack._basename) + ".idx"
-            entries = list(pack.index.iterentries())
-            pack_entries.append((pack_name, entries))
-
-        # Write MIDX file
         midx_path = os.path.join(self.pack_dir, "multi-pack-index")
+        # Skip packs that vanish mid-collection (e.g. concurrent
+        # ``git repack``); the survivors still produce a valid MIDX.
+        pack_entries: list[tuple[str, list[tuple[RawObjectID, int, int | None]]]] = []
+        for pack in self.packs:
+            try:
+                entries = list(pack.index.iterentries())
+            except PackFileDisappeared as exc:
+                self._evict_pack(exc.obj)
+                continue
+            pack_entries.append((os.path.basename(pack._basename) + ".idx", entries))
+        if not pack_entries:
+            return b"\x00" * 20
         return write_midx_file(midx_path, pack_entries)
 
     def write_commit_graph(

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -383,13 +383,25 @@ def take_msb_bytes(
 
 
 class PackFileDisappeared(Exception):
-    """Raised when a pack file unexpectedly disappears."""
+    """Raised when a pack file unexpectedly disappears.
 
-    def __init__(self, obj: object) -> None:
+    This typically happens when a concurrent operation (e.g. ``git repack``
+    or ``git gc --auto``) removes a pack file between the moment dulwich
+    snapshots the pack directory and the moment it actually opens the
+    pack's ``.idx`` or ``.pack`` file.
+
+    The ``obj`` attribute holds the :class:`Pack` (or :class:`FilePackIndex`)
+    whose backing file vanished, so the caller can evict the stale object
+    from its cache and rescan the pack directory.
+    """
+
+    obj: "Pack | FilePackIndex"
+
+    def __init__(self, obj: "Pack | FilePackIndex") -> None:
         """Initialize PackFileDisappeared exception.
 
         Args:
-            obj: The object that triggered the exception
+            obj: The pack or pack index that disappeared.
         """
         self.obj = obj
 
@@ -1883,7 +1895,7 @@ class PackData:
 
     def __del__(self) -> None:
         """Ensure pack file is closed when PackData is garbage collected."""
-        if self._file is not None:
+        if getattr(self, "_file", None) is not None:
             import warnings
 
             warnings.warn(
@@ -4068,7 +4080,10 @@ class Pack:
         """The pack data object being used."""
         if self._data is None:
             assert self._data_load
-            self._data = self._data_load()
+            try:
+                self._data = self._data_load()
+            except FileNotFoundError as exc:
+                raise PackFileDisappeared(self) from exc
             self.check_length_and_checksum()
         return self._data
 
@@ -4080,7 +4095,10 @@ class Pack:
         """
         if self._idx is None:
             assert self._idx_load
-            self._idx = self._idx_load()
+            try:
+                self._idx = self._idx_load()
+            except FileNotFoundError as exc:
+                raise PackFileDisappeared(self) from exc
         return self._idx
 
     @property

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -1089,6 +1089,123 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
                 pack.data._offset_cache._max_size,
             )
 
+    def test_pack_disappeared_during_lookup_recovers(self) -> None:
+        """A concurrent repack that deletes a pack must not raise KeyError.
+
+        Regression for https://github.com/jelmer/dulwich/issues/2159: when a
+        pack is removed between the moment ``_update_pack_cache`` snapshots
+        the pack directory and the moment its index is lazily opened, the
+        store should drop the stale Pack, rescan, and find the object in
+        the replacement pack.
+        """
+        store = DiskObjectStore(self.store_dir)
+        self.addCleanup(store.close)
+
+        # Two packs that overlap on b1. The "doomed" pack also contains b2
+        # so it has a distinct hash from the survivor (otherwise add_pack
+        # would dedupe).
+        b1 = make_object(Blob, data=b"shared-object")
+        b2 = make_object(Blob, data=b"only-in-doomed")
+
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(
+            f.write, [(b1, None), (b2, None)], object_format=DEFAULT_OBJECT_FORMAT
+        )
+        doomed = commit()
+        self.assertIsNotNone(doomed)
+
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(f.write, [(b1, None)], object_format=DEFAULT_OBJECT_FORMAT)
+        survivor = commit()
+        self.assertIsNotNone(survivor)
+
+        assert doomed is not None
+        # Drop file handles (mimicking eviction or process restart) before
+        # deleting on disk, so the next access goes through lazy load.
+        doomed.close()
+        os.remove(doomed._idx_path)
+        os.remove(doomed._data_path)
+
+        # b1 must still be found via the survivor pack rather than raising
+        # KeyError because of the disappeared doomed pack.
+        type_num, data = store.get_raw(b1.id)
+        self.assertEqual(Blob.type_num, type_num)
+        self.assertEqual(b"shared-object", data)
+
+    def test_contains_packed_recovers_after_pack_disappears(self) -> None:
+        """contains_packed must not return False if a replacement pack exists."""
+        store = DiskObjectStore(self.store_dir)
+        self.addCleanup(store.close)
+
+        b1 = make_object(Blob, data=b"contains-after-repack")
+        b2 = make_object(Blob, data=b"only-in-doomed-2")
+
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(
+            f.write, [(b1, None), (b2, None)], object_format=DEFAULT_OBJECT_FORMAT
+        )
+        doomed = commit()
+        self.assertIsNotNone(doomed)
+
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(f.write, [(b1, None)], object_format=DEFAULT_OBJECT_FORMAT)
+        survivor = commit()
+        self.assertIsNotNone(survivor)
+
+        assert doomed is not None
+        doomed.close()
+        os.remove(doomed._idx_path)
+        os.remove(doomed._data_path)
+
+        self.assertTrue(store.contains_packed(b1.id))
+
+    def test_iter_handles_disappeared_pack(self) -> None:
+        """Iterating SHAs must not crash when a cached pack file vanishes."""
+        store = DiskObjectStore(self.store_dir)
+        self.addCleanup(store.close)
+
+        b1 = make_object(Blob, data=b"iter-after-repack")
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(f.write, [(b1, None)], object_format=DEFAULT_OBJECT_FORMAT)
+        original = commit()
+        self.assertIsNotNone(original)
+
+        assert original is not None
+        original.close()
+        os.remove(original._idx_path)
+        os.remove(original._data_path)
+
+        # Should not raise; the disappeared pack is silently dropped.
+        self.assertEqual([], list(store))
+
+    def test_write_midx_handles_disappeared_pack(self) -> None:
+        """write_midx must not crash if a pack disappears mid-collection."""
+        store = DiskObjectStore(self.store_dir)
+        self.addCleanup(store.close)
+
+        b1 = make_object(Blob, data=b"midx-after-repack")
+        b2 = make_object(Blob, data=b"midx-survivor")
+
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(f.write, [(b1, None)], object_format=DEFAULT_OBJECT_FORMAT)
+        doomed = commit()
+        self.assertIsNotNone(doomed)
+
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(f.write, [(b2, None)], object_format=DEFAULT_OBJECT_FORMAT)
+        survivor = commit()
+        self.assertIsNotNone(survivor)
+
+        assert doomed is not None
+        doomed.close()
+        os.remove(doomed._idx_path)
+        os.remove(doomed._data_path)
+
+        # No exception. The midx is written from the surviving pack.
+        store.write_midx()
+        midx_path = os.path.join(store.pack_dir, "multi-pack-index")
+        self.assertTrue(os.path.exists(midx_path))
+
 
 class TreeLookupPathTests(TestCase):
     def setUp(self) -> None:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -868,6 +868,28 @@ class TestPack(PackTests):
             # This should not raise an exception
             p.check_length_and_checksum()
 
+    def test_index_missing_file_raises_pack_disappeared(self) -> None:
+        """A missing .idx surfaces as PackFileDisappeared, not FileNotFoundError."""
+        from dulwich.pack import PackFileDisappeared
+
+        basename = os.path.join(self.tempdir, "vanished-pack")
+        pack = Pack(basename, object_format=DEFAULT_OBJECT_FORMAT)
+        self.addCleanup(pack.close)
+        with self.assertRaises(PackFileDisappeared) as cm:
+            pack.index
+        self.assertIs(cm.exception.obj, pack)
+
+    def test_data_missing_file_raises_pack_disappeared(self) -> None:
+        """A missing .pack surfaces as PackFileDisappeared, not FileNotFoundError."""
+        from dulwich.pack import PackFileDisappeared
+
+        basename = os.path.join(self.tempdir, "vanished-pack")
+        pack = Pack(basename, object_format=DEFAULT_OBJECT_FORMAT)
+        self.addCleanup(pack.close)
+        with self.assertRaises(PackFileDisappeared) as cm:
+            pack.data
+        self.assertIs(cm.exception.obj, pack)
+
 
 class TestThinPack(PackTests):
     def setUp(self) -> None:


### PR DESCRIPTION
DiskObjectStore.packs snapshots objects/pack/ with os.listdir and opens each .idx/.pack lazily. If a concurrent git repack or gc --auto removes a pack between the snapshot and the lazy open, callers saw spurious KeyError, contains_packed returning False, iterators silently dropping objects, and write_midx raising FileNotFoundError.

Translate FileNotFoundError raised during Pack.index / Pack.data lazy load into PackFileDisappeared, then evict the stale Pack and rescan the pack directory before retrying lookups. Bounded retry mirrors git's reprepare_packed_git().

Fixes #2159