### PR TITLE
http: scope basic-auth credentials to the configured origin

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -5152,6 +5152,12 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
             # If you want callbacks with a custom pool manager, wrap it yourself
             self.pool_manager = pool_manager
 
+        # Credentials are scoped to the origin of base_url. They are attached
+        # per-request in _http_request rather than stored on the pool manager,
+        # so that a redirect to a different origin does not carry them to an
+        # origin they were not configured for.
+        self._auth_header: str | None = None
+        self._auth_origin: tuple[str | None, str | None, int | None] | None = None
         if username is not None:
             # No escaping needed: ":" is not allowed in username:
             # https://tools.ietf.org/html/rfc2617#section-2
@@ -5159,7 +5165,8 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
             import urllib3.util
 
             basic_auth = urllib3.util.make_headers(basic_auth=credentials)
-            self.pool_manager.headers.update(basic_auth)  # type: ignore
+            self._auth_header = basic_auth["authorization"]
+            self._auth_origin = self._origin(base_url)
 
         self.config = config
 
@@ -5173,6 +5180,21 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
             username=username,
             password=password,
         )
+
+    @staticmethod
+    def _origin(url: str) -> tuple[str | None, str | None, int | None]:
+        """Return the (scheme, host, port) origin of a URL.
+
+        Implicit default ports are resolved to their explicit value so that
+        e.g. ``https://example/`` and ``https://example:443/`` compare equal,
+        matching urllib3's own same-host check.
+        """
+        from urllib3.connection import port_by_scheme
+        from urllib3.util import parse_url
+
+        parsed = parse_url(url)
+        port = parsed.port or port_by_scheme.get(parsed.scheme or "")
+        return (parsed.scheme, parsed.host, port)
 
     def _get_url(self, path: str | bytes) -> str:
         if not isinstance(path, str):
@@ -5194,6 +5216,15 @@ class Urllib3HttpGitClient(AbstractHttpGitClient):
         if headers is not None:
             req_headers.update(headers)
         req_headers["Pragma"] = "no-cache"
+        # Only attach credentials to requests for the origin they were
+        # configured for. A redirect can rebase the target URL to a different
+        # origin; sending the credentials there would disclose them to a host
+        # they were never configured for.
+        if self._auth_header is not None:
+            if self._origin(url) == self._auth_origin:
+                req_headers["authorization"] = self._auth_header
+            else:
+                req_headers.pop("authorization", None)
 
         try:
             request_kwargs = {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1649,7 +1649,7 @@ class HttpGitClientTests(TestCase):
         self.assertEqual("user", c._username)
         self.assertEqual("passwd", c._password)
 
-        basic_auth = c.pool_manager.headers["authorization"]
+        basic_auth = c._auth_header
         auth_string = "{}:{}".format("user", "passwd")
         b64_credentials = base64.b64encode(auth_string.encode("latin1"))
         expected_basic_auth = "Basic {}".format(b64_credentials.decode("latin1"))
@@ -1662,7 +1662,7 @@ class HttpGitClientTests(TestCase):
         self.assertEqual("user", c._username)
         self.assertIsNone(c._password)
 
-        basic_auth = c.pool_manager.headers["authorization"]
+        basic_auth = c._auth_header
         auth_string = b"user:"
         b64_credentials = base64.b64encode(auth_string)
         expected_basic_auth = f"Basic {b64_credentials.decode('ascii')}"
@@ -1684,7 +1684,7 @@ class HttpGitClientTests(TestCase):
         self.assertEqual(c._username, username)
         self.assertEqual(c._password, None)
 
-        basic_auth = c.pool_manager.headers["authorization"]
+        basic_auth = c._auth_header
         auth_string = username.encode("ascii") + b":"
         b64_credentials = base64.b64encode(auth_string)
         expected_basic_auth = f"Basic {b64_credentials.decode('ascii')}"
@@ -1703,7 +1703,7 @@ class HttpGitClientTests(TestCase):
         self.assertEqual(original_username, c._username)
         self.assertEqual(original_password, c._password)
 
-        basic_auth = c.pool_manager.headers["authorization"]
+        basic_auth = c._auth_header
         auth_string = f"{original_username}:{original_password}"
         b64_credentials = base64.b64encode(auth_string.encode("latin1"))
         expected_basic_auth = "Basic {}".format(b64_credentials.decode("latin1"))
@@ -1812,6 +1812,91 @@ class HttpGitClientTests(TestCase):
             else:
                 # check also the no redirection case
                 self.assertEqual(processed_url, base_url)
+
+    def test_credentials_scoped_to_origin(self) -> None:
+        # Credentials configured for the original host must not be sent to a
+        # different origin that a redirect rebased the request onto.
+        from urllib3.response import HTTPResponse
+
+        tail = "info/refs?service=git-upload-pack"
+        refs_data = (
+            b"001e# service=git-upload-pack\n00000032"
+            b"fb2bebf4919a011f0fd7cec085443d0031228e76 HEAD\n0000"
+        )
+
+        class PoolManagerMock:
+            def __init__(self, redirect_location) -> None:
+                self.headers: dict[str, str] = {}
+                self._redirect_location = redirect_location
+                self.requests: list[tuple[str, dict]] = []
+
+            def request(
+                self,
+                method,
+                url,
+                fields=None,
+                headers=None,
+                redirect=True,
+                preload_content=True,
+                **kwargs,
+            ):
+                self.requests.append((url, dict(headers or {})))
+                if method == "POST":
+                    body = b"0000"
+                    content_type = "application/x-git-upload-pack-result"
+                    request_url = url
+                else:
+                    body = refs_data
+                    content_type = "application/x-git-upload-pack-advertisement"
+                    # urllib3 follows the redirect itself; the response's URL
+                    # reflects the final (redirected) location.
+                    request_url = self._redirect_location
+                return HTTPResponse(
+                    body=BytesIO(body),
+                    headers={"Content-Type": content_type},
+                    request_method=method,
+                    request_url=request_url,
+                    preload_content=preload_content,
+                    status=200,
+                )
+
+        base_url = "https://example.com/repo.git/"
+
+        def auth_header(req_headers):
+            for key, value in req_headers.items():
+                if key.lower() == "authorization":
+                    return value
+            return None
+
+        # Cross-origin redirect: the request that lands on the other origin
+        # must not carry the credentials.
+        pm = PoolManagerMock("https://other.example/repo.git/" + tail)
+        c = HttpGitClient(base_url, pool_manager=pm, username="user", password="secret")
+        c._discover_references(b"git-upload-pack", base_url)
+        # The follow-up smart request POSTs to the rebased origin.
+        c._smart_request("git-upload-pack", "https://other.example/repo.git/", b"0000")
+        other_origin_requests = [
+            (url, hdrs) for url, hdrs in pm.requests if "other.example" in url
+        ]
+        self.assertNotEqual([], other_origin_requests)
+        for url, hdrs in other_origin_requests:
+            self.assertIsNone(auth_header(hdrs), url)
+
+        # Same-origin redirect (path only): credentials are retained.
+        pm = PoolManagerMock("https://example.com/other.git/" + tail)
+        c = HttpGitClient(base_url, pool_manager=pm, username="user", password="secret")
+        c._discover_references(b"git-upload-pack", base_url)
+        for url, hdrs in pm.requests:
+            self.assertEqual("Basic dXNlcjpzZWNyZXQ=", auth_header(hdrs), url)
+
+        # Implicit vs explicit default port is the same origin.
+        pm = PoolManagerMock("https://example.com:443/repo.git/" + tail)
+        c = HttpGitClient(base_url, pool_manager=pm, username="user", password="secret")
+        c._smart_request(
+            "git-upload-pack", "https://example.com:443/repo.git/", b"0000"
+        )
+        for url, hdrs in pm.requests:
+            self.assertEqual("Basic dXNlcjpzZWNyZXQ=", auth_header(hdrs), url)
 
     def test_smart_request_content_type_with_directive_check(self) -> None:
         from urllib3.response import HTTPResponse


### PR DESCRIPTION
A server-controlled redirect from info/refs rebases base_url onto the redirect target, and the follow-up smart request is then sent to that origin. With the configured basic-auth stored on the pool manager, those credentials were attached to every request, including ones bound for an origin reached only via redirect.

Stop storing the credentials on the pool manager. Remember them together with the origin of base_url, and attach them in _http_request only when the request target shares that origin. Default ports are normalised so that an explicit :443/:80 matches the implicit form, mirroring urllib3's own same-host check.

Originally reported in https://github.com/jelmer/dulwich/pull/2201