### PR TITLE
honor protectNTFS in cone_mode_disable and filter-branch checkouts

### DIFF
--- a/dulwich/filter_branch.py
+++ b/dulwich/filter_branch.py
@@ -33,7 +33,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from typing import TypedDict
 
-from .index import Index, build_index_from_tree
+from .index import Index, build_index_from_tree, validate_path_element_ntfs
 from .object_store import BaseObjectStore
 from .objects import Commit, ObjectID, Tag, Tree
 from .refs import Ref, RefsContainer, local_tag_name
@@ -209,7 +209,13 @@ class CommitFilter:
 
         try:
             # Build index from tree
-            build_index_from_tree(".", tmp_index_path, self.object_store, tree_sha)
+            build_index_from_tree(
+                ".",
+                tmp_index_path,
+                self.object_store,
+                tree_sha,
+                validate_path_element=validate_path_element_ntfs,
+            )
 
             # Run index filter
             new_tree_sha = self.index_filter(tree_sha, tmp_index_path)

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -6204,13 +6204,14 @@ def cone_mode_disable(repo: str | os.PathLike[str] | Repo, force: bool = False) 
         commit = repo_obj[repo_obj.head()]
         assert isinstance(commit, Commit)
 
-        from ..index import build_index_from_tree
+        from ..index import build_index_from_tree, get_path_element_validator
 
         build_index_from_tree(
             repo_obj.path,
             repo_obj.index_path(),
             repo_obj.object_store,
             commit.tree,
+            validate_path_element=get_path_element_validator(config),
         )
 
 


### PR DESCRIPTION
cone_mode_disable and filter-branch's index_filter called build_index_from_tree without a path validator, so an NTFS-unsafe entry like git~2 could escape checks on checkout; pass the configured validator.