### PR TITLE
verify fetched object sha in dumb http get_raw

### DIFF
--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -269,6 +269,29 @@ class DumbHTTPObjectStore(BaseObjectStore):
 
         raise KeyError(sha)
 
+    def _check_object_sha(
+        self, sha: "RawObjectID | ObjectID", type_num: int, content: bytes
+    ) -> None:
+        """Verify that fetched content hashes to the requested object id.
+
+        The remote serves both the loose object bytes and the pack index that
+        maps a sha to an offset, so without this check a malicious or MITM'd
+        dumb server can return content that does not match the requested sha.
+        """
+        obj = ShaFile.from_raw_string(
+            type_num, content, object_format=self.object_format
+        )
+        actual = obj.get_id(self.object_format)
+        if len(sha) == self.object_format.oid_length:
+            expected = sha_to_hex(RawObjectID(sha))
+        else:
+            expected = bytes(sha)
+        if actual != expected:
+            raise ObjectFormatException(
+                f"Object {expected.decode('ascii')} has wrong contents "
+                f"(hashes to {actual.decode('ascii')})"
+            )
+
     def get_raw(self, sha: RawObjectID | ObjectID) -> tuple[int, bytes]:
         """Obtain the raw text for an object.
 
@@ -284,13 +307,11 @@ class DumbHTTPObjectStore(BaseObjectStore):
         # Try packs first
         try:
             result = self._fetch_from_pack(sha)
-            self._cached_objects[sha] = result
-            return result
         except KeyError:
-            pass
+            # Try loose object
+            result = self._fetch_loose_object(sha)
 
-        # Try loose object
-        result = self._fetch_loose_object(sha)
+        self._check_object_sha(sha, result[0], result[1])
         self._cached_objects[sha] = result
         return result
 

--- a/tests/test_dumb.py
+++ b/tests/test_dumb.py
@@ -27,7 +27,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from dulwich.dumb import DumbHTTPObjectStore, DumbRemoteHTTPRepo
-from dulwich.errors import NotGitRepository
+from dulwich.errors import NotGitRepository, ObjectFormatException
 from dulwich.objects import ZERO_SHA, Blob, Commit, ShaFile, Tag, Tree, sha_to_hex
 
 
@@ -159,6 +159,34 @@ P pack-abcdef1234567890abcdef1234567890abcdef12.pack
         type_num, content = self.store.get_raw(sha)
         self.assertEqual(Blob.type_num, type_num)
         self.assertEqual(b"cached content", content)
+
+    def test_get_raw_verifies_loose_object_sha(self) -> None:
+        # Server serves a different object's content under the requested sha.
+        trusted = Blob()
+        trusted.data = b"trusted content"
+        trusted_sha = trusted.id
+
+        evil = Blob()
+        evil.data = b"attacker controlled content"
+
+        path = f"objects/{trusted_sha[:2].decode('ascii')}/{trusted_sha[2:].decode('ascii')}"
+        self._add_response(path, self._make_object(evil))
+
+        self.assertRaises(
+            ObjectFormatException, self.store.get_raw, trusted_sha
+        )
+
+    def test_get_raw_loose_object_ok(self) -> None:
+        blob = Blob()
+        blob.data = b"Hello, world!"
+        hex_sha = blob.id
+
+        path = f"objects/{hex_sha[:2].decode('ascii')}/{hex_sha[2:].decode('ascii')}"
+        self._add_response(path, self._make_object(blob))
+
+        type_num, content = self.store.get_raw(hex_sha)
+        self.assertEqual(Blob.type_num, type_num)
+        self.assertEqual(b"Hello, world!", content)
 
     def test_contains_loose(self) -> None:
         # Create a blob object


### PR DESCRIPTION
1. get_raw fetches objects over dumb HTTP but never checks that the returned bytes hash back to the requested object id.
2. both the loose object path (_fetch_loose_object) and the pack offset lookup (_fetch_from_pack) are driven by remote-served data, so a malicious or man-in-the-middle dumb server can return content that does not match the sha and substitute a tree/blob/commit under a pinned or signed id, defeating the content-addressed integrity guarantee.
3. added a verification step at the get_raw chokepoint that rebuilds the object, recomputes the id with the store's object_format, and raises ObjectFormatException on mismatch, covering both the loose and pack paths. This mirrors git's http-walker, which verifies fetched loose objects.

Validated with a fetch where the server returns one object's content under another sha (accepted before, rejected after), plus regression tests; existing dumb tests still pass.
