### PR TITLE
client: Raise GitProtocolError when an error occurs with protocol v2

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -508,7 +508,9 @@ def read_pkt_refs_v2(
         parts = pkt.rstrip(b"\n").split(b" ")
         sha_bytes = parts[0]
         sha: ObjectID | None
-        if sha_bytes == b"unborn":
+        if sha_bytes == b"ERR":
+            raise GitProtocolError(b" ".join(parts[1:]).decode("utf-8", "replace"))
+        elif sha_bytes == b"unborn":
             sha = None
         else:
             sha = ObjectID(sha_bytes)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,7 +34,7 @@ from urllib.parse import quote as urlquote
 from urllib.parse import urlparse
 
 import dulwich
-from dulwich import client
+from dulwich import client, errors
 from dulwich.bundle import create_bundle_from_repo, write_bundle
 from dulwich.client import (
     AuthCallbackPoolManager,
@@ -670,6 +670,16 @@ class GitClientTests(TestCase):
             generate_pack_data,
             atomic=True,
         )
+
+    def test_read_pkt_refs_v1_error(self):
+        with self.assertRaises(errors.GitProtocolError) as cm:
+            client.read_pkt_refs_v1([b"ERR An error occurred on the git server"])
+        self.assertEqual("An error occurred on the git server", str(cm.exception))
+
+    def test_read_pkt_refs_v2_error(self):
+        with self.assertRaises(errors.GitProtocolError) as cm:
+            client.read_pkt_refs_v2([b"ERR An error occurred on the git server"])
+        self.assertEqual("An error occurred on the git server", str(cm.exception))
 
 
 class TestGetTransportAndPath(TestCase):


### PR DESCRIPTION
I stumbled across that error when sending a `git-upload-pack` request using protocol v2 that takes too much time on the git server:

```
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): gitlab.com:443
DEBUG:urllib3.connectionpool:https://gitlab.com:443 "GET /gitlab-org/gitlab.git/info/refs?service=git-upload-pack HTTP/1.1" 200 206
DEBUG:dulwich.protocol:git< b'# service=git-upload-pack\n'
DEBUG:dulwich.protocol:git< b'# service=git-upload-pack\n'
DEBUG:dulwich.protocol:git< 0000
DEBUG:dulwich.protocol:git< b'version 2\n'
DEBUG:dulwich.protocol:git< b'agent=git/2.54.0-rc1.gb15384c-Linux\n'
DEBUG:dulwich.protocol:git< b'ls-refs=unborn\n'
DEBUG:dulwich.protocol:git< b'fetch=shallow wait-for-done filter\n'
DEBUG:dulwich.protocol:git< b'server-option\n'
DEBUG:dulwich.protocol:git< b'object-format=sha1\n'
DEBUG:dulwich.protocol:git< b'bundle-uri\n'
DEBUG:dulwich.protocol:git< 0000
DEBUG:urllib3.connectionpool:https://gitlab.com:443 "POST /gitlab-org/gitlab.git/git-upload-pack HTTP/1.1" 200 97
DEBUG:dulwich.protocol:git< b'ERR GitLab is currently unable to handle this request due to load (ID 9febc24c1a'... (93 bytes)
WARNING:root:unknown part in pkt-ref: b'is'
WARNING:root:unknown part in pkt-ref: b'currently'
WARNING:root:unknown part in pkt-ref: b'unable'
WARNING:root:unknown part in pkt-ref: b'to'
WARNING:root:unknown part in pkt-ref: b'handle'
WARNING:root:unknown part in pkt-ref: b'this'
WARNING:root:unknown part in pkt-ref: b'request'
WARNING:root:unknown part in pkt-ref: b'due'
WARNING:root:unknown part in pkt-ref: b'to'
WARNING:root:unknown part in pkt-ref: b'load'
WARNING:root:unknown part in pkt-ref: b'(ID'
WARNING:root:unknown part in pkt-ref: b'9febc24c1ae3c6c9-CDG).'
ERROR:swh.loader.git.loader.GitLoader:Loading failure, updating to `failed` status
Traceback (most recent call last):
  File "/home/anlambert/swh/swh-environment/swh-loader-core/build/__editable__.swh_loader_core-5.24.3.dev5+g65f728aaf-py3-none-any/swh/loader/core/loader.py", line 460, in load
    more_data_to_fetch = self.fetch_data()
                         ^^^^^^^^^^^^^^^^^
  File "/home/anlambert/swh/swh-environment/swh-loader-git/build/__editable__.swh_loader_git-2.14.4.dev4+g1041f61d9-py3-none-any/swh/loader/git/loader.py", line 449, in fetch_data
    fetch_info = self.fetch_pack_from_origin(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/swh/swh-environment/swh-loader-git/build/__editable__.swh_loader_git-2.14.4.dev4+g1041f61d9-py3-none-any/swh/loader/git/loader.py", line 282, in fetch_pack_from_origin
    pack_result = client.fetch_pack(
                  ^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/.virtualenvs/swh/lib/python3.12/site-packages/dulwich/client.py", line 4812, in fetch_pack
    refs, server_capabilities, url, symrefs, _peeled = self._discover_references(
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/.virtualenvs/swh/lib/python3.12/site-packages/dulwich/client.py", line 4592, in _discover_references
    (refs, symrefs, peeled) = read_pkt_refs_v2(proto.read_pkt_seq())
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/.virtualenvs/swh/lib/python3.12/site-packages/dulwich/client.py", line 507, in read_pkt_refs_v2
    for pkt in pkt_seq:
  File "/home/anlambert/.virtualenvs/swh/lib/python3.12/site-packages/dulwich/protocol.py", line 528, in read_pkt_seq
    pkt = self.read_pkt_line()
          ^^^^^^^^^^^^^^^^^^^^
  File "/home/anlambert/.virtualenvs/swh/lib/python3.12/site-packages/dulwich/protocol.py", line 460, in read_pkt_line
    raise HangupException
dulwich.errors.HangupException: The remote server unexpectedly closed the connection.
```
With git protocol v1, `dulwich` raises a `GitProtocolError` exception with the git server error details so the same should happen with git protocol v2.
