### PR TITLE
tests: skip non-UTF8 filename tests on UTF-8-only filesystems (#2174)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,13 +1,13 @@
-1.2.2	2026-05-19
+1.2.3	UNRELEASED
 
- * Skip the three non-UTF8 filename tests
-   (``test_index.BuildIndexTests.test_no_decode_encode``,
-   ``test_refs.DiskRefsContainerTests.test_cyrillic``,
-   ``test_repository.BuildRepoRootTests.test_commit_no_encode_decode``)
-   when the filesystem rejects non-UTF8 filenames, e.g. OpenZFS with
-   ``utf8only=on``. Previously these tests treated "Linux + non-darwin /
-   non-win32" as a proxy for "filesystem accepts arbitrary bytes", which
-   fails on UTF-8-only Linux filesystems. (Matt Van Horn, #2174)
+ * Extend the per-test ``OSError`` handlers in the three non-UTF8 filename
+   tests (``test_index.test_no_decode_encode``, ``test_refs.test_cyrillic``,
+   ``test_repository.test_commit_no_encode_decode``) to also skip on
+   ``errno.EILSEQ``, so they pass on Linux filesystems that reject
+   non-UTF-8 names (e.g. OpenZFS with ``utf8only=on``). (Matt Van Horn, #2174)
+
+
+1.2.2	2026-05-19
 
  * Normalise hex SHAs to binary in ``DiskObjectStore.contains_packed``
    before consulting the multi-pack-index, mirroring what ``get_raw``

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
 1.2.2	2026-05-19
 
+ * Skip the three non-UTF8 filename tests
+   (``test_index.BuildIndexTests.test_no_decode_encode``,
+   ``test_refs.DiskRefsContainerTests.test_cyrillic``,
+   ``test_repository.BuildRepoRootTests.test_commit_no_encode_decode``)
+   when the filesystem rejects non-UTF8 filenames, e.g. OpenZFS with
+   ``utf8only=on``. Previously these tests treated "Linux + non-darwin /
+   non-win32" as a proxy for "filesystem accepts arbitrary bytes", which
+   fails on UTF-8-only Linux filesystems. (Matt Van Horn, #2174)
+
  * Normalise hex SHAs to binary in ``DiskObjectStore.contains_packed``
    before consulting the multi-pack-index, mirroring what ``get_raw``
    already did. Previously, passing a 40-character hex SHA (as

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "SkipTest",
     "TestCase",
     "expectedFailure",
+    "filesystem_supports_non_utf8_filenames",
     "skipIf",
 ]
 
@@ -48,6 +49,41 @@ from unittest import TestCase as _TestCase
 class DependencyMissing(SkipTest):
     def __init__(self, dependency: str) -> None:
         super().__init__(f"Dependency {dependency} missing")
+
+
+def filesystem_supports_non_utf8_filenames(directory: str | None = None) -> bool:
+    """Probe whether the filesystem accepts filenames with non-UTF8 bytes.
+
+    Some filesystems (notably OpenZFS with ``utf8only=on``) reject filenames
+    that are not valid UTF-8, even on platforms whose ``sys.platform`` value
+    suggests otherwise. The existing per-platform skips in the test suite do
+    not catch that case. Use this probe instead, so tests that intentionally
+    write non-UTF8 byte filenames skip on those filesystems rather than fail.
+
+    Args:
+      directory: Directory to probe. Defaults to the system temp directory.
+
+    Returns:
+      ``True`` if the filesystem accepted a probe filename containing a
+      non-UTF8 byte; ``False`` otherwise.
+    """
+    if directory is None:
+        directory = tempfile.gettempdir()
+    probe_dir = tempfile.mkdtemp(dir=directory)
+    try:
+        # 0xff is not a valid UTF-8 lead byte, so any UTF-8-only filesystem
+        # will reject this name with OSError (Linux ZFS utf8only=on returns
+        # EILSEQ on Linux, EINVAL on FreeBSD).
+        probe = os.path.join(os.fsencode(probe_dir), b"\xff_dulwich_probe")
+        try:
+            fd = os.open(probe, os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o600)
+        except (OSError, UnicodeError):
+            return False
+        os.close(fd)
+        os.unlink(probe)
+        return True
+    finally:
+        shutil.rmtree(probe_dir, ignore_errors=True)
 
 
 class TestCase(_TestCase):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,7 +26,6 @@ __all__ = [
     "SkipTest",
     "TestCase",
     "expectedFailure",
-    "filesystem_supports_non_utf8_filenames",
     "skipIf",
 ]
 
@@ -49,41 +48,6 @@ from unittest import TestCase as _TestCase
 class DependencyMissing(SkipTest):
     def __init__(self, dependency: str) -> None:
         super().__init__(f"Dependency {dependency} missing")
-
-
-def filesystem_supports_non_utf8_filenames(directory: str | None = None) -> bool:
-    """Probe whether the filesystem accepts filenames with non-UTF8 bytes.
-
-    Some filesystems (notably OpenZFS with ``utf8only=on``) reject filenames
-    that are not valid UTF-8, even on platforms whose ``sys.platform`` value
-    suggests otherwise. The existing per-platform skips in the test suite do
-    not catch that case. Use this probe instead, so tests that intentionally
-    write non-UTF8 byte filenames skip on those filesystems rather than fail.
-
-    Args:
-      directory: Directory to probe. Defaults to the system temp directory.
-
-    Returns:
-      ``True`` if the filesystem accepted a probe filename containing a
-      non-UTF8 byte; ``False`` otherwise.
-    """
-    if directory is None:
-        directory = tempfile.gettempdir()
-    probe_dir = tempfile.mkdtemp(dir=directory)
-    try:
-        # 0xff is not a valid UTF-8 lead byte, so any UTF-8-only filesystem
-        # will reject this name with OSError (Linux ZFS utf8only=on returns
-        # EILSEQ on Linux, EINVAL on FreeBSD).
-        probe = os.path.join(os.fsencode(probe_dir), b"\xff_dulwich_probe")
-        try:
-            fd = os.open(probe, os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o600)
-        except (OSError, UnicodeError):
-            return False
-        os.close(fd)
-        os.unlink(probe)
-        return True
-    finally:
-        shutil.rmtree(probe_dir, ignore_errors=True)
 
 
 class TestCase(_TestCase):

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -75,7 +75,7 @@ from dulwich.objects import S_IFGITLINK, ZERO_SHA, Blob, Tree, TreeEntry
 from dulwich.repo import Repo
 from dulwich.tests.utils import make_commit
 
-from . import TestCase, skipIf
+from . import TestCase, filesystem_supports_non_utf8_filenames, skipIf
 
 
 def can_symlink() -> bool:
@@ -754,6 +754,10 @@ class BuildIndexTests(TestCase):
         repo_dir = tempfile.mkdtemp()
         repo_dir_bytes = os.fsencode(repo_dir)
         self.addCleanup(shutil.rmtree, repo_dir)
+        if not filesystem_supports_non_utf8_filenames(repo_dir):
+            self.skipTest(
+                "filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on)"
+            )
         with Repo.init(repo_dir) as repo:
             # Populate repo
             file = Blob.from_string(b"foo")

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -21,6 +21,7 @@
 
 """Tests for the index."""
 
+import errno
 import os
 import shutil
 import stat
@@ -75,7 +76,7 @@ from dulwich.objects import S_IFGITLINK, ZERO_SHA, Blob, Tree, TreeEntry
 from dulwich.repo import Repo
 from dulwich.tests.utils import make_commit
 
-from . import TestCase, filesystem_supports_non_utf8_filenames, skipIf
+from . import TestCase, skipIf
 
 
 def can_symlink() -> bool:
@@ -754,10 +755,6 @@ class BuildIndexTests(TestCase):
         repo_dir = tempfile.mkdtemp()
         repo_dir_bytes = os.fsencode(repo_dir)
         self.addCleanup(shutil.rmtree, repo_dir)
-        if not filesystem_supports_non_utf8_filenames(repo_dir):
-            self.skipTest(
-                "filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on)"
-            )
         with Repo.init(repo_dir) as repo:
             # Populate repo
             file = Blob.from_string(b"foo")
@@ -783,6 +780,12 @@ class BuildIndexTests(TestCase):
                 if e.errno == 92 and sys.platform == "darwin":
                     # Our filename isn't supported by the platform :(
                     self.skipTest(f"can not write filename {e.filename!r}")
+                elif e.errno == errno.EILSEQ:
+                    # Filesystem rejects non-UTF8 filenames
+                    # (e.g. OpenZFS with utf8only=on).
+                    self.skipTest(
+                        f"filesystem rejects non-UTF8 filename {e.filename!r}"
+                    )
                 else:
                     raise
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -21,6 +21,7 @@
 
 """Tests for dulwich.refs."""
 
+import errno
 import os
 import sys
 import tempfile
@@ -49,7 +50,7 @@ from dulwich.repo import Repo
 from dulwich.tests.utils import open_repo, tear_down_repo
 from dulwich.worktree import add_worktree
 
-from . import SkipTest, TestCase, filesystem_supports_non_utf8_filenames
+from . import SkipTest, TestCase
 
 
 class CheckRefFormatTests(TestCase):
@@ -768,15 +769,21 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
     def test_cyrillic(self) -> None:
         if sys.platform in ("darwin", "win32"):
             raise SkipTest("filesystem encoding doesn't support arbitrary bytes")
-        if not filesystem_supports_non_utf8_filenames(self._repo.path):
-            raise SkipTest(
-                "filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on)"
-            )
         # reported in https://github.com/dulwich/dulwich/issues/608
         name = b"\xcd\xee\xe2\xe0\xff\xe2\xe5\xf2\xea\xe01"
         encoded_ref = b"refs/heads/" + name
-        with open(os.path.join(os.fsencode(self._repo.path), encoded_ref), "w") as f:
-            f.write("00" * 20)
+        try:
+            with open(
+                os.path.join(os.fsencode(self._repo.path), encoded_ref), "w"
+            ) as f:
+                f.write("00" * 20)
+        except OSError as e:
+            if e.errno == errno.EILSEQ:
+                # Filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on).
+                raise SkipTest(
+                    f"filesystem rejects non-UTF8 filename {e.filename!r}"
+                ) from e
+            raise
 
         expected_refs = set(_TEST_REFS.keys())
         expected_refs.add(encoded_ref)

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -49,7 +49,7 @@ from dulwich.repo import Repo
 from dulwich.tests.utils import open_repo, tear_down_repo
 from dulwich.worktree import add_worktree
 
-from . import SkipTest, TestCase
+from . import SkipTest, TestCase, filesystem_supports_non_utf8_filenames
 
 
 class CheckRefFormatTests(TestCase):
@@ -768,6 +768,10 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
     def test_cyrillic(self) -> None:
         if sys.platform in ("darwin", "win32"):
             raise SkipTest("filesystem encoding doesn't support arbitrary bytes")
+        if not filesystem_supports_non_utf8_filenames(self._repo.path):
+            raise SkipTest(
+                "filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on)"
+            )
         # reported in https://github.com/dulwich/dulwich/issues/608
         name = b"\xcd\xee\xe2\xe0\xff\xe2\xe5\xf2\xea\xe01"
         encoded_ref = b"refs/heads/" + name

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -47,7 +47,12 @@ from dulwich.repo import (
 )
 from dulwich.tests.utils import open_repo, setup_warning_catcher, tear_down_repo
 
-from . import DependencyMissing, TestCase, skipIf
+from . import (
+    DependencyMissing,
+    TestCase,
+    filesystem_supports_non_utf8_filenames,
+    skipIf,
+)
 
 missing_sha = b"b91fa4d900e17e99b433218e988c4eb4a3e9a097"
 
@@ -1867,6 +1872,10 @@ class BuildRepoRootTests(TestCase):
     def test_commit_no_encode_decode(self) -> None:
         r = self._repo
         repo_path_bytes = os.fsencode(r.path)
+        if not filesystem_supports_non_utf8_filenames(r.path):
+            self.skipTest(
+                "filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on)"
+            )
         encodings = ("utf8", "latin1")
         names = ["À".encode(encoding) for encoding in encodings]
         for name, encoding in zip(names, encodings):

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -21,6 +21,7 @@
 
 """Tests for the repository."""
 
+import errno
 import glob
 import importlib
 import locale
@@ -47,12 +48,7 @@ from dulwich.repo import (
 )
 from dulwich.tests.utils import open_repo, setup_warning_catcher, tear_down_repo
 
-from . import (
-    DependencyMissing,
-    TestCase,
-    filesystem_supports_non_utf8_filenames,
-    skipIf,
-)
+from . import DependencyMissing, TestCase, skipIf
 
 missing_sha = b"b91fa4d900e17e99b433218e988c4eb4a3e9a097"
 
@@ -1872,16 +1868,21 @@ class BuildRepoRootTests(TestCase):
     def test_commit_no_encode_decode(self) -> None:
         r = self._repo
         repo_path_bytes = os.fsencode(r.path)
-        if not filesystem_supports_non_utf8_filenames(r.path):
-            self.skipTest(
-                "filesystem rejects non-UTF8 filenames (e.g. ZFS utf8only=on)"
-            )
         encodings = ("utf8", "latin1")
         names = ["À".encode(encoding) for encoding in encodings]
         for name, encoding in zip(names, encodings):
             full_path = os.path.join(repo_path_bytes, name)
-            with open(full_path, "wb") as f:
-                f.write(encoding.encode("ascii"))
+            try:
+                with open(full_path, "wb") as f:
+                    f.write(encoding.encode("ascii"))
+            except OSError as e:
+                if e.errno == errno.EILSEQ:
+                    # Filesystem rejects non-UTF8 filenames
+                    # (e.g. OpenZFS with utf8only=on).
+                    self.skipTest(
+                        f"filesystem rejects non-UTF8 filename {e.filename!r}"
+                    )
+                raise
             # These files are break tear_down_repo, so cleanup these files
             # ourselves.
             self.addCleanup(os.remove, full_path)


### PR DESCRIPTION
Extend the per-test `OSError` handlers in the three non-UTF8 filename tests (`test_no_decode_encode`, `test_cyrillic`, `test_commit_no_encode_decode`) to also skip on `errno.EILSEQ` so they pass on filesystems that reject non-UTF-8 names (OpenZFS with `utf8only=on`, ZFS on FreeBSD, etc.). Matches the shape of the pre-existing `errno==92 darwin` arm in `test_no_decode_encode`. Closes #2174.