### PR TITLE
Fix gc removal of read-only pack files on Windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,10 @@
    newly-uncovered commits, because the parents provider still used the
    old boundary. (Jelmer Vernooĳ)
 
+ * Fix ``gc``/``repack`` on Windows raising ``PermissionError`` when
+   removing read-only pack files (as written by git). The read-only
+   attribute is now cleared before unlinking. (Jelmer Vernooĳ)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -228,6 +228,22 @@ PACK_MODE = 0o444 if sys.platform != "win32" else 0o644
 DEFAULT_TEMPFILE_GRACE_PERIOD = 14 * 24 * 60 * 60  # 2 weeks
 
 
+def _remove_readonly(path: str) -> None:
+    """Remove a file, clearing the read-only attribute first on Windows.
+
+    git stores pack files and loose objects read-only. Unix lets you unlink a
+    read-only file in a writable directory, but Windows refuses with
+    PermissionError, so clear the attribute and retry there.
+    """
+    try:
+        os.remove(path)
+    except PermissionError:
+        if sys.platform != "win32":
+            raise
+        os.chmod(path, stat.S_IWRITE | stat.S_IREAD)
+        os.remove(path)
+
+
 class PackInputTooLarge(OSError):
     """Raised when a received pack exceeds the configured input size cap.
 
@@ -1966,7 +1982,7 @@ class DiskObjectStore(PackBasedObjectStore):
         Raises:
           FileNotFoundError: If the object file doesn't exist
         """
-        os.remove(self._get_shafile_path(sha))
+        _remove_readonly(self._get_shafile_path(sha))
 
     def get_object_mtime(self, sha: ObjectID) -> float:
         """Get the modification time of an object.
@@ -2018,9 +2034,9 @@ class DiskObjectStore(PackBasedObjectStore):
         data_path = pack._data_path
         idx_path = pack._idx_path
         pack.close()
-        os.remove(data_path)
+        _remove_readonly(data_path)
         if os.path.exists(idx_path):
-            os.remove(idx_path)
+            _remove_readonly(idx_path)
 
     def _get_pack_basepath(
         self, entries: Iterable[tuple[bytes, int, int | None]]

--- a/tests/compat/__init__.py
+++ b/tests/compat/__init__.py
@@ -35,6 +35,7 @@ def test_suite() -> unittest.TestSuite:
         "client",
         "commit_graph",
         "dumb",
+        "gc",
         "index",
         "lfs",
         "midx",

--- a/tests/compat/test_gc.py
+++ b/tests/compat/test_gc.py
@@ -1,0 +1,114 @@
+# test_gc.py -- Compatibility tests for garbage collection.
+# Copyright (C) 2026 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Compatibility tests for dulwich garbage collection against C git."""
+
+import os
+import tempfile
+
+from dulwich import porcelain
+from dulwich.repo import Repo
+
+from .utils import CompatTestCase, rmtree_ro, run_git_or_fail
+
+
+class GcReadonlyPackCompatTests(CompatTestCase):
+    """Test that dulwich can garbage collect packs produced by C git.
+
+    C git writes pack files read-only. On Windows os.remove refuses to delete
+    a read-only file, so dulwich must clear the attribute before unlinking;
+    otherwise repack (and porcelain.gc) fails with PermissionError. See the
+    bug report referenced in dulwich/object_store.py:_remove_readonly.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.path = tempfile.mkdtemp()
+        self.addCleanup(rmtree_ro, self.path)
+
+    def _git(self, *args, **kwargs):
+        run_git_or_fail(list(args), cwd=self.path, **kwargs)
+
+    def test_gc_removes_readonly_git_packs(self) -> None:
+        self._git("init", ".")
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "Test")
+
+        # Two commits, each packed separately so git leaves two read-only packs
+        # for dulwich to consolidate.
+        with open(os.path.join(self.path, "a"), "w") as f:
+            f.write("first\n")
+        self._git("add", "a")
+        self._git("commit", "-m", "one")
+        self._git("repack", "-d")
+
+        with open(os.path.join(self.path, "b"), "w") as f:
+            f.write("second\n")
+        self._git("add", "b")
+        self._git("commit", "-m", "two")
+        self._git("repack", "-d")
+
+        pack_dir = os.path.join(self.path, ".git", "objects", "pack")
+        packs = [n for n in os.listdir(pack_dir) if n.endswith(".pack")]
+        self.assertEqual(2, len(packs))
+        # Confirm git wrote them read-only, the precondition for the bug.
+        for name in packs:
+            mode = os.stat(os.path.join(pack_dir, name)).st_mode
+            self.assertFalse(mode & 0o200, f"{name} is unexpectedly writable")
+
+        repo = Repo(self.path)
+        self.addCleanup(repo.close)
+        before = {p.name() for p in repo.object_store.packs}
+        self.assertEqual(2, len(before))
+
+        porcelain.gc(repo, grace_period=0)
+
+        after = {p.name() for p in repo.object_store.packs}
+        self.assertEqual(1, len(after))
+        # The original git packs are gone; a single consolidated pack remains.
+        self.assertEqual(set(), before & after)
+
+    def test_gc_prunes_unreachable_from_readonly_pack(self) -> None:
+        self._git("init", ".")
+        self._git("config", "user.email", "test@example.com")
+        self._git("config", "user.name", "Test")
+
+        with open(os.path.join(self.path, "a"), "w") as f:
+            f.write("reachable\n")
+        self._git("add", "a")
+        self._git("commit", "-m", "one")
+
+        # Create a dangling blob and pack everything so it lands in a
+        # read-only pack alongside the reachable objects.
+        blob_sha = run_git_or_fail(
+            ["hash-object", "-w", "--stdin"],
+            input=b"unreachable\n",
+            cwd=self.path,
+        ).strip()
+        self._git("repack", "-ad")
+
+        repo = Repo(self.path)
+        self.addCleanup(repo.close)
+        self.assertIn(blob_sha, repo.object_store)
+
+        porcelain.gc(repo, grace_period=0)
+
+        self.assertNotIn(blob_sha, repo.object_store)


### PR DESCRIPTION
git writes pack files read-only. On Windows os.remove refuses to unlink a read-only file, so repack (and porcelain.gc) failed with PermissionError when consolidating or pruning packs that git had created. Clear the read-only attribute before unlinking, matching git's own behaviour.