### PR TITLE
reject patch paths that escape the work tree in apply_patches

### DIFF
--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -1332,6 +1332,21 @@ def apply_patch_hunks(
     return result
 
 
+def _ensure_within_repo(repo_path: bytes, fs_path: bytes, rel_path: bytes) -> None:
+    """Reject patch target paths that resolve outside the working tree.
+
+    Patch headers are untrusted (e.g. ``git am`` of a mailbox), so a name such
+    as ``../../etc/cron.d/x`` or an absolute path must not be written through
+    ``os.path.join``. Mirrors git's refusal of paths outside the work tree.
+    """
+    repo_root = os.path.realpath(repo_path)
+    resolved = os.path.realpath(fs_path)
+    if resolved != repo_root and not resolved.startswith(
+        repo_root + os.fsencode(os.sep)
+    ):
+        raise ValueError(f"patch affects file outside repository: {rel_path!r}")
+
+
 def _apply_rename_or_copy(
     r: "Repo",
     src_path: bytes,
@@ -1377,6 +1392,8 @@ def _apply_rename_or_copy(
     repo_path_bytes = r.path.encode("utf-8") if isinstance(r.path, str) else r.path
     src_fs_path = os.path.join(repo_path_bytes, src_stripped)
     dst_fs_path = os.path.join(repo_path_bytes, dst_stripped)
+    _ensure_within_repo(repo_path_bytes, src_fs_path, src_stripped)
+    _ensure_within_repo(repo_path_bytes, dst_fs_path, dst_stripped)
 
     # Read content from source file
     op_name = "rename" if is_rename else "copy"
@@ -1529,9 +1546,9 @@ def apply_patches(
 
         # Convert to filesystem path
         tree_path = file_path
-        fs_path = os.path.join(
-            r.path.encode("utf-8") if isinstance(r.path, str) else r.path, file_path
-        )
+        repo_path_bytes = r.path.encode("utf-8") if isinstance(r.path, str) else r.path
+        fs_path = os.path.join(repo_path_bytes, file_path)
+        _ensure_within_repo(repo_path_bytes, fs_path, file_path)
 
         # Handle renames and copies
         original_lines: list[bytes] | None = None

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -21,6 +21,9 @@
 
 """Tests for patch.py."""
 
+import os
+import shutil
+import tempfile
 from io import BytesIO, StringIO
 from typing import NoReturn
 
@@ -31,6 +34,7 @@ from dulwich.patch import (
     FilePatch,
     PatchHunk,
     apply_patch_hunks,
+    apply_patches,
     commit_patch_id,
     get_summary,
     git_am_patch_split,
@@ -1533,3 +1537,46 @@ Binary files a/test.bin and b/test.bin differ
         self.assertEqual(len(patches), 1)
         self.assertEqual(patches[0].binary, True)
         self.assertIsNone(patches[0].binary_new)  # No patch data
+
+
+class ApplyPatchesPathTests(TestCase):
+    """Tests that apply_patches refuses paths outside the working tree."""
+
+    def _make_repo(self):
+        from dulwich.repo import Repo
+
+        path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, path, ignore_errors=True)
+        return Repo.init(path)
+
+    def test_rejects_parent_traversal(self) -> None:
+        r = self._make_repo()
+        outside = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside, ignore_errors=True)
+        target = os.path.join(outside, "pwned")
+        rel = os.path.relpath(target, r.path).encode()
+        diff = (
+            b"diff --git a/x b/x\n"
+            b"new file mode 100644\n"
+            b"--- /dev/null\n"
+            b"+++ b/" + rel + b"\n"
+            b"@@ -0,0 +1 @@\n"
+            b"+owned\n"
+        )
+        self.assertRaises(
+            ValueError, apply_patches, r, parse_unified_diff(diff), strip=1
+        )
+        self.assertFalse(os.path.exists(target))
+
+    def test_allows_in_tree_path(self) -> None:
+        r = self._make_repo()
+        diff = (
+            b"diff --git a/sub/x b/sub/x\n"
+            b"new file mode 100644\n"
+            b"--- /dev/null\n"
+            b"+++ b/sub/x\n"
+            b"@@ -0,0 +1 @@\n"
+            b"+hi\n"
+        )
+        apply_patches(r, parse_unified_diff(diff), strip=1)
+        self.assertTrue(os.path.exists(os.path.join(r.path, "sub", "x")))


### PR DESCRIPTION
apply_patches builds the write target with os.path.join(r.path, file_path) at patch.py:1551 straight from the +++/rename header, so applying an untrusted patch (e.g. via git am) whose path is `../../x` writes outside the work tree. Resolve each target against the repo root and refuse anything that escapes it.