### PR TITLE
refs: reject malformed ref prefixes/suffixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+1.2.4	UNRELEASED
+
+ * Validate input for various functions dealing with ref prefixes or
+   suffixes, resulting in clearer errors. (Jelmer Vernooĳ, #2192)
+
 1.2.3	2026-05-20
 
  * Raise ``GitProtocolError`` when a protocol v2 ref advertisement
@@ -22,7 +27,7 @@
    ``errno.EILSEQ``, so they pass on Linux filesystems that reject
    non-UTF-8 names (e.g. OpenZFS with ``utf8only=on``). (Matt Van Horn, #2174)
 
- * Reject ref names with empty path components (e.g. ``refs//a``)
+ * HARDEN: Reject ref names with empty path components (e.g. ``refs//a``)
    or with ``.lock`` as a non-final component (e.g. ``refs/a.lock/a``)
    in ``check_ref_format``, matching ``git check-ref-format``.
    (Jelmer Vernooĳ; reported by Christopher Toth)

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -307,6 +307,10 @@ class RefsContainer:
           message: Optional message for reflog
           prune: If True, remove refs not in other
         """
+        # Strip a trailing slash so joining ``base`` with a ref name below
+        # does not produce a malformed ref with an empty path component
+        # (e.g. b'refs/tags/' + b'/' + b'v1.0' -> b'refs/tags//v1.0').
+        base = Ref(base.rstrip(b"/"))
         if prune:
             to_delete = set(self.subkeys(base))
         else:
@@ -1475,6 +1479,9 @@ def local_branch_name(name: bytes) -> Ref:
     Returns:
       Full branch ref name (e.g., b"refs/heads/master")
 
+    Raises:
+      ValueError: If name starts with a slash
+
     Examples:
       >>> local_branch_name(b"master")
       b'refs/heads/master'
@@ -1483,6 +1490,8 @@ def local_branch_name(name: bytes) -> Ref:
     """
     if name.startswith(LOCAL_BRANCH_PREFIX):
         return Ref(name)
+    if name.startswith(b"/"):
+        raise ValueError(f"Branch name must not start with a slash: {name!r}")
     return Ref(LOCAL_BRANCH_PREFIX + name)
 
 
@@ -1495,6 +1504,9 @@ def local_tag_name(name: bytes) -> Ref:
     Returns:
       Full tag ref name (e.g., b"refs/tags/v1.0")
 
+    Raises:
+      ValueError: If name starts with a slash
+
     Examples:
       >>> local_tag_name(b"v1.0")
       b'refs/tags/v1.0'
@@ -1503,6 +1515,8 @@ def local_tag_name(name: bytes) -> Ref:
     """
     if name.startswith(LOCAL_TAG_PREFIX):
         return Ref(name)
+    if name.startswith(b"/"):
+        raise ValueError(f"Tag name must not start with a slash: {name!r}")
     return Ref(LOCAL_TAG_PREFIX + name)
 
 
@@ -1515,6 +1529,9 @@ def local_replace_name(name: bytes) -> Ref:
     Returns:
       Full replace ref name (e.g., b"refs/replace/<sha>")
 
+    Raises:
+      ValueError: If name starts with a slash
+
     Examples:
       >>> local_replace_name(b"abc123")
       b'refs/replace/abc123'
@@ -1523,6 +1540,8 @@ def local_replace_name(name: bytes) -> Ref:
     """
     if name.startswith(LOCAL_REPLACE_PREFIX):
         return Ref(name)
+    if name.startswith(b"/"):
+        raise ValueError(f"Replace name must not start with a slash: {name!r}")
     return Ref(LOCAL_REPLACE_PREFIX + name)
 
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -362,6 +362,19 @@ class RefsContainerTests:
             self._refs[b"refs/remotes/origin/other"],
         )
 
+    def test_import_refs_base_trailing_slash(self) -> None:
+        # A trailing slash on the base must not produce a malformed ref
+        # with an empty path component (e.g. b'refs/tags//v1.0').
+        self._refs.import_refs(
+            b"refs/tags/",
+            {b"v1.0": b"42d06bd4b77fed026b154d16493e5deab78f02ec"},
+        )
+        self.assertEqual(
+            b"42d06bd4b77fed026b154d16493e5deab78f02ec",
+            self._refs[b"refs/tags/v1.0"],
+        )
+        self.assertNotIn(b"refs/tags//v1.0", self._refs.allkeys())
+
     def test_import_refs_name_prune(self) -> None:
         self._refs[b"refs/remotes/origin/other"] = (
             b"48d01bd4b77fed026b154d16493e5deab78f02ec"
@@ -1225,6 +1238,12 @@ class RefUtilityFunctionsTests(TestCase):
         # Test idempotency - already has prefix
         self.assertEqual(b"refs/heads/master", local_branch_name(b"refs/heads/master"))
 
+    def test_local_branch_name_leading_slash(self) -> None:
+        """Test local_branch_name rejects names starting with a slash."""
+        from dulwich.refs import local_branch_name
+
+        self.assertRaises(ValueError, local_branch_name, b"/master")
+
     def test_local_tag_name(self) -> None:
         """Test local_tag_name function."""
         from dulwich.refs import local_tag_name
@@ -1235,6 +1254,18 @@ class RefUtilityFunctionsTests(TestCase):
 
         # Test idempotency - already has prefix
         self.assertEqual(b"refs/tags/v1.0", local_tag_name(b"refs/tags/v1.0"))
+
+    def test_local_tag_name_leading_slash(self) -> None:
+        """Test local_tag_name rejects names starting with a slash."""
+        from dulwich.refs import local_tag_name
+
+        self.assertRaises(ValueError, local_tag_name, b"/v1.0")
+
+    def test_local_replace_name_leading_slash(self) -> None:
+        """Test local_replace_name rejects names starting with a slash."""
+        from dulwich.refs import local_replace_name
+
+        self.assertRaises(ValueError, local_replace_name, b"/abc123")
 
     def test_extract_branch_name(self) -> None:
         """Test extract_branch_name function."""


### PR DESCRIPTION
.. instead of failing further down the callstack

Fixes #2192