### PR TITLE
match credential url paths on segment boundaries

### DIFF
--- a/dulwich/credentials.py
+++ b/dulwich/credentials.py
@@ -55,7 +55,11 @@ def match_urls(url: ParseResult, url_prefix: ParseResult) -> bool:
         and url.port == url_prefix.port
     )
     user_match = url.username == url_prefix.username if url_prefix.username else True
-    path_match = url.path.rstrip("/").startswith(url_prefix.path.rstrip())
+    # Match the path on path-segment boundaries, like git's urlmatch: a config
+    # path scopes the entry to that path and anything below it, so "/foo"
+    # matches "/foo" and "/foo/bar" but not "/foobar".
+    prefix_path = url_prefix.path.rstrip("/")
+    path_match = url.path == prefix_path or url.path.startswith(prefix_path + "/")
     return base_match and user_match and path_match
 
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -45,6 +45,19 @@ class TestCredentialHelpersUtils(TestCase):
         non_matching = urlparse("https://git.sr.ht/")
         self.assertFalse(match_urls(url, non_matching))
 
+    def test_match_urls_path_boundary(self) -> None:
+        prefix = urlparse("https://example.com/private")
+        self.assertTrue(match_urls(urlparse("https://example.com/private"), prefix))
+        self.assertTrue(
+            match_urls(urlparse("https://example.com/private/repo"), prefix)
+        )
+        # A sibling path that merely shares a string prefix must not match,
+        # otherwise path-scoped credentials leak to it.
+        self.assertFalse(
+            match_urls(urlparse("https://example.com/private-evil"), prefix)
+        )
+        self.assertFalse(match_urls(urlparse("https://example.com/priv"), prefix))
+
     def test_match_partial_url(self) -> None:
         url = urlparse("https://github.com/jelmer/dulwich/")
         self.assertTrue(match_partial_url(url, "github.com"))


### PR DESCRIPTION
1. match_urls compares the path with url.path.startswith(url_prefix.path), so a config entry scoped to a path also matches any sibling path that merely shares the string prefix (https://host/private matches a request to https://host/private-evil).
2. this picks which [credential "url"] and [http "url"] sections apply, and http.<url>.extraHeader usually holds an Authorization token, so a path-scoped secret gets sent to a different path on the same host.
Switched the path check to segment boundaries like git's urlmatch, so a config path matches only itself and paths below it. Existing match_urls cases still pass; added a boundary test.