### PR TITLE
Fix apply_patch writing index entries with mode 0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,10 @@
    ``git range-diff``. Requires the ``munkres`` package, installable via the
    ``dulwich[range_diff]`` extra. (Jelmer Vernooĳ, #1828)
 
+ * Fix ``apply_patch`` writing index entries with mode ``0``, which made
+   native git abort with ``unsupported ce_mode: 0``. The file mode is now
+   derived from the work-tree file. (Jelmer Vernooĳ, #2218)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -1470,7 +1470,7 @@ def _apply_rename_or_copy(
 
     if not cached and os.path.exists(dst_fs_path):
         st = os.stat(dst_fs_path)
-        entry = index_entry_from_stat(st, blob.id, 0)
+        entry = index_entry_from_stat(st, blob.id)
     else:
         entry = IndexEntry(
             ctime=(0, 0),
@@ -1634,7 +1634,7 @@ def apply_patches(
 
                 if not cached and os.path.exists(fs_path):
                     st = os.stat(fs_path)
-                    entry = index_entry_from_stat(st, blob.id, 0)
+                    entry = index_entry_from_stat(st, blob.id)
                 else:
                     entry = IndexEntry(
                         ctime=(0, 0),
@@ -1803,7 +1803,7 @@ def apply_patches(
             # Get file stat for index entry
             if not cached and os.path.exists(fs_path):
                 st = os.stat(fs_path)
-                entry = index_entry_from_stat(st, blob.id, 0)
+                entry = index_entry_from_stat(st, blob.id)
             else:
                 # Create a minimal index entry for cached-only changes
                 entry = IndexEntry(

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -12488,6 +12488,11 @@ index 1234567..abcdefg 100644
             result = f.read()
         self.assertEqual(result, b"line 1\nline two\nline 3\n")
 
+        # The index entry must keep a valid file mode, otherwise native git
+        # aborts with "unsupported ce_mode: 0" (see issue #2218).
+        index = self.repo.open_index()
+        self.assertEqual(index[b"test.txt"].mode, 0o100644)
+
     def test_apply_new_file(self) -> None:
         """Test applying a patch that creates a new file."""
         # Create an initial commit with a dummy file


### PR DESCRIPTION
apply_patches passed 0 as the third positional argument to index_entry_from_stat, whose signature is (stat_val, hex_sha, mode=None). That set mode=0 instead of deriving it from the work-tree file, so native git aborted with "unsupported ce_mode: 0" when reading the index.

Fixes #2218