### PR TITLE
don't expand config includes when parsing .gitmodules

### DIFF
--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -1001,6 +1001,7 @@ class ConfigFile(ConfigDict):
         max_include_depth: int = DEFAULT_MAX_INCLUDE_DEPTH,
         file_opener: FileOpener | None = None,
         condition_matchers: Mapping[str, ConditionMatcher] | None = None,
+        expand_includes: bool = True,
     ) -> "ConfigFile":
         """Read configuration from a file-like object.
 
@@ -1012,6 +1013,9 @@ class ConfigFile(ConfigDict):
             max_include_depth: Maximum allowed include depth
             file_opener: Optional callback to open included files
             condition_matchers: Optional dict of condition matchers for includeIf
+            expand_includes: Whether to honor include/includeIf directives. Set
+                to False when parsing untrusted config (e.g. .gitmodules) to
+                avoid following include.path to arbitrary files.
         """
         if include_depth > max_include_depth:
             # Prevent excessive recursion
@@ -1055,16 +1059,17 @@ class ConfigFile(ConfigDict):
                     ret._values[section][setting] = value
 
                     # Process include/includeIf directives
-                    ret._handle_include_directive(
-                        section,
-                        setting,
-                        value,
-                        config_dir=config_dir,
-                        include_depth=include_depth,
-                        max_include_depth=max_include_depth,
-                        file_opener=file_opener,
-                        condition_matchers=condition_matchers,
-                    )
+                    if expand_includes:
+                        ret._handle_include_directive(
+                            section,
+                            setting,
+                            value,
+                            config_dir=config_dir,
+                            include_depth=include_depth,
+                            max_include_depth=max_include_depth,
+                            file_opener=file_opener,
+                            condition_matchers=condition_matchers,
+                        )
 
                     setting = None
             else:  # continuation line
@@ -1081,16 +1086,17 @@ class ConfigFile(ConfigDict):
                     ret._values[section][setting] = value
 
                     # Process include/includeIf directives
-                    ret._handle_include_directive(
-                        section,
-                        setting,
-                        value,
-                        config_dir=config_dir,
-                        include_depth=include_depth,
-                        max_include_depth=max_include_depth,
-                        file_opener=file_opener,
-                        condition_matchers=condition_matchers,
-                    )
+                    if expand_includes:
+                        ret._handle_include_directive(
+                            section,
+                            setting,
+                            value,
+                            config_dir=config_dir,
+                            include_depth=include_depth,
+                            max_include_depth=max_include_depth,
+                            file_opener=file_opener,
+                            condition_matchers=condition_matchers,
+                        )
 
                     continuation = None
                     setting = None
@@ -1313,6 +1319,7 @@ class ConfigFile(ConfigDict):
         max_include_depth: int = DEFAULT_MAX_INCLUDE_DEPTH,
         file_opener: FileOpener | None = None,
         condition_matchers: Mapping[str, ConditionMatcher] | None = None,
+        expand_includes: bool = True,
     ) -> "ConfigFile":
         """Read configuration from a file on disk.
 
@@ -1321,6 +1328,9 @@ class ConfigFile(ConfigDict):
             max_include_depth: Maximum allowed include depth
             file_opener: Optional callback to open included files
             condition_matchers: Optional dict of condition matchers for includeIf
+            expand_includes: Whether to honor include/includeIf directives. Set
+                to False when parsing untrusted config (e.g. .gitmodules) to
+                avoid following include.path to arbitrary files.
         """
         abs_path = os.fspath(path)
         config_dir = os.path.dirname(abs_path)
@@ -1341,6 +1351,7 @@ class ConfigFile(ConfigDict):
                 max_include_depth=max_include_depth,
                 file_opener=file_opener,
                 condition_matchers=condition_matchers,
+                expand_includes=expand_includes,
             )
             ret.path = abs_path
             return ret
@@ -1638,7 +1649,11 @@ def read_submodules(
     path: str | os.PathLike[str],
 ) -> Iterator[tuple[bytes, bytes, bytes]]:
     """Read a .gitmodules file."""
-    cfg = ConfigFile.from_path(path)
+    # .gitmodules is attacker-controlled in any cloned tree; do not expand
+    # include/includeIf directives so a hostile file cannot make us open and
+    # parse arbitrary paths on disk. This matches git, which parses submodule
+    # config with includes disabled.
+    cfg = ConfigFile.from_path(path, expand_includes=False)
     return parse_submodules(cfg)
 
 
@@ -1652,6 +1667,10 @@ def parse_submodules(config: ConfigFile) -> Iterator[tuple[bytes, bytes, bytes]]
         where name is quoted part of the section's name.
     """
     for section in config.sections():
+        if len(section) != 2:
+            # Sections without a subsection name (e.g. a stray [include])
+            # cannot be submodule entries; skip rather than crash.
+            continue
         section_kind, section_name = section
         if section_kind == b"submodule":
             try:

--- a/dulwich/porcelain/submodule.py
+++ b/dulwich/porcelain/submodule.py
@@ -61,7 +61,7 @@ def submodule_add(
         # TODO(jelmer): Move this logic to dulwich.submodule
         gitmodules_path = os.path.join(r.path, ".gitmodules")
         try:
-            config = ConfigFile.from_path(gitmodules_path)
+            config = ConfigFile.from_path(gitmodules_path, expand_includes=False)
         except FileNotFoundError:
             config = ConfigFile()
             config.path = gitmodules_path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,7 @@ from dulwich.config import (
     env_config,
     get_git_proxy_command,
     parse_submodules,
+    read_submodules,
 )
 
 from . import TestCase
@@ -468,6 +469,23 @@ who\"
 
             cf = ConfigFile.from_path(main_path)
             self.assertEqual(b"true", cf.get((b"core",), b"bare"))
+
+    def test_expand_includes_disabled(self) -> None:
+        """include directives are ignored when expand_includes=False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = os.path.realpath(tmpdir)
+
+            included_path = os.path.join(tmpdir, "included.config")
+            with open(included_path, "wb") as f:
+                f.write(b"[core]\n    bare = true\n")
+
+            main_path = os.path.join(tmpdir, "main.config")
+            with open(main_path, "wb") as f:
+                escaped_path = included_path.replace("\\", "\\\\")
+                f.write(f"[include]\n    path = {escaped_path}\n".encode())
+
+            cf = ConfigFile.from_path(main_path, expand_includes=False)
+            self.assertRaises(KeyError, cf.get, (b"core",), b"bare")
 
     def test_includeif_hasconfig(self) -> None:
         """Test includeIf with hasconfig conditions."""
@@ -1293,6 +1311,30 @@ class SubmodulesTests(TestCase):
             ],
             got,
         )
+
+    def test_parse_submodules_skips_sectionless_include(self) -> None:
+        cf = ConfigFile.from_file(
+            BytesIO(
+                b"[submodule \"a\"]\n\tpath = a\n\turl = ./a\n[include]\n\tpath = x\n"
+            ),
+            expand_includes=False,
+        )
+        self.assertEqual([(b"a", b"./a", b"a")], list(parse_submodules(cf)))
+
+    def test_read_submodules_ignores_includes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir = os.path.realpath(tmpdir)
+            with open(os.path.join(tmpdir, "evil.config"), "wb") as f:
+                f.write(b'[submodule "leaked"]\n\tpath = p\n\turl = file:///\n')
+            gitmodules = os.path.join(tmpdir, ".gitmodules")
+            with open(gitmodules, "wb") as f:
+                f.write(
+                    b'[submodule "real"]\n\tpath = sub\n\turl = ./sub\n'
+                    b"[include]\n\tpath = evil.config\n"
+                )
+            self.assertEqual(
+                [(b"sub", b"./sub", b"real")], list(read_submodules(gitmodules))
+            )
 
 
 class ApplyInsteadOfTests(TestCase):


### PR DESCRIPTION
read_submodules parses the untrusted .gitmodules of a cloned tree with config includes enabled, so a hostile `[include] path` makes dulwich open and parse arbitrary files during `clone --recurse-submodules`; disable include expansion there, like git does.