### PR TITLE
shell-quote path placeholders in merge driver command

### DIFF
--- a/dulwich/merge_drivers.py
+++ b/dulwich/merge_drivers.py
@@ -29,6 +29,7 @@ __all__ = [
 ]
 
 import os
+import shlex
 import subprocess
 import tempfile
 from collections.abc import Callable
@@ -112,12 +113,12 @@ class ProcessMergeDriver:
 
             # Prepare command with placeholders
             cmd = self.command
-            cmd = cmd.replace("%O", ancestor_path)
-            cmd = cmd.replace("%A", ours_path)
-            cmd = cmd.replace("%B", theirs_path)
+            cmd = cmd.replace("%O", shlex.quote(ancestor_path))
+            cmd = cmd.replace("%A", shlex.quote(ours_path))
+            cmd = cmd.replace("%B", shlex.quote(theirs_path))
             cmd = cmd.replace("%L", str(marker_size))
             if path:
-                cmd = cmd.replace("%P", path)
+                cmd = cmd.replace("%P", shlex.quote(path))
 
             # Execute merge command
             try:

--- a/tests/test_merge_drivers.py
+++ b/tests/test_merge_drivers.py
@@ -21,7 +21,9 @@
 """Tests for merge driver support."""
 
 import importlib.util
+import os
 import sys
+import tempfile
 import unittest
 
 from dulwich.attrs import GitAttributes, Pattern
@@ -204,6 +206,22 @@ class ProcessMergeDriverTests(unittest.TestCase):
             expected = b"path: dir/file.xml\n"
         self.assertEqual(result, expected)
         self.assertTrue(success)
+
+    def test_merge_path_with_shell_metacharacters(self):
+        """Path placeholders are shell-quoted before substitution."""
+        marker = os.path.join(tempfile.gettempdir(), "dulwich_md_injection")
+        if os.path.exists(marker):
+            os.remove(marker)
+        self.addCleanup(
+            lambda: os.path.exists(marker) and os.remove(marker)
+        )
+        command = "cat %P > /dev/null"
+        driver = ProcessMergeDriver(command, "inject_driver")
+        evil = f"a$(touch {marker}).txt"
+
+        driver.merge(b"a", b"b", b"c", path=evil)
+
+        self.assertFalse(os.path.exists(marker))
 
 
 class MergeBlobsWithDriversTests(unittest.TestCase):


### PR DESCRIPTION
%P in a custom merge driver command is the file's tree path, which an attacker controls. ProcessMergeDriver.merge substitutes it (and %O/%A/%B) raw into a shell=True call, so a tree entry named `a$(touch /tmp/pwned).txt` runs that command during a three-way merge once a merge=<driver> attribute matches. git shell-quotes these placeholders with sq_quote; use shlex.quote to match.