### PR TITLE
drop credentials when info/refs redirects to a different origin

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -4463,6 +4463,9 @@ class AbstractHttpGitClient(GitClient):
         """
         raise NotImplementedError(self._http_request)
 
+    def _reset_credentials(self) -> None:
+        """Drop stored credentials before following a cross-origin redirect."""
+
     def _discover_references(
         self,
         service: bytes,
@@ -4509,6 +4512,15 @@ class AbstractHttpGitClient(GitClient):
                 raise GitProtocolError(
                     f"Redirected from URL {url} to URL {resp.redirect_location} without {tail}"
                 )
+            orig, dest = urlparse(url), urlparse(resp.redirect_location)
+            if (orig.scheme, orig.hostname, orig.port) != (
+                dest.scheme,
+                dest.hostname,
+                dest.port,
+            ):
+                # A server-controlled redirect to a different origin must not
+                # carry the credentials configured for the original host.
+                self._reset_credentials()
             base_url = urljoin(url, resp.redirect_location[: -len(tail)])
 
         try:
@@ -5173,6 +5185,9 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
             username=username,
             password=password,
         )
+
+    def _reset_credentials(self) -> None:
+        self.pool_manager.headers.pop("authorization", None)
 
     def _get_url(self, path: str | bytes) -> str:
         if not isinstance(path, str):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1813,6 +1813,62 @@ class HttpGitClientTests(TestCase):
                 # check also the no redirection case
                 self.assertEqual(processed_url, base_url)
 
+    def test_redirect_drops_credentials_cross_origin(self) -> None:
+        from urllib3._collections import HTTPHeaderDict
+        from urllib3.response import HTTPResponse
+
+        tail = "info/refs?service=git-upload-pack"
+        refs_data = (
+            b"001e# service=git-upload-pack\n00000032"
+            b"fb2bebf4919a011f0fd7cec085443d0031228e76 HEAD\n0000"
+        )
+
+        class PoolManagerMock:
+            def __init__(self, location) -> None:
+                self.headers = HTTPHeaderDict()
+                self._location = location
+                self.sent = []
+
+            def request(
+                self,
+                method,
+                url,
+                fields=None,
+                headers=None,
+                redirect=True,
+                preload_content=True,
+            ):
+                self.sent.append((url, dict(headers or {})))
+                return HTTPResponse(
+                    body=BytesIO(refs_data),
+                    headers={
+                        "Content-Type": "application/x-git-upload-pack-advertisement"
+                    },
+                    request_method=method,
+                    request_url=self._location,
+                    preload_content=preload_content,
+                    status=200,
+                )
+
+        base_url = "https://victim.example/repo.git/"
+
+        # Cross-origin redirect: credentials must not survive the rebase.
+        pm = PoolManagerMock("https://attacker.example/repo.git/" + tail)
+        c = HttpGitClient(
+            base_url, pool_manager=pm, username="user", password="secret"
+        )
+        self.assertIn("authorization", c.pool_manager.headers)
+        c._discover_references(b"git-upload-pack", base_url)
+        self.assertNotIn("authorization", c.pool_manager.headers)
+
+        # Same-origin redirect (path only): credentials are kept.
+        pm = PoolManagerMock("https://victim.example/repo.git/" + tail)
+        c = HttpGitClient(
+            base_url, pool_manager=pm, username="user", password="secret"
+        )
+        c._discover_references(b"git-upload-pack", base_url)
+        self.assertIn("authorization", c.pool_manager.headers)
+
     def test_smart_request_content_type_with_directive_check(self) -> None:
         from urllib3.response import HTTPResponse
 


### PR DESCRIPTION
_discover_references at client.py:4506 rebases base_url to the server-supplied redirect Location, and every following request re-sends pool_manager.headers, so a redirect to another host hands the configured basic-auth / http.extraHeader credentials to that host. Drop the Authorization header when the redirect changes scheme, host, or port.