### PR TITLE
refs: reject names with empty or .lock components

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.3	UNRELEASED
 
+ * Reject ref names with empty path components (e.g. ``refs//a``)
+   or with ``.lock`` as a non-final component (e.g. ``refs/a.lock/a``)
+   in ``check_ref_format``, matching ``git check-ref-format``. (Jelmer Vernooĳ; reported by Christopher Toth)
+
  * Honour ``GIT_CONFIG_COUNT`` / ``GIT_CONFIG_KEY_<n>`` /
    ``GIT_CONFIG_VALUE_<n>`` in porcelain entry points, via the new
    opt-in ``config.env_config`` helper. (Jelmer Vernooĳ, #2168)

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -124,7 +124,7 @@ def check_ref_format(refname: Ref) -> bool:
     """
     # These could be combined into one big expression, but are listed
     # separately to parallel [1].
-    if b"/." in refname or refname.startswith(b"."):  # type: ignore[comparison-overlap]
+    if refname == b"@":
         return False
     if b"/" not in refname:  # type: ignore[comparison-overlap]
         return False
@@ -135,12 +135,17 @@ def check_ref_format(refname: Ref) -> bool:
             return False
     if refname[-1] in b"/.":
         return False
-    if refname.endswith(b".lock"):
-        return False
     if b"@{" in refname:  # type: ignore[comparison-overlap]
         return False
     if b"\\" in refname:  # type: ignore[comparison-overlap]
         return False
+    for component in refname.split(b"/"):
+        if not component:
+            return False
+        if component.startswith(b"."):
+            return False
+        if component.endswith(b".lock"):
+            return False
     return True
 
 
@@ -1683,7 +1688,7 @@ def _import_remote_refs(
         if n.startswith(LOCAL_TAG_PREFIX) and not n.endswith(PEELED_TAG_SUFFIX)
     }
     refs_container.import_refs(
-        Ref(LOCAL_TAG_PREFIX), tags, message=message, prune=prune_tags
+        Ref(b"refs/tags"), tags, message=message, prune=prune_tags
     )
 
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -61,10 +61,10 @@ class CheckRefFormatTests(TestCase):
     def test_valid(self) -> None:
         self.assertTrue(check_ref_format(b"heads/foo"))
         self.assertTrue(check_ref_format(b"foo/bar/baz"))
-        self.assertTrue(check_ref_format(b"refs///heads/foo"))
         self.assertTrue(check_ref_format(b"foo./bar"))
         self.assertTrue(check_ref_format(b"heads/foo@bar"))
         self.assertTrue(check_ref_format(b"heads/fix.lock.error"))
+        self.assertTrue(check_ref_format(b"heads/foo.lock.bar"))
 
     def test_invalid(self) -> None:
         self.assertFalse(check_ref_format(b"foo"))
@@ -76,6 +76,13 @@ class CheckRefFormatTests(TestCase):
         self.assertFalse(check_ref_format(b"heads/foo.lock"))
         self.assertFalse(check_ref_format(b"heads/v@{ation"))
         self.assertFalse(check_ref_format(b"heads/foo\bar"))
+        self.assertFalse(check_ref_format(b"refs//a"))
+        self.assertFalse(check_ref_format(b"refs/heads//a"))
+        self.assertFalse(check_ref_format(b"refs///heads/foo"))
+        self.assertFalse(check_ref_format(b"/refs/heads/foo"))
+        self.assertFalse(check_ref_format(b"refs/a.lock/a"))
+        self.assertFalse(check_ref_format(b"refs/heads/a.lock/a"))
+        self.assertFalse(check_ref_format(b"@"))
 
 
 ONES = b"1" * 40


### PR DESCRIPTION
Consistent with C Git.

Reported by Christopher Toth.