### PR TITLE
Pack ingestion hardening fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
    ``GIT_CONFIG_VALUE_<n>`` in porcelain entry points, via the new
    opt-in ``config.env_config`` helper. (Jelmer Vernooĳ, #2168)
 
+ * Verify the trailing pack checksum in
+   ``MemoryObjectStore.add_pack`` so a non-thin fetch into a
+   ``MemoryRepo`` no longer accepts a pack with a truncated trailer.
+   (Jelmer Vernooĳ; reported by Christopher Toth)
+
  * Inflate every object in ``DiskObjectStore._complete_pack``
    so malformed trees (and other payloads ``MemoryObjectStore`` and
    ``git fsck`` reject) no longer silently land on disk.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
    ``GIT_CONFIG_VALUE_<n>`` in porcelain entry points, via the new
    opt-in ``config.env_config`` helper. (Jelmer Vernooĳ, #2168)
 
+ * Inflate every object in ``DiskObjectStore._complete_pack``
+   so malformed trees (and other payloads ``MemoryObjectStore`` and
+   ``git fsck`` reject) no longer silently land on disk.
+   (Jelmer Vernooĳ; reported by Christopher Toth)
+
 1.2.2	2026-05-19
 
  * Normalise hex SHAs to binary in ``DiskObjectStore.contains_packed``

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@
    ``GIT_CONFIG_VALUE_<n>`` in porcelain entry points, via the new
    opt-in ``config.env_config`` helper. (Jelmer Vernooĳ, #2168)
 
+ * Reject delta-resolved commit/tree/tag objects with a
+   zero-byte payload in ``DeltaChainIterator``, and turn a delta
+   truncated mid-size-header into a typed ``ApplyDeltaError``.
+   (Jelmer Vernooĳ; reported by Christopher Toth)
+
  * Verify the trailing pack checksum in
    ``MemoryObjectStore.add_pack`` so a non-thin fetch into a
    ``MemoryRepo`` no longer accepts a pack with a truncated trailer.

--- a/crates/pack/src/lib.rs
+++ b/crates/pack/src/lib.rs
@@ -96,19 +96,25 @@ fn bisect_find_sha(
     Ok(None)
 }
 
-fn get_delta_header_size(delta: &[u8], index: &mut usize, length: usize) -> usize {
+fn get_delta_header_size(
+    delta: &[u8],
+    index: &mut usize,
+    length: usize,
+) -> Result<usize, &'static str> {
     let mut size: usize = 0;
     let mut i: usize = 0;
-    while *index < length {
+    loop {
+        if *index >= length {
+            return Err("delta truncated in size header");
+        }
         let cmd = delta[*index];
         *index += 1;
         size |= ((cmd & !0x80) as usize) << i;
         i += 7;
         if cmd & 0x80 == 0 {
-            break;
+            return Ok(size);
         }
     }
-    size
 }
 
 fn py_chunked_as_string<'a>(
@@ -148,7 +154,8 @@ fn apply_delta(py: Python, py_src_buf: Py<PyAny>, py_delta: Py<PyAny>) -> PyResu
     let delta_len = delta.len();
     let mut index = 0;
 
-    let src_size = get_delta_header_size(delta.as_ref(), &mut index, delta_len);
+    let src_size = get_delta_header_size(delta.as_ref(), &mut index, delta_len)
+        .map_err(ApplyDeltaError::new_err)?;
     if src_size != src_buf_len {
         return Err(ApplyDeltaError::new_err(format!(
             "Unexpected source buffer size: {} vs {}",
@@ -156,7 +163,8 @@ fn apply_delta(py: Python, py_src_buf: Py<PyAny>, py_delta: Py<PyAny>) -> PyResu
         )));
     }
 
-    let dest_size = get_delta_header_size(delta.as_ref(), &mut index, delta_len);
+    let dest_size = get_delta_header_size(delta.as_ref(), &mut index, delta_len)
+        .map_err(ApplyDeltaError::new_err)?;
     let mut out = vec![0; dest_size];
     let mut outindex = 0;
 
@@ -439,17 +447,26 @@ mod tests {
         // Test decoding various encoded sizes
         let mut index = 0;
         let delta = vec![0x00];
-        assert_eq!(get_delta_header_size(&delta, &mut index, delta.len()), 0);
+        assert_eq!(
+            get_delta_header_size(&delta, &mut index, delta.len()),
+            Ok(0)
+        );
         assert_eq!(index, 1);
 
         let mut index = 0;
         let delta = vec![0x01];
-        assert_eq!(get_delta_header_size(&delta, &mut index, delta.len()), 1);
+        assert_eq!(
+            get_delta_header_size(&delta, &mut index, delta.len()),
+            Ok(1)
+        );
         assert_eq!(index, 1);
 
         let mut index = 0;
         let delta = vec![127];
-        assert_eq!(get_delta_header_size(&delta, &mut index, delta.len()), 127);
+        assert_eq!(
+            get_delta_header_size(&delta, &mut index, delta.len()),
+            Ok(127)
+        );
         assert_eq!(index, 1);
     }
 
@@ -458,21 +475,38 @@ mod tests {
         // Test decoding multi-byte sizes
         let mut index = 0;
         let delta = vec![0x80, 0x01];
-        assert_eq!(get_delta_header_size(&delta, &mut index, delta.len()), 128);
+        assert_eq!(
+            get_delta_header_size(&delta, &mut index, delta.len()),
+            Ok(128)
+        );
         assert_eq!(index, 2);
 
         let mut index = 0;
         let delta = vec![0x80, 0x02];
-        assert_eq!(get_delta_header_size(&delta, &mut index, delta.len()), 256);
+        assert_eq!(
+            get_delta_header_size(&delta, &mut index, delta.len()),
+            Ok(256)
+        );
         assert_eq!(index, 2);
 
         let mut index = 0;
         let delta = vec![0x80, 0x80, 0x01];
         assert_eq!(
             get_delta_header_size(&delta, &mut index, delta.len()),
-            16384
+            Ok(16384)
         );
         assert_eq!(index, 3);
+    }
+
+    #[test]
+    fn test_get_delta_header_size_truncated() {
+        let mut index = 0;
+        let delta = vec![0x80];
+        assert!(get_delta_header_size(&delta, &mut index, delta.len()).is_err());
+
+        let mut index = 0;
+        let delta: Vec<u8> = vec![];
+        assert!(get_delta_header_size(&delta, &mut index, delta.len()).is_err());
     }
 
     #[test]
@@ -485,9 +519,12 @@ mod tests {
             let mut index = 0;
             let decoded = get_delta_header_size(&encoded, &mut index, encoded.len());
             assert_eq!(
-                decoded, value,
-                "Roundtrip failed for value {}: encoded {:?}, decoded {}",
-                value, encoded, decoded
+                decoded,
+                Ok(value),
+                "Roundtrip failed for value {}: encoded {:?}, decoded {:?}",
+                value,
+                encoded,
+                decoded
             );
             assert_eq!(index, encoded.len());
         }
@@ -629,10 +666,10 @@ mod tests {
         // Apply delta should reconstruct target
         let mut index = 0;
         let src_size = get_delta_header_size(&delta, &mut index, delta.len());
-        assert_eq!(src_size, base.len());
+        assert_eq!(src_size, Ok(base.len()));
 
         let dest_size = get_delta_header_size(&delta, &mut index, delta.len());
-        assert_eq!(dest_size, target.len());
+        assert_eq!(dest_size, Ok(target.len()));
 
         // The delta should be valid and smaller than sending the full target
         assert!(delta.len() > 0);

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -2736,10 +2736,21 @@ class MemoryObjectStore(PackCapableObjectStore):
                 f.seek(0)
 
                 p = PackData.from_file(f, self.object_format, size)
-                for obj in PackInflater.for_pack_data(p, self.get_raw):  # type: ignore[arg-type]
-                    self.add_object(obj)
-                p.close()
-                f.close()
+                try:
+                    # Verify the trailing pack checksum before extracting
+                    # objects. Without this, a fetch that delivered a
+                    # truncated pack would still be accepted: ``add_pack``
+                    # iterates objects by offset and never reaches the
+                    # trailing bytes, so a stream that lost the last few
+                    # bytes of its trailer slipped through silently.
+                    # ``add_thin_pack`` already validates via
+                    # ``PackStreamCopier.verify``; do the equivalent here.
+                    p.check()
+                    for obj in PackInflater.for_pack_data(p, self.get_raw):  # type: ignore[arg-type]
+                        self.add_object(obj)
+                finally:
+                    p.close()
+                    f.close()
             else:
                 f.close()
 

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -2099,7 +2099,27 @@ class DiskObjectStore(PackBasedObjectStore):
             big_file_threshold=self.pack_big_file_threshold,
             delta_base_cache_limit=self.delta_base_cache_limit,
         )
-        final_pack.check_length_and_checksum()
+        try:
+            final_pack.check_length_and_checksum()
+            # Materialise every object so payloads that fail to parse
+            # (e.g. tree entries with garbage modes) are rejected rather
+            # than silently landed on disk. MemoryObjectStore already
+            # validates ingested objects this way via PackInflater; without
+            # the same check DiskObjectStore was strictly weaker.
+            for _obj in PackInflater.for_pack_data(
+                final_pack.data, resolve_ext_ref=self.get_raw
+            ):
+                pass
+        except BaseException:
+            final_pack.close()
+            with suppress(FileNotFoundError):
+                os.remove(target_pack_path)
+            with suppress(FileNotFoundError):
+                os.remove(target_index_path)
+            if self.pack_write_bitmaps and refs:
+                with suppress(FileNotFoundError):
+                    os.remove(pack_base_name + ".bitmap")
+            raise
         # Extract just the hash from pack_base_name (/path/to/pack-HASH -> HASH)
         pack_hash = os.path.basename(pack_base_name)[len("pack-") :]
         self._add_cached_pack(pack_hash, final_pack)

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -2154,7 +2154,7 @@ class DiskObjectStore(PackBasedObjectStore):
             indexer = PackIndexer(
                 f,
                 self.object_format.hash_func,
-                resolve_ext_ref=self.get_raw,  # type: ignore[arg-type]
+                resolve_ext_ref=self.get_raw,
             )
             copier = PackStreamCopier(
                 self.object_format.hash_func,
@@ -2189,7 +2189,7 @@ class DiskObjectStore(PackBasedObjectStore):
                 with PackData(path, file=f, object_format=self.object_format) as pd:
                     indexer = PackIndexer.for_pack_data(
                         pd,
-                        resolve_ext_ref=self.get_raw,  # type: ignore[arg-type]
+                        resolve_ext_ref=self.get_raw,
                     )
                     return self._complete_pack(f, path, len(pd), indexer)  # type: ignore[arg-type]
             else:
@@ -2746,7 +2746,7 @@ class MemoryObjectStore(PackCapableObjectStore):
                     # ``add_thin_pack`` already validates via
                     # ``PackStreamCopier.verify``; do the equivalent here.
                     p.check()
-                    for obj in PackInflater.for_pack_data(p, self.get_raw):  # type: ignore[arg-type]
+                    for obj in PackInflater.for_pack_data(p, self.get_raw):
                         self.add_object(obj)
                 finally:
                     p.close()

--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -710,7 +710,11 @@ class ShaFile:
 
     @staticmethod
     def from_raw_chunks(
-        type_num: int, chunks: list[bytes], sha: ObjectID | RawObjectID | None = None
+        type_num: int,
+        chunks: list[bytes],
+        sha: ObjectID | RawObjectID | None = None,
+        *,
+        object_format: ObjectFormat | None = None,
     ) -> "ShaFile":
         """Creates an object of the indicated type from the raw chunks given.
 
@@ -718,12 +722,15 @@ class ShaFile:
           type_num: The numeric type of the object.
           chunks: An iterable of the raw uncompressed contents.
           sha: Optional known sha for the object
+          object_format: Optional object format (hash algorithm) for the object.
+            Required for trees in SHA-256 repositories so entry parsing uses
+            the correct OID length.
         """
         cls = object_class(type_num)
         if cls is None:
             raise AssertionError(f"unsupported class type num: {type_num}")
         obj = cls()
-        obj.set_raw_chunks(chunks, sha)
+        obj.set_raw_chunks(chunks, sha, object_format=object_format)
         return obj
 
     @classmethod

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -176,8 +176,8 @@ PACK_SPOOL_FILE_MAX_SIZE = 16 * 1024 * 1024
 DEFAULT_PACK_INDEX_VERSION = 2
 
 
-OldUnpackedObject = tuple[bytes | int, list[bytes]] | list[bytes]
-ResolveExtRefFn = Callable[[bytes], tuple[int, OldUnpackedObject]]
+OldUnpackedObject = tuple[bytes | int, list[bytes]] | list[bytes] | bytes
+ResolveExtRefFn = Callable[[RawObjectID | ObjectID], tuple[int, bytes | list[bytes]]]
 ProgressFn = Callable[[int, str], None]
 PackHint = tuple[int, bytes | None]
 
@@ -2332,7 +2332,7 @@ class DeltaChainIterator(Generic[T]):
             if base_sha not in self._pending_ref:
                 continue
             try:
-                type_num, chunks = self._resolve_ext_ref(base_sha)
+                type_num, chunks = self._resolve_ext_ref(RawObjectID(base_sha))
             except KeyError:
                 # Not an external ref, but may depend on one. Either it will
                 # get popped via a _follow_chain call, or we will raise an
@@ -2341,7 +2341,7 @@ class DeltaChainIterator(Generic[T]):
             self._ext_refs.append(RawObjectID(base_sha))
             self._pending_ref.pop(base_sha)
             for new_offset in pending:
-                yield from self._follow_chain(new_offset, type_num, chunks)  # type: ignore[arg-type]
+                yield from self._follow_chain(new_offset, type_num, chunks)
 
         self._ensure_no_pending()
 
@@ -2349,7 +2349,10 @@ class DeltaChainIterator(Generic[T]):
         raise NotImplementedError
 
     def _resolve_object(
-        self, offset: int, obj_type_num: int, base_chunks: list[bytes] | None
+        self,
+        offset: int,
+        obj_type_num: int,
+        base_chunks: bytes | list[bytes] | None,
     ) -> UnpackedObject:
         assert self._file is not None
         self._file.seek(offset)
@@ -2383,7 +2386,10 @@ class DeltaChainIterator(Generic[T]):
         return unpacked
 
     def _follow_chain(
-        self, offset: int, obj_type_num: int, base_chunks: list[bytes] | None
+        self,
+        offset: int,
+        obj_type_num: int,
+        base_chunks: bytes | list[bytes] | None,
     ) -> Iterator[T]:
         # Unlike PackData.get_object_at, there is no need to cache offsets as
         # this approach by design inflates each object exactly once.
@@ -4442,6 +4448,9 @@ class Pack:
             prev_offset = base_offset
             if get_ref is None:
                 get_ref = self.get_ref
+            assert isinstance(base_obj, tuple), (
+                f"Expected delta tuple, got {base_obj.__class__.__name__}"
+            )
             if base_type == OFS_DELTA:
                 (delta_offset, delta) = base_obj
                 # TODO: clean up asserts and replace with nicer error messages

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2191,6 +2191,7 @@ class DeltaChainIterator(Generic[T]):
         hash_func: Callable[[], "HashObject"],
         *,
         resolve_ext_ref: ResolveExtRefFn | None = None,
+        object_format: "ObjectFormat | None" = None,
     ) -> None:
         """Initialize DeltaChainIterator.
 
@@ -2198,9 +2199,13 @@ class DeltaChainIterator(Generic[T]):
             file_obj: File object to read pack data from
             hash_func: Hash function to use for computing object IDs
             resolve_ext_ref: Optional function to resolve external references
+            object_format: Optional object format. Required by subclasses
+                that materialise objects (e.g. PackInflater) when iterating
+                packs in a non-default hash algorithm such as SHA-256.
         """
         self._file = file_obj
         self.hash_func = hash_func
+        self._object_format = object_format
         self._resolve_ext_ref = resolve_ext_ref
         self._pending_ofs: dict[int, list[int]] = defaultdict(list)
         self._pending_ref: dict[bytes, list[int]] = defaultdict(list)
@@ -2221,7 +2226,10 @@ class DeltaChainIterator(Generic[T]):
           DeltaChainIterator instance
         """
         walker = cls(
-            None, pack_data.object_format.hash_func, resolve_ext_ref=resolve_ext_ref
+            None,
+            pack_data.object_format.hash_func,
+            resolve_ext_ref=resolve_ext_ref,
+            object_format=pack_data.object_format,
         )
         walker.set_pack_data(pack_data)
         for unpacked in pack_data.iter_unpacked(include_comp=False):
@@ -2249,7 +2257,10 @@ class DeltaChainIterator(Generic[T]):
           DeltaChainIterator instance
         """
         walker = cls(
-            None, pack.object_format.hash_func, resolve_ext_ref=resolve_ext_ref
+            None,
+            pack.object_format.hash_func,
+            resolve_ext_ref=resolve_ext_ref,
+            object_format=pack.object_format,
         )
         walker.set_pack_data(pack.data)
         todo = set()
@@ -2463,7 +2474,12 @@ class PackInflater(DeltaChainIterator[ShaFile]):
         Returns:
             ShaFile object from the unpacked data
         """
-        return unpacked.sha_file()
+        assert unpacked.obj_type_num is not None and unpacked.obj_chunks is not None
+        return ShaFile.from_raw_chunks(
+            unpacked.obj_type_num,
+            unpacked.obj_chunks,
+            object_format=self._object_format,
+        )
 
 
 class SHA1Reader(BinaryIO):

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2367,6 +2367,19 @@ class DeltaChainIterator(Generic[T]):
             assert unpacked.pack_type_num in DELTA_TYPES
             unpacked.obj_type_num = obj_type_num
             unpacked.obj_chunks = apply_delta(base_chunks, unpacked.decomp_chunks)
+            # A delta that resolves to a zero-byte payload for a
+            # commit/tree/tag is malformed: ``_parse_message`` /
+            # ``parse_tree`` accept the empty input silently, so without
+            # this guard a too-short delta could materialise an
+            # otherwise-valid SHA pointing at an empty commit object
+            # (which ``git fsck`` rejects). Only blobs may legitimately
+            # be empty, and an empty blob would never be stored as a
+            # delta in practice.
+            # Blob.type_num == 3 (avoid the import cycle).
+            if obj_type_num != 3 and chunks_length(unpacked.obj_chunks) == 0:
+                raise ApplyDeltaError(
+                    f"delta resolved to empty payload for type {obj_type_num}"
+                )
         return unpacked
 
     def _follow_chain(
@@ -3745,7 +3758,13 @@ def apply_delta(
     def get_delta_header_size(delta: bytes, index: int) -> tuple[int, int]:
         size = 0
         i = 0
-        while delta:
+        while True:
+            # Bound-check explicitly: ``delta[index:index+1]`` silently
+            # returns b"" past the end, which would crash with TypeError
+            # in ``ord`` and leave the caller unable to distinguish a
+            # truncated delta from a programming bug.
+            if index >= delta_length:
+                raise ApplyDeltaError("delta truncated in size header")
             cmd = ord(delta[index : index + 1])
             index += 1
             size |= (cmd & ~0x80) << i

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -118,6 +118,29 @@ class MemoryObjectStoreTests(ObjectStoreTests, TestCase):
         self.assertEqual([], entries)
         o.add_thin_pack(f.read, None)
 
+    def test_add_pack_rejects_truncated_checksum(self) -> None:
+        # A pack stream that lost the last few bytes of its trailing
+        # checksum must be rejected by MemoryObjectStore.add_pack;
+        # otherwise a MemoryRepo non-thin fetch would silently accept
+        # truncated network input. add_thin_pack already validates via
+        # PackStreamCopier.verify().
+        from dulwich.errors import ChecksumMismatch
+
+        o = MemoryObjectStore()
+        f, commit, abort = o.add_pack()
+        try:
+            scratch = BytesIO()
+            build_pack(scratch, [(Blob.type_num, b"hello world")])
+            data = scratch.getvalue()
+            # Drop a few bytes of the 20-byte trailing checksum.
+            f.write(data[:-5])
+            self.assertRaises(ChecksumMismatch, commit)
+        except BaseException:
+            abort()
+            raise
+        # The truncated pack must not have leaked objects into the store.
+        self.assertEqual([], list(o))
+
     def test_add_pack_data_with_deltas(self) -> None:
         """Test that add_pack_data properly handles delta objects.
 

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -352,6 +352,28 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
             self.assertEqual([], entries)
             o.add_thin_pack(f.read, None)
 
+    def test_add_pack_rejects_malformed_tree(self) -> None:
+        # A pack containing a "tree" whose body cannot be parsed must not
+        # be ingested: MemoryObjectStore and ``git fsck`` already reject
+        # such objects, so DiskObjectStore must too. Otherwise a malicious
+        # remote can poison the repository.
+        from dulwich.errors import ObjectFormatException
+
+        o = DiskObjectStore(self.store_dir)
+        self.addCleanup(o.close)
+        f, commit, abort = o.add_pack()
+        try:
+            build_pack(f, [(Tree.type_num, b"this is not a tree at all")])
+            # build_pack rewinds f; commit() detects the pack only when
+            # f.tell() > 0, so re-seek to the end of the written pack.
+            f.seek(0, os.SEEK_END)
+            self.assertRaises(ObjectFormatException, commit)
+        except BaseException:
+            abort()
+            raise
+        # No pack/index files should have been left behind.
+        self.assertEqual([], os.listdir(o.pack_dir))
+
     def test_pack_index_version_config(self) -> None:
         # Test that pack.indexVersion configuration is respected
         from dulwich.config import ConfigDict

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -252,6 +252,13 @@ class TestPackDeltas(TestCase):
         """Test apply_delta with a truncated insert operation."""
         self.assertRaises(ApplyDeltaError, apply_delta, b"", b"\x00\x01\x01")
 
+    def test_apply_delta_truncated_header(self) -> None:
+        # A delta that ends mid-size-header used to crash with a
+        # generic TypeError from ``ord(b"")``; the explicit bound
+        # check now turns it into a typed ApplyDeltaError.
+        self.assertRaises(ApplyDeltaError, apply_delta, b"", b"\x80")
+        self.assertRaises(ApplyDeltaError, apply_delta, b"", b"")
+
     def test_create_delta_insert_only(self) -> None:
         """Test create_delta when only insertions are required."""
         base = b""
@@ -1719,6 +1726,30 @@ class DeltaChainIteratorTests(TestCase):
         )
         # Delta resolution changed to DFS
         self.assertEntriesMatch([0, 4, 2, 1, 3], entries, self.make_pack_iter(f))
+
+    def test_ref_delta_rejects_empty_commit_payload(self) -> None:
+        # A delta against a commit/tree/tag that resolves to zero bytes
+        # produces a "valid" SHA pointing at an empty payload that
+        # downstream commit/tree parsers happily accept (their loops
+        # simply iterate zero times). Git fsck rejects such objects, so
+        # we must reject them at pack-read time rather than materialise
+        # the empty payload as a real object.
+        commit = make_object(
+            Commit,
+            tree=b"a" * 40,
+            author=b"me <a@b>",
+            committer=b"me <a@b>",
+            author_time=1,
+            commit_time=1,
+            author_timezone=0,
+            commit_timezone=0,
+            message=b"msg",
+        )
+        self.store.add_object(commit)
+        f = BytesIO()
+        build_pack(f, [(REF_DELTA, (commit.id, b""))], store=self.store)
+        pack_iter = self.make_pack_iter(f)
+        self.assertRaises(ApplyDeltaError, list, pack_iter._walk_all_chains())
 
     def test_long_chain(self) -> None:
         n = 100


### PR DESCRIPTION
Three pack-ingestion hardening fixes that   bring dulwich's reader in line with git's index-pack / fsck input validation. Validate object payloads in DiskObjectStore.add_pack, verify the trailing pack checksum in MemoryObjectStore.add_pack, and reject   deltas that resolve to a zero-byte commit/tree/tag (plus a typed ApplyDeltaError for deltas truncated mid-size-header).