### PR TITLE
contain loose ref names within the ref store in refpath

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -944,7 +944,18 @@ class DiskRefsContainer(RefsContainer):
             path = path.replace(b"/", os.fsencode(os.path.sep))
 
         root_dir = self.worktree_path if is_per_worktree_ref(name) else self.path
-        return os.path.join(root_dir, path)
+        filename = os.path.join(root_dir, path)
+        # A ref name containing ".." or an absolute path would resolve outside
+        # the ref store. The write paths guard against this via _check_refname,
+        # but lookups (read_loose_ref, follow's resolved symref target,
+        # git-upload-archive's "argument") do not, so enforce containment here.
+        normalized = os.path.normpath(filename)
+        root_norm = os.path.normpath(root_dir)
+        if normalized != root_norm and not normalized.startswith(
+            root_norm + os.fsencode(os.path.sep)
+        ):
+            raise RefFormatError(name)
+        return filename
 
     def get_packed_refs(self) -> dict[Ref, ObjectID]:
         """Get contents of the packed-refs file.
@@ -1051,8 +1062,8 @@ class DiskRefsContainer(RefsContainer):
         Raises:
           IOError: if any other error occurs
         """
-        filename = self.refpath(name)
         try:
+            filename = self.refpath(name)
             with GitFile(filename, "rb") as f:
                 header = f.read(len(SYMREF))
                 if header == SYMREF:
@@ -1063,7 +1074,7 @@ class DiskRefsContainer(RefsContainer):
                     f.seek(0)
                     line = f.readline().rstrip(b"\r\n")
                     return line
-        except (OSError, UnicodeError):
+        except (OSError, UnicodeError, RefFormatError):
             # don't assume anything specific about the error; in
             # particular, invalid or forbidden paths can raise weird
             # errors depending on the specific operating system

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -504,6 +504,20 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
             b"42d06bd4b77fed026b154d16493e5deab78f02ec",
         )
 
+    def test_refpath_escape(self) -> None:
+        # A ref name must not be able to address a file outside the ref store.
+        self.assertRaises(
+            errors.RefFormatError, self._refs.refpath, b"../../../etc/passwd"
+        )
+        self.assertRaises(errors.RefFormatError, self._refs.refpath, b"/etc/passwd")
+
+    def test_read_loose_ref_escape(self) -> None:
+        outside = os.path.join(os.path.dirname(self._repo.path), "secret")
+        with open(outside, "wb") as f:
+            f.write(b"42d06bd4b77fed026b154d16493e5deab78f02ec\n")
+        self.assertEqual(None, self._refs.read_loose_ref(b"../secret"))
+        self.assertRaises(KeyError, lambda: self._refs[b"../secret"])
+
     def test_delete_refs_container(self) -> None:
         # We shouldn't delete the refs directory
         self._refs[b"refs/heads/blah"] = b"42d06bd4b77fed026b154d16493e5deab78f02ec"


### PR DESCRIPTION
Loose ref names reach DiskRefsContainer.refpath from lookups that skip the validation the write paths get (_check_refname): read_loose_ref, follow's resolved symref target, and git-upload-archive's client-supplied `argument` in server.py. os.path.join honors `..` and absolute names, so resolving a name like `../../secret` reads a file outside the ref store and hands back its first line as the ref value. Enforce containment in refpath so every read and write site is covered at the one chokepoint.