### PR TITLE
config: Honour GIT_CONFIG_COUNT in porcelain entry points

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+1.2.3	UNRELEASED
+
+ * Honour ``GIT_CONFIG_COUNT`` / ``GIT_CONFIG_KEY_<n>`` /
+   ``GIT_CONFIG_VALUE_<n>`` in porcelain entry points, via the new
+   opt-in ``config.env_config`` helper. (Jelmer Vernooĳ, #2168)
+
 1.2.2	2026-05-19
 
  * Normalise hex SHAs to binary in ``DiskObjectStore.contains_packed``

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -38,6 +38,7 @@ __all__ = [
     "FileOpener",
     "StackedConfig",
     "apply_instead_of",
+    "env_config",
     "get_win_legacy_system_paths",
     "get_win_system_paths",
     "get_xdg_config_home_path",
@@ -1468,6 +1469,66 @@ def get_win_legacy_system_paths() -> Iterator[str]:
         yield os.path.join(git_dir, "etc", "gitconfig")
 
 
+def env_config(
+    environ: Mapping[str, str],
+) -> "ConfigFile | None":
+    """Build a ConfigFile from GIT_CONFIG_COUNT/KEY_n/VALUE_n vars.
+
+    See git-config(1). Any missing key/value, a key without a dot, or a
+    non-numeric or negative ``GIT_CONFIG_COUNT`` is treated as an error.
+    Callers that want git's "env overrides everything" precedence should
+    prepend the result to their ``StackedConfig.backends``; nothing in
+    dulwich consults ``os.environ`` for these variables on its own.
+
+    Args:
+      environ: Mapping to read the variables from (e.g. ``os.environ``).
+
+    Returns:
+      A ConfigFile holding the overrides, or None if GIT_CONFIG_COUNT is
+      unset or empty (which git treats as zero pairs).
+    """
+    raw_count = environ.get("GIT_CONFIG_COUNT")
+    if raw_count is None or raw_count == "":
+        return None
+    try:
+        count = int(raw_count)
+    except ValueError:
+        raise ValueError(f"bogus count in GIT_CONFIG_COUNT: {raw_count!r}") from None
+    if count < 0:
+        raise ValueError(f"bogus count in GIT_CONFIG_COUNT: {raw_count!r}")
+
+    cf = ConfigFile()
+    for i in range(count):
+        key_var = f"GIT_CONFIG_KEY_{i}"
+        value_var = f"GIT_CONFIG_VALUE_{i}"
+        try:
+            key = environ[key_var]
+        except KeyError:
+            raise KeyError(f"missing config key {key_var}") from None
+        try:
+            value = environ[value_var]
+        except KeyError:
+            raise KeyError(f"missing config value {value_var}") from None
+        if "." not in key:
+            raise ValueError(f"invalid config format: {key}")
+        # Git keys are <section>.<name> or <section>.<subsection>.<name>.
+        # The subsection (if present) may itself contain dots.
+        first_dot = key.find(".")
+        last_dot = key.rfind(".")
+        section_name = key[:first_dot]
+        name = key[last_dot + 1 :]
+        if first_dot == last_dot:
+            section: Section = (section_name.encode("utf-8"),)
+        else:
+            subsection = key[first_dot + 1 : last_dot]
+            section = (
+                section_name.encode("utf-8"),
+                subsection.encode("utf-8"),
+            )
+        cf.add(section, name.encode("utf-8"), value.encode("utf-8"))
+    return cf
+
+
 class StackedConfig(Config):
     """Configuration which reads from multiple config files.."""
 
@@ -1531,6 +1592,7 @@ class StackedConfig(Config):
                 logger.debug("Gitconfig file not found: %s", path)
                 continue
             backends.append(cf)
+
         return backends
 
     def get(self, section: SectionLike, name: NameLike) -> Value:

--- a/dulwich/filters.py
+++ b/dulwich/filters.py
@@ -774,8 +774,7 @@ class FilterRegistry:
             lfs_dir = tempfile.mkdtemp(prefix="dulwich-lfs-")
             lfs_store = LFSStore.create(lfs_dir)
 
-        config = registry.repo.get_config_stack() if registry.repo else None
-        return LFSFilterDriver(lfs_store, config=config)
+        return LFSFilterDriver(lfs_store, config=registry.config)
 
     def _create_text_filter(self, registry: "FilterRegistry") -> FilterDriver:
         """Create text filter driver for line ending conversion.

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -339,7 +339,7 @@ from ..client import (
     SendPackResult,
     get_transport_and_path,
 )
-from ..config import Config, StackedConfig
+from ..config import Config, StackedConfig, env_config
 from ..diff_tree import (
     CHANGE_ADD,
     CHANGE_COPY,
@@ -1483,6 +1483,9 @@ def clone(
 
     if config is None:
         config = StackedConfig.default()
+        env_override = env_config(os.environ)
+        if env_override is not None:
+            config.backends.insert(0, env_override)
 
     if checkout is None:
         checkout = not bare
@@ -5033,6 +5036,9 @@ def ls_remote(
     """
     if config is None:
         config = StackedConfig.default()
+        env_override = env_config(os.environ)
+        if env_override is not None:
+            config.backends.insert(0, env_override)
     remote_str = remote.decode() if isinstance(remote, bytes) else remote
     client, host_path = get_transport_and_path(
         remote_str,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,7 @@ from dulwich.config import (
     _format_string,
     _parse_string,
     apply_instead_of,
+    env_config,
     get_git_proxy_command,
     parse_submodules,
 )
@@ -1016,6 +1017,162 @@ class StackedConfigTests(TestCase):
                 config_path.encode() if isinstance(paths[0], bytes) else config_path,
                 paths,
             )
+        finally:
+            os.unlink(config_path)
+
+
+class EnvConfigTests(TestCase):
+    def test_unset(self) -> None:
+        self.assertIsNone(env_config({}))
+
+    def test_empty_count(self) -> None:
+        self.assertIsNone(
+            env_config({"GIT_CONFIG_COUNT": ""}),
+        )
+
+    def test_zero(self) -> None:
+        cf = env_config({"GIT_CONFIG_COUNT": "0"})
+        self.assertIsNotNone(cf)
+        self.assertEqual([], list(cf.sections()))
+
+    def test_simple_key(self) -> None:
+        cf = env_config(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "user.name",
+                "GIT_CONFIG_VALUE_0": "Alice",
+            }
+        )
+        self.assertEqual(b"Alice", cf.get((b"user",), b"name"))
+
+    def test_subsection_key(self) -> None:
+        cf = env_config(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "remote.upstream.url",
+                "GIT_CONFIG_VALUE_0": "https://example.com/repo.git",
+            }
+        )
+        self.assertEqual(
+            b"https://example.com/repo.git",
+            cf.get((b"remote", b"upstream"), b"url"),
+        )
+
+    def test_subsection_with_dots(self) -> None:
+        # Subsection names may contain dots (e.g. url.<base>.insteadOf).
+        cf = env_config(
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "url.https://example.com/.insteadOf",
+                "GIT_CONFIG_VALUE_0": "git@example.com:",
+            }
+        )
+        self.assertEqual(
+            b"git@example.com:",
+            cf.get((b"url", b"https://example.com/"), b"insteadOf"),
+        )
+
+    def test_multi_value(self) -> None:
+        cf = env_config(
+            {
+                "GIT_CONFIG_COUNT": "2",
+                "GIT_CONFIG_KEY_0": "remote.origin.fetch",
+                "GIT_CONFIG_VALUE_0": "+refs/heads/*:refs/remotes/origin/*",
+                "GIT_CONFIG_KEY_1": "remote.origin.fetch",
+                "GIT_CONFIG_VALUE_1": "+refs/tags/*:refs/tags/*",
+            }
+        )
+        self.assertEqual(
+            [
+                b"+refs/heads/*:refs/remotes/origin/*",
+                b"+refs/tags/*:refs/tags/*",
+            ],
+            list(cf.get_multivar((b"remote", b"origin"), b"fetch")),
+        )
+
+    def test_bogus_count_non_numeric(self) -> None:
+        self.assertRaises(
+            ValueError,
+            env_config,
+            {"GIT_CONFIG_COUNT": "abc"},
+        )
+
+    def test_bogus_count_negative(self) -> None:
+        self.assertRaises(
+            ValueError,
+            env_config,
+            {"GIT_CONFIG_COUNT": "-1"},
+        )
+
+    def test_missing_key(self) -> None:
+        self.assertRaises(
+            KeyError,
+            env_config,
+            {"GIT_CONFIG_COUNT": "1", "GIT_CONFIG_VALUE_0": "x"},
+        )
+
+    def test_missing_value(self) -> None:
+        self.assertRaises(
+            KeyError,
+            env_config,
+            {"GIT_CONFIG_COUNT": "1", "GIT_CONFIG_KEY_0": "user.name"},
+        )
+
+    def test_invalid_key_no_dot(self) -> None:
+        self.assertRaises(
+            ValueError,
+            env_config,
+            {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "nodot",
+                "GIT_CONFIG_VALUE_0": "x",
+            },
+        )
+
+    def test_default_does_not_consult_env_count(self) -> None:
+        # StackedConfig.default() must not silently pick up GIT_CONFIG_COUNT
+        # overrides; callers have to opt in via env_overrides().
+        with tempfile.NamedTemporaryFile(
+            suffix=".gitconfig", delete=False
+        ) as global_config:
+            global_config.write(b"[user]\n\tname = FromFile\n")
+            global_config.flush()
+            config_path = global_config.name
+
+        try:
+            self.overrideEnv("GIT_CONFIG_GLOBAL", config_path)
+            self.overrideEnv("GIT_CONFIG_NOSYSTEM", "1")
+            self.overrideEnv("GIT_CONFIG_COUNT", "1")
+            self.overrideEnv("GIT_CONFIG_KEY_0", "user.name")
+            self.overrideEnv("GIT_CONFIG_VALUE_0", "FromEnv")
+            sc = StackedConfig.default()
+            self.assertEqual(b"FromFile", sc.get((b"user",), b"name"))
+        finally:
+            os.unlink(config_path)
+
+    def test_env_overrides_opt_in(self) -> None:
+        # Callers that want git's "env wins" behaviour prepend the
+        # env_config() result themselves.
+        with tempfile.NamedTemporaryFile(
+            suffix=".gitconfig", delete=False
+        ) as global_config:
+            global_config.write(b"[user]\n\tname = FromFile\n")
+            global_config.flush()
+            config_path = global_config.name
+
+        try:
+            self.overrideEnv("GIT_CONFIG_GLOBAL", config_path)
+            self.overrideEnv("GIT_CONFIG_NOSYSTEM", "1")
+            environ = {
+                "GIT_CONFIG_COUNT": "1",
+                "GIT_CONFIG_KEY_0": "user.name",
+                "GIT_CONFIG_VALUE_0": "FromEnv",
+            }
+            backends = StackedConfig.default_backends()
+            override = env_config(environ)
+            self.assertIsNotNone(override)
+            sc = StackedConfig([override, *backends])
+            self.assertEqual(b"FromEnv", sc.get((b"user",), b"name"))
         finally:
             os.unlink(config_path)
 


### PR DESCRIPTION
Fixes #2168