### PR TITLE
Drain the ``Walker`` PQ fully into an output buffer before yielding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 1.2.2	UNRELEASED
 
+ * Drain the ``Walker`` PQ fully into an output buffer before yielding
+   when excludes are present, mirroring git's ``limit_list`` /
+   ``get_revision_1`` two-phase model. Previously, an exclude seed with
+   an older ``commit_time`` than its ancestors (e.g. from rebase or
+   auto-stash clock skew) could yield reachable commits before
+   ``_exclude_parents`` had a chance to mark them. (Jelmer Vernooĳ, #2176)
+
  * Escape ``"`` and ``\`` in subsection names when writing config
    files, and unescape them when parsing. Previously a subsection
    name containing either character was emitted verbatim, producing

--- a/dulwich/walk.py
+++ b/dulwich/walk.py
@@ -179,6 +179,13 @@ class _CommitTimeQueue:
         self._last: Commit | None = None
         self._extra_commits_left = _MAX_EXTRA_COMMITS
         self._is_finished = False
+        # When there are excludes, we drain the PQ into _out before yielding
+        # anything. This lets an exclude commit popped late (e.g. due to
+        # clock skew from rebases / auto-stash) flag earlier buffered commits
+        # as excluded before they are emitted — git's two-phase limit_list +
+        # get_revision model. Without excludes, _out stays None and we stream.
+        self._buffered = bool(walker.excluded)
+        self._out: deque[Commit] | None = None
 
         for commit_id in chain(walker.include, walker.excluded):
             self._push(commit_id)
@@ -217,9 +224,13 @@ class _CommitTimeQueue:
                     todo.append(parent_commit)
                 excluded.add(parent)
 
-    def next(self) -> WalkEntry | None:
-        if self._is_finished:
-            return None
+    def _step(self) -> Commit | None:
+        """Pop one commit from the PQ, advancing parents and exclude state.
+
+        Returns the popped commit if it should be considered for output (not
+        excluded at pop time, not past the slop boundary), else ``None``.
+        Returns ``None`` and sets ``_is_finished`` when the walk is done.
+        """
         while self._pq:
             _, commit = heapq.heappop(self._pq)
             sha = commit.id
@@ -255,7 +266,6 @@ class _CommitTimeQueue:
                 reset_extra_commits = False
 
             if reset_extra_commits:
-                # We're not at a boundary, so reset the counter.
                 self._extra_commits_left = _MAX_EXTRA_COMMITS
             else:
                 self._extra_commits_left -= 1
@@ -264,9 +274,32 @@ class _CommitTimeQueue:
 
             if not is_excluded:
                 self._last = commit
-                return WalkEntry(self._walker, commit)
+                return commit
         self._is_finished = True
         return None
+
+    def next(self) -> WalkEntry | None:
+        if self._is_finished and not self._out:
+            return None
+        if self._buffered:
+            if self._out is None:
+                self._out = deque()
+                while not self._is_finished:
+                    commit = self._step()
+                    if commit is not None:
+                        self._out.append(commit)
+            while self._out:
+                commit = self._out.popleft()
+                # An exclude commit popped after this commit was buffered may
+                # have marked it excluded via _exclude_parents.
+                if commit.id in self._excluded:
+                    continue
+                return WalkEntry(self._walker, commit)
+            return None
+        commit = self._step()
+        if commit is None:
+            return None
+        return WalkEntry(self._walker, commit)
 
     __next__ = next
 

--- a/tests/test_walk.py
+++ b/tests/test_walk.py
@@ -477,6 +477,23 @@ class WalkerTest(TestCase):
         _c1, _c2, c3 = self.make_linear_commits(3)
         self.assertWalkYields([], [c3.id], exclude=[c3.id])
 
+    def test_exclude_diverged_older_than_merge_base(self) -> None:
+        # Linear chain c1..c20 with increasing timestamps. y is a child of c10
+        # with a timestamp older than every commit in the chain (simulates
+        # rebase/auto-stash clock skew). exclude=[y] must exclude c1..c10,
+        # even though c1..c10 get popped from the date-ordered PQ long before
+        # y — too long for the small "extra commits" buffer to paper over.
+        n = 20
+        spec = [[1]] + [[i, i - 1] for i in range(2, n + 1)]
+        times = [100 + i for i in range(1, n + 1)]
+        spec.append([n + 1, 10])
+        times.append(1)
+        commits = self.make_commits(spec, times=times)
+        cs = commits[:n]
+        y = commits[n]
+        expected = list(reversed(cs[10:]))  # c20..c11
+        self.assertWalkYields(expected, [cs[-1].id], exclude=[y.id])
+
 
 class WalkEntryTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Previously, an exclude seed with an older ``commit_time`` than its ancestors (e.g. from rebase or auto-stash clock skew) could yield reachable commits before ``_exclude_parents`` had a chance to mark them.

Fixes #2176