### PR TITLE
reject backslash and colon in validate_path_element_ntfs

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -1979,6 +1979,14 @@ def validate_path_element_ntfs(element: bytes) -> bool:
     Returns:
       True if path element is valid for NTFS, False otherwise
     """
+    # NTFS treats ``\`` as a path separator, so an element that still
+    # contains one would be split further on extraction and could escape
+    # the working tree (e.g. ``..\\evil``). ``:`` introduces an NTFS
+    # alternate data stream and can be used to alias ``.git`` references
+    # (e.g. ``evil:.git\\config``). Both are rejected by git's verify_path
+    # when core.protectNTFS is in effect.
+    if b"\\" in element or b":" in element:
+        return False
     normalized = _normalize_path_element_ntfs(element)
     if normalized in INVALID_DOTNAMES:
         return False

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1436,6 +1436,13 @@ class TestValidatePathElement(TestCase):
         self.assertFalse(validate_path_element_ntfs(b".giT"))
         self.assertFalse(validate_path_element_ntfs(b".."))
         self.assertFalse(validate_path_element_ntfs(b"git~1"))
+        # Elements containing a backslash or colon must be rejected: NTFS
+        # uses ``\`` as a separator (so ``..\\evil`` would escape) and
+        # ``:`` opens an alternate data stream (which can alias .git).
+        self.assertFalse(validate_path_element_ntfs(b"..\\evil"))
+        self.assertFalse(validate_path_element_ntfs(b"foo\\bar"))
+        self.assertFalse(validate_path_element_ntfs(b"evil:.git"))
+        self.assertFalse(validate_path_element_ntfs(b"foo:bar"))
 
     def test_hfs(self) -> None:
         # Normal paths should pass


### PR DESCRIPTION
Tree entries like `..\evil` or `evil:.git\config` slip through `validate_path_element_ntfs` today: `split(b"/")` keeps them as one element, and the normalizer only rstrip-lowercases. On Windows that lets a tree path escape the working tree at `build_index_from_tree` / checkout time, the same shape recently fixed in archive.py. Mirroring git's verify_path under core.protectNTFS by rejecting elements that contain `\` or `:`.