### PR TITLE
match signature key ids on fingerprint suffix

### DIFF
--- a/dulwich/signature.py
+++ b/dulwich/signature.py
@@ -471,10 +471,13 @@ class GPGCliSignatureVendor(SignatureSigner, SignatureVerifier):
                 # Check each signing key against trusted keyids
                 for signed_by in signing_keys:
                     signed_by_normalized = signed_by.replace(" ", "").upper()
-                    # Check if signed_by matches or is a suffix of any trusted keyid
-                    # (GPG sometimes shows short key IDs)
+                    # A key ID is the trailing hex of a fingerprint, so the
+                    # shorter value must be a suffix of the longer one. Plain
+                    # substring matching would accept a key whose fingerprint
+                    # merely contains the trusted ID somewhere in the middle.
                     if any(
-                        signed_by_normalized in keyid or keyid in signed_by_normalized
+                        signed_by_normalized.endswith(keyid)
+                        or keyid.endswith(signed_by_normalized)
                         for keyid in keyids_normalized
                     ):
                         return
@@ -639,8 +642,12 @@ class X509SignatureVendor(SignatureSigner, SignatureVerifier):
 
                 for signed_by in signing_certs:
                     signed_by_normalized = signed_by.replace(" ", "").upper()
+                    # A key ID is the trailing hex of a fingerprint, so the
+                    # shorter value must be a suffix of the longer one rather
+                    # than appearing anywhere inside it.
                     if any(
-                        signed_by_normalized in keyid or keyid in signed_by_normalized
+                        signed_by_normalized.endswith(keyid)
+                        or keyid.endswith(signed_by_normalized)
                         for keyid in keyids_normalized
                     ):
                         return

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -311,6 +311,49 @@ class GPGCliSignatureVendorTests(unittest.TestCase):
         self.assertIsInstance(result, bool)
 
 
+class KeyIDMatchingTests(unittest.TestCase):
+    """Tests for trusted key ID matching, independent of an installed gpg."""
+
+    def _run_with_stderr(self, vendor, stderr: str) -> None:
+        from unittest import mock
+
+        completed = subprocess.CompletedProcess(
+            ["gpg"], 0, stdout=b"", stderr=stderr.encode()
+        )
+        with mock.patch("subprocess.run", return_value=completed):
+            vendor.verify(b"data", b"signature")
+
+    def test_gpg_rejects_keyid_embedded_in_fingerprint(self) -> None:
+        """A trusted ID buried inside an untrusted fingerprint is not a match."""
+        from dulwich.signature import UntrustedSignature
+
+        vendor = GPGCliSignatureVendor(keyids=["DEADBEEF"])
+        stderr = (
+            "gpg: Good signature\n"
+            "Primary key fingerprint: 1111 1111 1111 1111 1111  "
+            "1111 1111 DEAD BEEF 1111\n"
+        )
+        with self.assertRaises(UntrustedSignature):
+            self._run_with_stderr(vendor, stderr)
+
+    def test_gpg_accepts_short_keyid_suffix(self) -> None:
+        """A short key ID reported by gpg matches a trusted full fingerprint."""
+        trusted = "AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555"
+        vendor = GPGCliSignatureVendor(keyids=[trusted])
+        stderr = f"gpg: Good signature\ngpg: using RSA key {trusted[-16:]}\n"
+        # Should not raise.
+        self._run_with_stderr(vendor, stderr)
+
+    def test_x509_rejects_keyid_embedded_in_fingerprint(self) -> None:
+        """Same suffix rule applies to the gpgsm/X.509 path."""
+        from dulwich.signature import UntrustedSignature, X509SignatureVendor
+
+        vendor = X509SignatureVendor(keyids=["DEADBEEF"])
+        stderr = "gpgsm: Good signature from 1111DEADBEEF1111\n"
+        with self.assertRaises(UntrustedSignature):
+            self._run_with_stderr(vendor, stderr)
+
+
 class X509SignatureVendorTests(unittest.TestCase):
     """Tests for X509SignatureVendor."""
 


### PR DESCRIPTION
1. `GPGCliSignatureVendor.verify` and `X509SignatureVendor.verify` decide whether a signed commit/tag came from a trusted key by parsing the signing key id from gpg/gpgsm output and testing `signed_by in keyid or keyid in signed_by`.
2. A key id is the trailing hex of a fingerprint, so substring containment accepts an untrusted key whose fingerprint merely embeds a trusted id somewhere in the middle. With a short trusted id (e.g. from config), an attacker key whose full fingerprint contains that id gets accepted through `verify_commit`/`verify_tag`.
3. Switched both vendors to a suffix check (`endswith` in either direction) so a key id matches only when it is the suffix of the fingerprint, which preserves the short-id case gpg reports.

Validation: added mock-based tests that feed crafted gpg/gpgsm stderr. The embedded-id cases fail on the current tree (signature accepted) and pass after the change, while a legitimate short long-id suffix still verifies.