### PR TITLE
validate pack names from dumb HTTP info/packs

### DIFF
--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -27,6 +27,7 @@ __all__ = [
 ]
 
 import os
+import re
 import tempfile
 import zlib
 from collections.abc import Callable, Iterator, Mapping, Sequence
@@ -54,6 +55,10 @@ from .objects import (
 from .pack import Pack, PackData, PackIndex, UnpackedObject, load_pack_index_file
 from .protocol import split_peeled_refs
 from .refs import Ref, read_info_refs
+
+# Pack names advertised by a remote may only be of the form git uses,
+# pack-<hash>, with a 40 (SHA-1) or 64 (SHA-256) hex digit name.
+_PACK_NAME_RE = re.compile(r"pack-[0-9a-f]{40}(?:[0-9a-f]{24})?\Z")
 
 
 class DumbHTTPObjectStore(BaseObjectStore):
@@ -190,6 +195,12 @@ class DumbHTTPObjectStore(BaseObjectStore):
                     pack_name = pack_name.split("/")[-1]
                 if pack_name.endswith(".pack"):
                     pack_name = pack_name[:-5]  # Remove .pack extension
+                # The name is server-controlled and is interpolated into both
+                # request URLs and a local temp path, so only accept the
+                # pack-<hash> form git uses; otherwise "/"-stripping still lets
+                # e.g. backslash-separated names escape the temp dir on Windows.
+                if not _PACK_NAME_RE.match(pack_name):
+                    continue
                 self._packs.append((pack_name, None))
 
     def _get_pack_index(self, pack_name: str) -> PackIndex:

--- a/tests/test_dumb.py
+++ b/tests/test_dumb.py
@@ -152,6 +152,24 @@ P pack-abcdef1234567890abcdef1234567890abcdef12.pack
             "pack-abcdef1234567890abcdef1234567890abcdef12", self.store._packs[1][0]
         )
 
+    def test_load_packs_rejects_traversal_names(self) -> None:
+        # The pack name is server-controlled and ends up in a local temp
+        # path; only the pack-<hash> form git uses must be accepted. A
+        # backslash-separated name is not split on "/" and would escape the
+        # temp dir on Windows, so it must be dropped.
+        packs_content = (
+            b"P ..\\..\\..\\..\\evil.pack\n"
+            b"P pack-1234567890abcdef1234567890abcdef12345678.pack\n"
+            b"P not-a-pack.pack\n"
+        )
+        self._add_response("objects/info/packs", packs_content)
+
+        self.store._load_packs()
+        self.assertEqual(
+            [("pack-1234567890abcdef1234567890abcdef12345678", None)],
+            self.store._packs,
+        )
+
     def test_get_raw_from_cache(self) -> None:
         sha = b"1" * 40
         self.store._cached_objects[sha] = (Blob.type_num, b"cached content")


### PR DESCRIPTION
The dumb HTTP object store takes pack names straight from the remote's objects/info/packs and interpolates them into both request URLs and a local temp path it writes the downloaded pack to. The only sanitising there strips a leading directory with split("/")[-1], which misses backslashes, so a server advertising `P ..\..\..\evil.pack` escapes the temp dir and writes an arbitrary file on Windows. Restrict the parsed names to git's pack-<hash> form in _load_packs, the single point feeding the index and pack fetches.