### PR TITLE
contain get_named_file reads within the control dir

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1804,15 +1804,23 @@ class Repo(BaseRepo):
             control dir.
         Returns: An open file object, or None if the file does not exist.
         """
-        # TODO(dborowitz): sanitize filenames, since this is used directly by
-        # the dumb web serving code.
         if basedir is None:
             basedir = self.controldir()
         if isinstance(path, bytes):
             path = path.decode("utf-8")
         path = path.lstrip(os.path.sep)
+        full_path = os.path.join(basedir, path)
+        # The dumb HTTP server passes request-derived names straight through
+        # here, so refuse any name that resolves outside basedir (e.g.
+        # "../../config"). Treat an escaping path as a missing file.
+        normcase_base = os.path.normcase(os.path.abspath(basedir))
+        normcase_full = os.path.normcase(os.path.abspath(full_path))
+        if normcase_full != normcase_base and not normcase_full.startswith(
+            normcase_base + os.path.sep
+        ):
+            return None
         try:
-            return open(os.path.join(basedir, path), "rb")
+            return open(full_path, "rb")
         except FileNotFoundError:
             return None
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1175,6 +1175,20 @@ class BuildRepoRootTests(TestCase):
             self._repo.get_shallow(),
         )
 
+    def test_get_named_file_rejects_path_traversal(self) -> None:
+        # The dumb HTTP server hands request-derived names to get_named_file,
+        # so a name that escapes the control dir must not return a file.
+        outside = os.path.join(os.path.dirname(self._repo_dir), "outside-secret")
+        with open(outside, "wb") as f:
+            f.write(b"secret")
+        self.addCleanup(os.remove, outside)
+        # <controldir>/../../outside-secret resolves to the file above.
+        traversal = os.path.join("..", "..", "outside-secret")
+        self.assertIsNone(self._repo.get_named_file(traversal))
+        # Legitimate names under the control dir still resolve.
+        with self._repo.get_named_file("HEAD") as f:
+            self.assertTrue(f.read().startswith(b"ref: "))
+
     def test_update_shallow(self) -> None:
         self._repo.update_shallow(None, None)  # no op
         self.assertEqual(set(), self._repo.get_shallow())


### PR DESCRIPTION
1. get_named_file joins the supplied name onto the control dir and only strips a leading separator, so a name like ../../config resolves outside the control dir and opens an unrelated file.
2. dulwich.web and dulwich.aiohttp feed request-derived names straight into this helper (HEAD, info/refs, pack files), the dumb-serving case the method's own TODO flagged.
3. Resolve the joined path and return None (the existing missing-file result) when it falls outside basedir, mirroring the containment check in FileSystemBackend.open_repository; legitimate names still resolve.

Regression test reads an out-of-tree file before the change and gets None after.