### PR TITLE
index: Honor core.protectNTFS on all work-tree updates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,13 @@
+1.2.6	UNRELEASED
+
+ * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all
+   work-tree updates. The 1.2.5 path hardening (CVE-2026-42305) only
+   reached ``checkout`` and ``reset``; ``update_working_tree`` (used by
+   ``merge``, ``pull`` and others) fell back to the default validator, so
+   a crafted branch could still check out an NTFS-unsafe name such as
+   ``git~2`` even with ``core.protectNTFS=true``.
+   (Jelmer Vernooĳ; reported by donovan-jasper)
+
 1.2.5	2026-05-28
 
  * SECURITY(GHSA-gfhv-vqv2-4544): Validate submodule paths in

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,12 @@
    ``git~2`` even with ``core.protectNTFS=true``.
    (Jelmer Vernooĳ; reported by donovan-jasper)
 
+ * Remove the ``force_remove_untracked`` argument from
+   ``index.update_working_tree``. It had been a no-op since the function
+   was rewritten to apply changes from a diff iterator, and removing
+   untracked files is not part of ``reset --hard`` semantics.
+   (Jelmer Vernooĳ)
+
 1.2.5	2026-05-28
 
  * SECURITY(GHSA-gfhv-vqv2-4544): Validate submodule paths in

--- a/dulwich/am.py
+++ b/dulwich/am.py
@@ -290,7 +290,6 @@ def _reset_worktree_to_tree(
         index_tree_id,
         target_tree_id,
         change_iterator=changes,
-        force_remove_untracked=True,
         allow_overwrite_modified=True,
         config=config,
     )

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -2786,6 +2786,13 @@ def update_working_tree(
         CHANGE_UNCHANGED,
     )
 
+    if force_remove_untracked:
+        import warnings
+
+        warnings.warn(
+            "force_remove_untracked is a no-op and will be removed in a future release",
+            DeprecationWarning,
+        )
     repo_path = repo.path if isinstance(repo.path, bytes) else repo.path.encode()
     if config is None:
         config = repo.get_config_stack()

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -2763,7 +2763,9 @@ def update_working_tree(
       new_tree_id: SHA of the tree to update to
       change_iterator: Iterator of TreeChange objects to apply
       honor_filemode: An optional flag to honor core.filemode setting
-      validate_path_element: Function to validate path elements to check out
+      validate_path_element: Function to validate path elements to check out.
+        If None, derived from ``config`` so that ``core.protectNTFS`` and
+        ``core.protectHFS`` are honored by default.
       symlink_fn: Function to use for creating symlinks
       force_remove_untracked: If True, remove files that exist in working
         directory but not in target tree, even if old_tree_id is None
@@ -2775,9 +2777,6 @@ def update_working_tree(
       config: Repository configuration. If None, falls back to
         ``repo.get_config_stack()``.
     """
-    if validate_path_element is None:
-        validate_path_element = validate_path_element_default
-
     from .diff_tree import (
         CHANGE_ADD,
         CHANGE_COPY,
@@ -2790,6 +2789,13 @@ def update_working_tree(
     repo_path = repo.path if isinstance(repo.path, bytes) else repo.path.encode()
     if config is None:
         config = repo.get_config_stack()
+
+    if validate_path_element is None:
+        # Derive the validator from config so callers cannot accidentally
+        # skip ``core.protectNTFS``/``core.protectHFS`` enforcement by
+        # omitting this argument.
+        validate_path_element = get_path_element_validator(config)
+
     index = repo.open_index(config=config)
 
     # Convert iterator to list since we need multiple passes

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -2876,7 +2876,6 @@ def reset(
                 honor_filemode=honor_filemode,
                 validate_path_element=validate_path_element,
                 symlink_fn=symlink_fn,
-                force_remove_untracked=True,
                 blob_normalizer=blob_normalizer,
                 allow_overwrite_modified=True,  # Allow overwriting modified files,
                 config=r.get_config_stack(),
@@ -5462,7 +5461,7 @@ def _perform_tree_switch(
       repo: Repository object
       current_tree_id: Current tree ID (or None for empty repo)
       target_tree_id: Target tree ID to switch to
-      force: If True, force removal of untracked files and allow overwriting modified files
+      force: If True, allow overwriting modified files
     """
     honor_filemode, validate_path_element, symlink_fn = _get_worktree_update_config(
         repo
@@ -5484,7 +5483,6 @@ def _perform_tree_switch(
         honor_filemode=honor_filemode,
         validate_path_element=validate_path_element,
         symlink_fn=symlink_fn,
-        force_remove_untracked=force,
         blob_normalizer=blob_normalizer,
         allow_overwrite_modified=force,
         config=config,

--- a/tests/porcelain/test_merge.py
+++ b/tests/porcelain/test_merge.py
@@ -23,11 +23,12 @@
 
 import importlib.util
 import os
+import stat
 import tempfile
 import unittest
 
 from dulwich import porcelain
-from dulwich.objects import ZERO_SHA
+from dulwich.objects import ZERO_SHA, Blob, Commit, Tree
 from dulwich.repo import Repo
 
 from .. import DependencyMissing, TestCase
@@ -477,6 +478,49 @@ class PorcelainMergeTests(TestCase):
             with Repo(tmpdir) as repo:
                 commit = repo[merge_commit]
                 self.assertEqual(len(commit.parents), 2)
+
+    def _commit_tree(self, repo, tree, parents):
+        repo.object_store.add_object(tree)
+        commit = Commit()
+        commit.tree = tree.id
+        commit.parents = parents
+        commit.author = commit.committer = b"Test <test@example.com>"
+        commit.author_time = commit.commit_time = 1
+        commit.author_timezone = commit.commit_timezone = 0
+        commit.message = b"test"
+        repo.object_store.add_object(commit)
+        return commit.id
+
+    def test_merge_rejects_ntfs_dotgit_alias(self):
+        """A fast-forward merge honors core.protectNTFS for the new tree."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Repo.init(tmpdir) as repo:
+                repo.get_config().set((b"core",), b"protectNTFS", b"true")
+                repo.get_config().write_to_path()
+
+                blob = Blob.from_string(b"base\n")
+                repo.object_store.add_object(blob)
+                base_tree = Tree()
+                base_tree.add(b"ok.txt", stat.S_IFREG | 0o644, blob.id)
+                base = self._commit_tree(repo, base_tree, [])
+                repo.refs[b"refs/heads/master"] = base
+                repo.refs.set_symbolic_ref(b"HEAD", b"refs/heads/master")
+                repo.get_worktree().reset_index(base_tree.id)
+
+                payload = Blob.from_string(b"payload\n")
+                repo.object_store.add_object(payload)
+                attack_tree = Tree()
+                attack_tree.add(b"ok.txt", stat.S_IFREG | 0o644, blob.id)
+                # ``git~2`` is an NTFS 8.3 short-name alias for ``.git``.
+                attack_tree.add(b"git~2", stat.S_IFREG | 0o755, payload.id)
+                attack = self._commit_tree(repo, attack_tree, [base])
+
+                porcelain.merge(repo, attack)
+
+                self.assertFalse(
+                    os.path.exists(os.path.join(tmpdir, "git~2")),
+                    "merge materialized an NTFS .git alias despite protectNTFS",
+                )
 
 
 class PorcelainMergeTreeTests(TestCase):


### PR DESCRIPTION
The NTFS/HFS path hardening added in 1.2.5 (CVE-2026-42305) only reached checkout and reset. update_working_tree, the shared helper used by merge, pull, cherry-pick, revert and bisect, defaulted validate_path_element to validate_path_element_default when callers omitted it, which only refuses .git, . and ..

Derive the validator from config when the caller passes none, so the protective default cannot be bypassed by omission. Adds a regression test driving porcelain.merge with a git~2 entry under protectNTFS.

Reported-by: donovan-jasper