### PR TITLE
Return Self from __enter__

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PYTHON = python3
 RUFF ?= $(PYTHON) -m ruff
-SETUP = $(PYTHON) setup.py
+SETUP = $(PYTHON) -m build
 TESTRUNNER ?= unittest
 RUNTEST = PYTHONHASHSEED=random PYTHONPATH=$(shell pwd)$(if $(PYTHONPATH),:$(PYTHONPATH),) $(PYTHON) -m $(TESTRUNNER) $(TEST_OPTIONS)
 COVERAGE = python3-coverage

--- a/dulwich/bundle.py
+++ b/dulwich/bundle.py
@@ -29,6 +29,7 @@ __all__ = [
     "write_bundle",
 ]
 
+import sys
 import types
 from collections.abc import Callable, Iterator, Sequence
 from typing import (
@@ -38,6 +39,11 @@ from typing import (
     cast,
     runtime_checkable,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 if TYPE_CHECKING:
     from .object_format import ObjectFormat
@@ -112,7 +118,7 @@ class Bundle:
             self.pack_data.close()
             self.pack_data = None
 
-    def __enter__(self) -> "Bundle":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -96,6 +96,11 @@ from .patch import DiffAlgorithmNotAvailable
 from .repo import Repo
 from .stripspace import stripspace
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 logger = logging.getLogger(__name__)
 
 
@@ -256,7 +261,7 @@ class AutoFlushTextIOWrapper:
         """Delegate all other attributes to the underlying stream."""
         return getattr(self._stream, name)
 
-    def __enter__(self) -> "AutoFlushTextIOWrapper":
+    def __enter__(self) -> Self:
         """Support context manager protocol."""
         return self
 
@@ -339,7 +344,7 @@ class AutoFlushBinaryIOWrapper:
         """Delegate all other attributes to the underlying stream."""
         return getattr(self._stream, name)
 
-    def __enter__(self) -> "AutoFlushBinaryIOWrapper":
+    def __enter__(self) -> Self:
         """Support context manager protocol."""
         return self
 
@@ -799,7 +804,7 @@ class PagerBuffer(BinaryIO):
         """Return next line (not supported)."""
         raise io.UnsupportedOperation("PagerBuffer does not support iteration")
 
-    def __enter__(self) -> "PagerBuffer":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 
@@ -901,7 +906,7 @@ class Pager(TextIO):
                 pass
             self.pager_process = None
 
-    def __enter__(self) -> "Pager":
+    def __enter__(self) -> Self:
         """Context manager entry."""
         return self
 

--- a/dulwich/diff.py
+++ b/dulwich/diff.py
@@ -57,6 +57,7 @@ import io
 import logging
 import os
 import stat
+import sys
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING, BinaryIO
 
@@ -69,6 +70,11 @@ from .object_store import iter_tree_contents
 from .objects import S_ISGITLINK, Blob, Commit, ObjectID
 from .patch import write_blob_diff, write_object_diff
 from .repo import Repo
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -718,7 +724,7 @@ class ColorizedDiffStream(BinaryIO):
         """This stream is writable."""
         return True
 
-    def __enter__(self) -> "ColorizedDiffStream":
+    def __enter__(self) -> Self:
         """Context manager entry."""
         return self
 

--- a/dulwich/file.py
+++ b/dulwich/file.py
@@ -36,6 +36,11 @@ from typing import IO, Any, ClassVar, Literal, overload
 
 from ._typing import Buffer
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 
 def ensure_dir_exists(
     dirname: str | bytes | os.PathLike[str] | os.PathLike[bytes],
@@ -284,7 +289,7 @@ class _GitFile(IO[bytes]):
             warnings.warn(f"unclosed {self!r}", ResourceWarning, stacklevel=2)
             self.abort()
 
-    def __enter__(self) -> "_GitFile":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -129,6 +129,11 @@ from typing import (
     TypeVar,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 try:
     import mmap
 except ImportError:
@@ -1910,15 +1915,15 @@ class PackData:
                 # Ignore errors during cleanup
                 pass
 
-    def __enter__(self) -> "PackData":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 
     def __exit__(
         self,
-        exc_type: type | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        type: type | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         """Exit context manager."""
         self.close()
@@ -2599,7 +2604,7 @@ class SHA1Reader(BinaryIO):
         """Write data to the file (not supported)."""
         raise UnsupportedOperation("write")
 
-    def __enter__(self) -> "SHA1Reader":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 
@@ -2767,7 +2772,7 @@ class SHA1Writer(BinaryIO):
         """
         raise UnsupportedOperation("read")
 
-    def __enter__(self) -> "SHA1Writer":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 
@@ -2934,7 +2939,7 @@ class HashWriter(BinaryIO):
         """
         raise UnsupportedOperation("read")
 
-    def __enter__(self) -> "HashWriter":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 
@@ -4248,15 +4253,15 @@ class Pack:
                 # Ignore errors during cleanup
                 pass
 
-    def __enter__(self) -> "Pack":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 
     def __exit__(
         self,
-        exc_type: type | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
+        type: type | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
     ) -> None:
         """Exit context manager."""
         self.close()

--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -104,6 +104,7 @@ __all__ = [
 ]
 
 import logging
+import sys
 import types
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from io import BytesIO
@@ -114,6 +115,11 @@ import dulwich
 
 from .errors import GitProtocolError, HangupException
 from .objects import ObjectID
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 
@@ -427,7 +433,7 @@ class Protocol:
                 # Ignore errors during cleanup
                 pass
 
-    def __enter__(self) -> "Protocol":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -56,6 +56,7 @@ __all__ = [
 ]
 
 import os
+import sys
 import types
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import suppress
@@ -67,6 +68,11 @@ from typing import (
     NewType,
     TypeVar,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 if TYPE_CHECKING:
     from .file import _GitFile
@@ -1711,7 +1717,7 @@ class locked_ref:
         self._realname: Ref | None = None
         self._deleted = False
 
-    def __enter__(self) -> "locked_ref":
+    def __enter__(self) -> Self:
         """Enter the context manager and acquire the lock.
 
         Returns:

--- a/dulwich/reftable.py
+++ b/dulwich/reftable.py
@@ -67,6 +67,7 @@ import os
 import random
 import shutil
 import struct
+import sys
 import time
 import zlib
 from collections.abc import Callable, Mapping
@@ -81,6 +82,11 @@ from dulwich.refs import (
     Ref,
     RefsContainer,
 )
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 
 def decode_varint_from_stream(stream: BinaryIO) -> int | None:
@@ -826,7 +832,7 @@ class _ReftableBatchContext:
     def __init__(self, refs_container: "ReftableRefsContainer") -> None:
         self.refs_container = refs_container
 
-    def __enter__(self) -> "_ReftableBatchContext":
+    def __enter__(self) -> Self:
         self.refs_container._batch_mode = True
         return self
 

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -73,6 +73,11 @@ from typing import (
     TypeVar,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+
 if TYPE_CHECKING:
     # There are no circular imports here, but we try to defer imports as long
     # as possible to reduce start-up time for anything that doesn't need
@@ -2371,7 +2376,7 @@ class Repo(BaseRepo):
             self.filter_context.close()
             self.filter_context = None
 
-    def __enter__(self) -> "Repo":
+    def __enter__(self) -> Self:
         """Enter context manager."""
         return self
 


### PR DESCRIPTION
This allows for easier subclassing of the objects.

I've also updated the `build` and `install` Makefile targets to use [build](https://pypi.org/project/build) rather than calling `setup.py`, since that gives you build isolation and is not deprecated.
