### PR TITLE
index: match git on invalid checkout paths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,15 @@
  * Verify that an object retrieved by id actually hashes to the requested
    id, raising ``ChecksumMismatch`` otherwise. (Jelmer Vernooĳ, #2223)
 
+ * Check out files whose names contain a colon or backslash. The NTFS path
+   validator rejected any element containing ``:`` or ``\``, so such files
+   were silently dropped on clone. It now rejects only the ``.git``/``git~1``
+   alternate-data-stream spellings, like git. (Jelmer Vernooĳ, #2205)
+
+ * Abort the checkout when a tree entry has an invalid path (e.g. a ``.git``
+   alias) instead of silently skipping it.
+   (Jelmer Vernooĳ, #2205)
+
  * Reject pack names containing path separators in the dumb HTTP transport,
    so a malicious server can no longer escape the temporary directory.
    (Jelmer Vernooĳ, #2213)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -3367,7 +3367,7 @@ class cmd_reset(Command):
 class cmd_revert(Command):
     """Revert some existing commits."""
 
-    def run(self, args: Sequence[str]) -> None:
+    def run(self, args: Sequence[str]) -> int | None:
         """Execute the revert command.
 
         Args:
@@ -3384,15 +3384,20 @@ class cmd_revert(Command):
         parser.add_argument("commits", nargs="+", help="Commits to revert")
         parsed_args = parser.parse_args(args)
 
-        result = porcelain.revert(
-            ".",
-            commits=parsed_args.commits,
-            no_commit=parsed_args.no_commit,
-            message=parsed_args.message,
-        )
+        try:
+            result = porcelain.revert(
+                ".",
+                commits=parsed_args.commits,
+                no_commit=parsed_args.no_commit,
+                message=parsed_args.message,
+            )
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
 
         if result and not parsed_args.no_commit:
             logger.info("[%s] Revert completed", result.decode("ascii")[:7])
+        return None
 
 
 class cmd_daemon(Command):
@@ -3793,7 +3798,7 @@ class cmd_prune(Command):
 class cmd_pull(Command):
     """Fetch from and integrate with another repository or a local branch."""
 
-    def run(self, args: Sequence[str]) -> None:
+    def run(self, args: Sequence[str]) -> int | None:
         """Execute the pull command.
 
         Args:
@@ -3805,14 +3810,19 @@ class cmd_pull(Command):
         parser.add_argument("--filter", type=str, nargs=1)
         parser.add_argument("--protocol", type=int)
         parsed_args = parser.parse_args(args)
-        porcelain.pull(
-            ".",
-            remote_location=parsed_args.from_location or None,
-            refspecs=parsed_args.refspec or None,
-            filter_spec=parsed_args.filter,
-            protocol_version=parsed_args.protocol or _protocol_version_from_env(),
-            ssh_command=_ssh_command_from_env(),
-        )
+        try:
+            porcelain.pull(
+                ".",
+                remote_location=parsed_args.from_location or None,
+                refspecs=parsed_args.refspec or None,
+                filter_spec=parsed_args.filter,
+                protocol_version=parsed_args.protocol or _protocol_version_from_env(),
+                ssh_command=_ssh_command_from_env(),
+            )
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
+        return None
 
 
 class cmd_push(Command):
@@ -4758,7 +4768,7 @@ class cmd_stash_push(Command):
 class cmd_stash_pop(Command):
     """Apply a stash and remove it from the stash list."""
 
-    def run(self, args: Sequence[str]) -> None:
+    def run(self, args: Sequence[str]) -> int | None:
         """Execute the stash-pop command.
 
         Args:
@@ -4766,8 +4776,13 @@ class cmd_stash_pop(Command):
         """
         parser = argparse.ArgumentParser()
         parser.parse_args(args)
-        porcelain.stash_pop(".")
+        try:
+            porcelain.stash_pop(".")
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
         logger.info("Restored working directory and index state")
+        return None
 
 
 class cmd_bisect(SuperCommand):
@@ -5209,6 +5224,9 @@ class cmd_merge(Command):
                         merge_commit_id.decode(),
                     )
             return 0
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
         except porcelain.Error as e:
             logger.error("%s", e)
             return 1
@@ -5711,6 +5729,9 @@ class cmd_cherry_pick(Command):
                 logger.info("Cherry-pick successful: %s", result.decode())
 
             return None
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
         except porcelain.Error as e:
             logger.error("%s", e)
             return 1

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -87,7 +87,7 @@ from .errors import (
     GitProtocolError,
     NotGitRepository,
 )
-from .index import Index
+from .index import Index, InvalidPathError
 from .log_utils import _configure_logging_from_trace
 from .objects import Commit, ObjectID, RawObjectID, sha_to_hex, valid_hexsha
 from .objectspec import parse_commit_range
@@ -2072,7 +2072,7 @@ class cmd_init(Command):
 class cmd_clone(Command):
     """Clone a repository into a new directory."""
 
-    def run(self, args: Sequence[str]) -> None:
+    def run(self, args: Sequence[str]) -> int | None:
         """Execute the clone command.
 
         Args:
@@ -2132,6 +2132,11 @@ class cmd_clone(Command):
             )
         except GitProtocolError as e:
             logger.exception(e)
+        except InvalidPathError as e:
+            # The clone is kept; only the checkout failed, matching git.
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
+        return None
 
 
 def _get_commit_message_with_template(
@@ -3322,7 +3327,7 @@ class cmd_reflog(Command):
 class cmd_reset(Command):
     """Reset current HEAD to the specified state."""
 
-    def run(self, args: Sequence[str]) -> None:
+    def run(self, args: Sequence[str]) -> int | None:
         """Execute the reset command.
 
         Args:
@@ -3351,7 +3356,12 @@ class cmd_reset(Command):
             mode = "mixed"
 
         # Use the porcelain.reset function for all modes
-        porcelain.reset(".", mode=mode, treeish=parsed_args.treeish)
+        try:
+            porcelain.reset(".", mode=mode, treeish=parsed_args.treeish)
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
+            return 1
+        return None
 
 
 class cmd_revert(Command):
@@ -4550,6 +4560,9 @@ class cmd_checkout(Command):
             )
         except porcelain.CheckoutError as e:
             sys.stderr.write(f"{e}\n")
+            return 1
+        except InvalidPathError as e:
+            logger.exception("unable to checkout working tree: %s", e)
             return 1
         return 0
 

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1580,8 +1580,6 @@ class GitClient:
                 else:
                     head = None
 
-            if checkout and head is not None:
-                target.get_worktree().reset_index(config=target.get_config_stack())
         except BaseException:
             if target is not None:
                 target.close()
@@ -1590,6 +1588,11 @@ class GitClient:
 
                 shutil.rmtree(target_path)
             raise
+
+        # Checkout runs after the clone is complete, so a checkout failure
+        # leaves the fetched repository in place rather than deleting it.
+        if checkout and head is not None:
+            target.get_worktree().reset_index(config=target.get_config_stack())
         return target
 
     def fetch(
@@ -3272,8 +3275,6 @@ class LocalGitClient(GitClient):
                 else:
                     head = None
 
-            if checkout and head is not None:
-                target.get_worktree().reset_index(config=target.get_config_stack())
         except BaseException:
             if target is not None:
                 target.close()
@@ -3282,6 +3283,11 @@ class LocalGitClient(GitClient):
 
                 shutil.rmtree(target_path)
             raise
+
+        # Checkout runs after the clone is complete, so a checkout failure
+        # leaves the fetched repository in place rather than deleting it.
+        if checkout and head is not None:
+            target.get_worktree().reset_index(config=target.get_config_stack())
         return target
 
 

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -1592,7 +1592,13 @@ class GitClient:
         # Checkout runs after the clone is complete, so a checkout failure
         # leaves the fetched repository in place rather than deleting it.
         if checkout and head is not None:
-            target.get_worktree().reset_index(config=target.get_config_stack())
+            try:
+                target.get_worktree().reset_index(config=target.get_config_stack())
+            except BaseException:
+                # Release file handles on the kept repository so callers can
+                # still remove or reopen it (notably on Windows).
+                target.close()
+                raise
         return target
 
     def fetch(
@@ -3287,7 +3293,13 @@ class LocalGitClient(GitClient):
         # Checkout runs after the clone is complete, so a checkout failure
         # leaves the fetched repository in place rather than deleting it.
         if checkout and head is not None:
-            target.get_worktree().reset_index(config=target.get_config_stack())
+            try:
+                target.get_worktree().reset_index(config=target.get_config_stack())
+            except BaseException:
+                # Release file handles on the kept repository so callers can
+                # still remove or reopen it (notably on Windows).
+                target.close()
+                raise
         return target
 
 

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -41,6 +41,7 @@ __all__ = [
     "Index",
     "IndexEntry",
     "IndexExtension",
+    "InvalidPathError",
     "ResolveUndoExtension",
     "SerializedIndexEntry",
     "SparseDirExtension",
@@ -1960,6 +1961,15 @@ def make_path_normalizer(
     return normalize
 
 
+class InvalidPathError(Exception):
+    """Raised when a tree entry's path is unsafe to write to the work tree."""
+
+    def __init__(self, path: bytes) -> None:
+        """Initialize the exception with the offending path."""
+        self.path = path
+        super().__init__(f"invalid path {path.decode('utf-8', 'replace')!r}")
+
+
 def validate_path_element_default(element: bytes) -> bool:
     """Validate a path element using default rules.
 
@@ -1972,12 +1982,32 @@ def validate_path_element_default(element: bytes) -> bool:
     return _normalize_path_element_default(element) not in INVALID_DOTNAMES
 
 
-def _is_ntfs_dotgit_short_name(normalized: bytes) -> bool:
-    """Match NTFS 8.3 short-name forms of ``.git`` (``git~<digits>``)."""
-    if not normalized.startswith(b"git~"):
+def _is_ntfs_dotgit(name: bytes) -> bool:
+    """Match NTFS-dangerous spellings of ``.git`` at the start of ``name``.
+
+    Matches ``.git`` or the 8.3 short name ``git~1`` followed only by
+    dots/spaces and then the end of the element, a separator, or a ``:``
+    (an alternate-data-stream marker, as in ``.git::$INDEX_ALLOCATION``).
+    """
+    if name[:1] == b".":
+        if name[1:4].lower() != b"git":
+            return False
+        i = 4
+    elif name[:1].lower() == b"g":  # ``git~1`` 8.3 short name
+        if name[1:3].lower() != b"it" or name[3:5] != b"~1":
+            return False
+        i = 5
+    else:
         return False
-    tail = normalized[4:]
-    return len(tail) > 0 and tail.isdigit()
+
+    while i < len(name):
+        c = name[i : i + 1]
+        if c == b":":
+            return True
+        if c != b"." and c != b" ":
+            return False
+        i += 1
+    return True
 
 
 # Reserved Windows device names. Opening any of these on Windows
@@ -2008,20 +2038,16 @@ def validate_path_element_ntfs(element: bytes) -> bool:
     Returns:
       True if path element is valid for NTFS, False otherwise
     """
-    # A backslash is a path separator on Windows, so accepting it
-    # here would let a tree authored on POSIX escape the work tree
-    # or plant files under ``.git\`` when checked out on Windows.
-    if b"\\" in element:
+    # A backslash is a separator on Windows but an ordinary filename
+    # character on POSIX, so only reject it on Windows.
+    if os.name == "nt" and b"\\" in element:
         return False
-    # NTFS alternate data streams are addressed as ``name:stream``;
-    # reject any element containing ``:`` so ``.git::$INDEX_ALLOCATION``
-    # and similar forms cannot bypass the ``.git`` check.
-    if b":" in element:
-        return False
+    # Backslash also separates ``.git`` spellings, so check each segment.
+    for segment in element.split(b"\\"):
+        if _is_ntfs_dotgit(segment):
+            return False
     normalized = _normalize_path_element_ntfs(element)
     if normalized in INVALID_DOTNAMES:
-        return False
-    if _is_ntfs_dotgit_short_name(normalized):
         return False
     if _is_reserved_windows_device_name(normalized):
         return False
@@ -2150,8 +2176,10 @@ def build_index_from_tree(
         assert (
             entry.path is not None and entry.mode is not None and entry.sha is not None
         )
+        # Validate as we go and abort on the first invalid path,
+        # leaving any files already written in place.
         if not validate_path(entry.path, validate_path_element):
-            continue
+            raise InvalidPathError(entry.path)
         full_path = _tree_to_fs_path(root_path, entry.path, tree_encoding)
 
         if not os.path.exists(os.path.dirname(full_path)):
@@ -2960,9 +2988,10 @@ def update_working_tree(
                 and change.new.mode is not None
             )
             path = change.new.path
+            # Validate as we go and abort on the first invalid path,
+            # leaving any changes already applied in place.
             if not validate_path(path, validate_path_element):
-                continue
-
+                raise InvalidPathError(path)
             full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
             try:
                 modify_stat: os.stat_result | None = os.lstat(full_path)

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -34,6 +34,7 @@ from .diff_tree import tree_changes
 from .file import GitFile
 from .index import (
     IndexEntry,
+    InvalidPathError,
     _tree_to_fs_path,
     build_file_from_blob,
     commit_tree,
@@ -205,7 +206,7 @@ class Stash:
                     and tree_entry.sha is not None
                 )
                 if not validate_path(tree_entry.path, validate_path_element):
-                    continue
+                    raise InvalidPathError(tree_entry.path)
 
                 # Add to index with stage 0 (normal)
                 # Get file stats for the entry
@@ -226,7 +227,7 @@ class Stash:
                 and tree_entry2.sha is not None
             )
             if not validate_path(tree_entry2.path, validate_path_element):
-                continue
+                raise InvalidPathError(tree_entry2.path)
 
             full_path = _tree_to_fs_path(repo_path, tree_entry2.path)
 

--- a/tests/cli/test_merge.py
+++ b/tests/cli/test_merge.py
@@ -438,6 +438,59 @@ class CLIMergeTests(TestCase):
             finally:
                 os.chdir(old_cwd)
 
+    def test_merge_invalid_path_returns_error(self):
+        """An invalid path in the merged tree returns exit code 1, not a crash."""
+        import stat
+
+        from dulwich.objects import Blob, Commit, Tree
+        from dulwich.repo import Repo
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with Repo.init(tmpdir) as repo:
+                repo.get_config().set((b"core",), b"protectNTFS", b"true")
+                repo.get_config().write_to_path()
+
+                blob = Blob.from_string(b"base\n")
+                repo.object_store.add_object(blob)
+                base_tree = Tree()
+                base_tree.add(b"ok.txt", stat.S_IFREG | 0o644, blob.id)
+                repo.object_store.add_object(base_tree)
+                base = Commit()
+                base.tree = base_tree.id
+                base.author = base.committer = b"Test <test@example.com>"
+                base.author_time = base.commit_time = 0
+                base.author_timezone = base.commit_timezone = 0
+                base.message = b"base\n"
+                repo.object_store.add_object(base)
+                repo.refs[b"refs/heads/master"] = base.id
+                repo.refs.set_symbolic_ref(b"HEAD", b"refs/heads/master")
+                repo.get_worktree().reset_index(base_tree.id)
+
+                payload = Blob.from_string(b"payload\n")
+                repo.object_store.add_object(payload)
+                attack_tree = Tree()
+                attack_tree.add(b"ok.txt", stat.S_IFREG | 0o644, blob.id)
+                # ``git~1`` is the NTFS 8.3 short-name alias for ``.git``.
+                attack_tree.add(b"git~1", stat.S_IFREG | 0o755, payload.id)
+                repo.object_store.add_object(attack_tree)
+                attack = Commit()
+                attack.tree = attack_tree.id
+                attack.parents = [base.id]
+                attack.author = attack.committer = b"Test <test@example.com>"
+                attack.author_time = attack.commit_time = 0
+                attack.author_timezone = attack.commit_timezone = 0
+                attack.message = b"attack\n"
+                repo.object_store.add_object(attack)
+
+            old_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                with self.assertLogs("dulwich.cli", level="ERROR"):
+                    ret = main(["merge", attack.id.decode()])
+                self.assertEqual(ret, 1)
+            finally:
+                os.chdir(old_cwd)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/porcelain/test_merge.py
+++ b/tests/porcelain/test_merge.py
@@ -28,6 +28,7 @@ import tempfile
 import unittest
 
 from dulwich import porcelain
+from dulwich.index import InvalidPathError
 from dulwich.objects import ZERO_SHA, Blob, Commit, Tree
 from dulwich.repo import Repo
 
@@ -511,14 +512,15 @@ class PorcelainMergeTests(TestCase):
                 repo.object_store.add_object(payload)
                 attack_tree = Tree()
                 attack_tree.add(b"ok.txt", stat.S_IFREG | 0o644, blob.id)
-                # ``git~2`` is an NTFS 8.3 short-name alias for ``.git``.
-                attack_tree.add(b"git~2", stat.S_IFREG | 0o755, payload.id)
+                # ``git~1`` is the NTFS 8.3 short-name alias for ``.git``.
+                attack_tree.add(b"git~1", stat.S_IFREG | 0o755, payload.id)
                 attack = self._commit_tree(repo, attack_tree, [base])
 
-                porcelain.merge(repo, attack)
-
+                # The alias aborts the merge checkout rather than being
+                # silently skipped.
+                self.assertRaises(InvalidPathError, porcelain.merge, repo, attack)
                 self.assertFalse(
-                    os.path.exists(os.path.join(tmpdir, "git~2")),
+                    os.path.exists(os.path.join(tmpdir, "git~1")),
                     "merge materialized an NTFS .git alias despite protectNTFS",
                 )
 

--- a/tests/porcelain/test_merge.py
+++ b/tests/porcelain/test_merge.py
@@ -519,8 +519,12 @@ class PorcelainMergeTests(TestCase):
                 # The alias aborts the merge checkout rather than being
                 # silently skipped.
                 self.assertRaises(InvalidPathError, porcelain.merge, repo, attack)
-                self.assertFalse(
-                    os.path.exists(os.path.join(tmpdir, "git~1")),
+                # Check the directory listing rather than os.path.exists: on
+                # Windows the latter resolves the ``git~1`` 8.3 short name onto
+                # the real ``.git`` directory and would report a phantom hit.
+                self.assertNotIn(
+                    "git~1",
+                    os.listdir(tmpdir),
                     "merge materialized an NTFS .git alias despite protectNTFS",
                 )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,6 +22,7 @@
 import base64
 import os
 import shutil
+import stat
 import sys
 import tempfile
 import time
@@ -1255,6 +1256,38 @@ class LocalGitClientTests(TestCase):
         expected[b"refs/remotes/origin/HEAD"] = expected[b"HEAD"]
         expected[b"refs/remotes/origin/master"] = expected[b"refs/heads/master"]
         self.assertEqual(expected, result_repo.get_refs())
+
+    def test_clone_invalid_path_keeps_repo(self) -> None:
+        # A tree entry with an invalid path aborts the checkout, but the
+        # clone itself is kept (objects, refs and HEAD), matching git.
+        from dulwich.index import InvalidPathError
+
+        source_path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, source_path)
+        source = Repo.init(source_path)
+        self.addCleanup(source.close)
+        blob = Blob.from_string(b"payload\n")
+        tree = Tree()
+        tree.add(b".git/config", stat.S_IFREG | 0o644, blob.id)
+        commit = Commit()
+        commit.tree = tree.id
+        commit.author = commit.committer = b"Test <test@example.com>"
+        commit.author_time = commit.commit_time = 0
+        commit.author_timezone = commit.commit_timezone = 0
+        commit.message = b"evil\n"
+        source.object_store.add_objects([(blob, None), (tree, None), (commit, None)])
+        source.refs[b"refs/heads/master"] = commit.id
+        source.refs.set_symbolic_ref(b"HEAD", b"refs/heads/master")
+
+        target = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, target)
+        c = LocalGitClient()
+        self.assertRaises(InvalidPathError, c.clone, source.path, target, mkdir=False)
+
+        # The clone is preserved: HEAD resolves and the work tree is empty.
+        with Repo(target) as cloned:
+            self.assertEqual(commit.id, cloned.head())
+        self.assertEqual([".git"], os.listdir(target))
 
     def test_clone_sha256_local(self) -> None:
         """Test that cloning a SHA-256 local repo creates a SHA-256 clone."""

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -589,6 +589,11 @@ class BuildIndexTests(TestCase):
             self.assertEqual([".git"], os.listdir(repo.path))
 
     def test_git_dir(self) -> None:
+        # A ``.git/`` path is invalid and must abort the whole checkout
+        # rather than being silently skipped while other entries are
+        # written.
+        from dulwich.index import InvalidPathError
+
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
         with Repo.init(repo_dir) as repo:
@@ -602,59 +607,72 @@ class BuildIndexTests(TestCase):
 
             repo.object_store.add_objects([(o, None) for o in [filea, filee, tree]])
 
-            build_index_from_tree(
-                repo.path, repo.index_path(), repo.object_store, tree.id
+            self.assertRaises(
+                InvalidPathError,
+                build_index_from_tree,
+                repo.path,
+                repo.index_path(),
+                repo.object_store,
+                tree.id,
             )
 
-            # Verify index entries
-            index = repo.open_index()
-            self.assertEqual(len(index), 1)
+            # Nothing was written, including the otherwise-valid entry.
+            self.assertFalse(os.path.exists(os.path.join(repo.path, ".git", "a")))
+            self.assertFalse(os.path.exists(os.path.join(repo.path, "c", "e")))
 
-            # filea
-            apath = os.path.join(repo.path, ".git", "a")
-            self.assertFalse(os.path.exists(apath))
+    def test_ntfs_malicious_entry_aborts_checkout(self) -> None:
+        # A tree authored on POSIX containing an entry that would resolve to
+        # ``.git`` on NTFS (a ``.git\`` prefix, the ``git~1`` 8.3 short
+        # name, or a ``.git::`` alternate-data-stream form) must abort the
+        # checkout under the NTFS validator rather than silently skip it;
+        # otherwise an attacker could plant ``.git\hooks\pre-commit.exe`` on
+        # a Windows clone. Each is checked on its own so a single benign
+        # entry alongside it never gets written.
+        from dulwich.index import InvalidPathError, validate_path_element_ntfs
 
-            # filee
-            epath = os.path.join(repo.path, "c", "e")
-            self.assertTrue(os.path.exists(epath))
-            self.assertReasonableIndexEntry(
-                index[b"c/e"], stat.S_IFREG | 0o644, 1, filee.id
-            )
-            self.assertFileContents(epath, b"d")
+        evil_names = [
+            b".git\\hooks\\pre-commit.exe",
+            b"git~1",
+            b".git::$INDEX_ALLOCATION",
+        ]
+        for evil_name in evil_names:
+            repo_dir = tempfile.mkdtemp()
+            self.addCleanup(shutil.rmtree, repo_dir)
+            with Repo.init(repo_dir) as repo:
+                evil = Blob.from_string(b"payload")
+                benign = Blob.from_string(b"ok")
+                tree = Tree()
+                tree[evil_name] = (stat.S_IFREG | 0o644, evil.id)
+                tree[b"ok.txt"] = (stat.S_IFREG | 0o644, benign.id)
+                repo.object_store.add_objects([(o, None) for o in [evil, benign, tree]])
 
-    def test_ntfs_malicious_entries_dropped(self) -> None:
-        # A malicious tree authored on POSIX containing NTFS-hostile
-        # entries must not materialize any of them under the NTFS
-        # validator; the combination would let an attacker plant
-        # ``.git\hooks\pre-commit.exe`` or ``.git::$INDEX_ALLOCATION``
-        # on a Windows clone.
+                self.assertRaises(
+                    InvalidPathError,
+                    build_index_from_tree,
+                    repo.path,
+                    repo.index_path(),
+                    repo.object_store,
+                    tree.id,
+                    validate_path_element=validate_path_element_ntfs,
+                )
+
+                # Nothing was written, including the benign entry.
+                self.assertEqual(os.listdir(repo.path), [".git"])
+
+    def test_ntfs_colon_filename_checked_out(self) -> None:
+        # A file whose name merely contains a colon (an NTFS-hostile
+        # character in general, but not a ``.git`` alternate-data-stream
+        # form) must still be checked out, matching C git which only
+        # rejects the ``.git``/``git~1`` ADS spellings. See issue #2205.
         from dulwich.index import validate_path_element_ntfs
 
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)
         with Repo.init(repo_dir) as repo:
-            hook = Blob.from_string(b"malicious hook")
-            escape = Blob.from_string(b"outside payload")
-            shortname = Blob.from_string(b"masquerading as .git")
-            ads = Blob.from_string(b"alternate data stream payload")
-            benign = Blob.from_string(b"ok")
-
+            blob = Blob.from_string(b"foo\n")
             tree = Tree()
-            tree[b".git\\hooks\\pre-commit.exe"] = (
-                stat.S_IFREG | 0o755,
-                hook.id,
-            )
-            tree[b"..\\outside.txt"] = (stat.S_IFREG | 0o644, escape.id)
-            tree[b"git~1"] = (stat.S_IFREG | 0o644, shortname.id)
-            tree[b".git::$INDEX_ALLOCATION"] = (
-                stat.S_IFREG | 0o644,
-                ads.id,
-            )
-            tree[b"ok.txt"] = (stat.S_IFREG | 0o644, benign.id)
-
-            repo.object_store.add_objects(
-                [(o, None) for o in [hook, escape, shortname, ads, benign, tree]]
-            )
+            tree[b"with:colon.txt"] = (stat.S_IFREG | 0o644, blob.id)
+            repo.object_store.add_objects([(o, None) for o in [blob, tree]])
 
             build_index_from_tree(
                 repo.path,
@@ -665,29 +683,12 @@ class BuildIndexTests(TestCase):
             )
 
             index = repo.open_index()
-            self.assertEqual(list(index), [b"ok.txt"])
-
-            # Nothing written under the literal paths (the POSIX form)
-            # or under `.git/` (the Windows decomposition of `\`).
-            self.assertFalse(
-                os.path.exists(os.path.join(repo.path, ".git\\hooks\\pre-commit.exe"))
-            )
-            self.assertFalse(
-                os.path.exists(
-                    os.path.join(repo.path, ".git", "hooks", "pre-commit.exe")
-                )
-            )
-            # ``git~1`` and ``.git::$INDEX_ALLOCATION`` would resolve
-            # against the existing ``.git`` directory on NTFS (8.3
-            # short-name and alternate-data-stream resolution), so
-            # ``os.path.exists`` can return true even when nothing was
-            # materialized as a literal entry. Check the directory
-            # listing instead.
-            work_tree_entries = os.listdir(repo.path)
-            self.assertNotIn("git~1", work_tree_entries)
-            self.assertNotIn(".git::$INDEX_ALLOCATION", work_tree_entries)
-            # Nothing escaped the work tree either.
-            self.assertNotIn("outside.txt", os.listdir(os.path.dirname(repo.path)))
+            self.assertEqual(list(index), [b"with:colon.txt"])
+            # The file must actually land in the work tree; the original
+            # symptom (issue #2205) was the file being silently skipped.
+            colon_path = os.path.join(repo.path, "with:colon.txt")
+            self.assertTrue(os.path.exists(colon_path))
+            self.assertFileContents(colon_path, b"foo\n")
 
     def test_nonempty(self) -> None:
         repo_dir = tempfile.mkdtemp()
@@ -1503,6 +1504,21 @@ class TestValidatePathElement(TestCase):
         self.assertFalse(validate_path_element_ntfs(b".giT"))
         self.assertFalse(validate_path_element_ntfs(b".."))
         self.assertFalse(validate_path_element_ntfs(b"git~1"))
+        # git only collapses ``git~1`` onto ``.git``; other short-name
+        # indices are ordinary filenames.
+        self.assertTrue(validate_path_element_ntfs(b"git~2"))
+        # A bare colon is allowed; C git only rejects the ``.git``
+        # alternate-data-stream spellings (issue #2205).
+        self.assertTrue(validate_path_element_ntfs(b"with:colon.txt"))
+        self.assertFalse(validate_path_element_ntfs(b".git::$INDEX_ALLOCATION"))
+        # Trailing dots/spaces on ``.git`` collapse back to ``.git``.
+        self.assertFalse(validate_path_element_ntfs(b".git."))
+        self.assertFalse(validate_path_element_ntfs(b".git "))
+        self.assertFalse(validate_path_element_ntfs(b".git . ."))
+        # A backslash is a separator for the ``.git`` scan, so a ``.git``
+        # ADS form behind one is still rejected.
+        self.assertFalse(validate_path_element_ntfs(b".git\\hooks"))
+        self.assertFalse(validate_path_element_ntfs(b"a\\.git::$INDEX_ALLOCATION"))
 
     def test_hfs(self) -> None:
         # Normal paths should pass
@@ -1533,15 +1549,17 @@ class TestValidatePathElement(TestCase):
         self.assertTrue(validate_path_element_hfs(b".g\xc3\xaft"))  # .gït
         self.assertTrue(validate_path_element_hfs(b"git"))  # git without dot
 
-    def test_ntfs_rejects_backslash(self) -> None:
-        # A backslash is a path separator on Windows, so a tree entry
-        # containing one would materialize as nested directories and
-        # let an attacker plant ``.git\hooks\pre-commit`` or escape
-        # the work tree with ``..\outside``.
+    def test_ntfs_backslash_separates_dotgit_check(self) -> None:
+        # C git treats a backslash as a directory separator when scanning
+        # for the ``.git`` NTFS spellings, so a ``.git`` form behind one is
+        # rejected even though the bare backslash itself is not (it is only
+        # rejected when actually running on Windows).
         self.assertFalse(validate_path_element_ntfs(b".git\\hooks\\pre-commit"))
-        self.assertFalse(validate_path_element_ntfs(b"..\\outside"))
-        self.assertFalse(validate_path_element_ntfs(b"a\\b"))
-        self.assertFalse(validate_path_element_ntfs(b"foo\\"))
+        self.assertFalse(validate_path_element_ntfs(b"a\\.git::$INDEX_ALLOCATION"))
+        # A backslash in an ordinary filename is accepted on POSIX, matching
+        # C git (``..\outside`` becomes a literal file inside the work tree).
+        self.assertTrue(validate_path_element_ntfs(b"..\\outside"))
+        self.assertTrue(validate_path_element_ntfs(b"a\\b"))
 
     def test_non_ntfs_validators_accept_backslash(self) -> None:
         # On POSIX/HFS a backslash is a valid filename byte. The
@@ -1550,29 +1568,30 @@ class TestValidatePathElement(TestCase):
         self.assertTrue(validate_path_element_default(b"a\\b"))
         self.assertTrue(validate_path_element_hfs(b"a\\b"))
 
-    def test_ntfs_rejects_all_short_name_variants(self) -> None:
-        # Git's is_ntfs_dotgit rejects any ``git~<digits>`` 8.3
-        # short-name form; previously only the literal ``git~1`` was
-        # checked.
-        for name in (b"git~1", b"git~2", b"git~10", b"GIT~1", b"gIt~3"):
+    def test_ntfs_only_git_tilde_one_short_name(self) -> None:
+        # C git's is_ntfs_dotgit only collapses the exact ``git~1`` 8.3
+        # short name (case-insensitive) onto ``.git``; other ``git~<n>``
+        # forms are ordinary filenames.
+        for name in (b"git~1", b"GIT~1", b"git~1.", b"git~1 "):
             self.assertFalse(
                 validate_path_element_ntfs(name),
                 f"{name!r} should be rejected on NTFS",
             )
-        # Trailing ``.``/space is stripped by NTFS, so these are the same names.
-        self.assertFalse(validate_path_element_ntfs(b"git~1."))
-        self.assertFalse(validate_path_element_ntfs(b"git~1 "))
-        # Names that merely contain ``git~`` are still accepted.
-        self.assertTrue(validate_path_element_ntfs(b"git~foo"))
-        self.assertTrue(validate_path_element_ntfs(b"mygit~1"))
+        for name in (b"git~2", b"git~10", b"gIt~3", b"git~foo", b"mygit~1"):
+            self.assertTrue(
+                validate_path_element_ntfs(name),
+                f"{name!r} should be accepted on NTFS",
+            )
 
-    def test_ntfs_rejects_alternate_data_stream(self) -> None:
+    def test_ntfs_rejects_dotgit_alternate_data_stream(self) -> None:
         # NTFS alternate data streams are addressed as ``name:stream``;
-        # a ``:`` anywhere in an element can smuggle a write to
-        # ``.git::$INDEX_ALLOCATION`` etc.
+        # the ``.git::$INDEX_ALLOCATION`` form smuggles a write to the
+        # ``.git`` directory. A colon elsewhere is an ordinary character
+        # and must be accepted (issue #2205).
         self.assertFalse(validate_path_element_ntfs(b".git::$INDEX_ALLOCATION"))
         self.assertFalse(validate_path_element_ntfs(b".git:evil"))
-        self.assertFalse(validate_path_element_ntfs(b"foo:bar"))
+        self.assertTrue(validate_path_element_ntfs(b"foo:bar"))
+        self.assertTrue(validate_path_element_ntfs(b"with:colon.txt"))
 
     def test_ntfs_rejects_reserved_device_names(self) -> None:
         # CON, PRN, AUX, NUL and COM1..9 / LPT1..9 are reserved

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1556,10 +1556,12 @@ class TestValidatePathElement(TestCase):
         # rejected when actually running on Windows).
         self.assertFalse(validate_path_element_ntfs(b".git\\hooks\\pre-commit"))
         self.assertFalse(validate_path_element_ntfs(b"a\\.git::$INDEX_ALLOCATION"))
-        # A backslash in an ordinary filename is accepted on POSIX, matching
-        # C git (``..\outside`` becomes a literal file inside the work tree).
-        self.assertTrue(validate_path_element_ntfs(b"..\\outside"))
-        self.assertTrue(validate_path_element_ntfs(b"a\\b"))
+        # A backslash in an ordinary filename is a literal byte on POSIX, but
+        # an actual path separator on Windows, where it is rejected so a tree
+        # authored on POSIX cannot escape the work tree.
+        bare_backslash_ok = os.name != "nt"
+        self.assertEqual(bare_backslash_ok, validate_path_element_ntfs(b"..\\outside"))
+        self.assertEqual(bare_backslash_ok, validate_path_element_ntfs(b"a\\b"))
 
     def test_non_ntfs_validators_accept_backslash(self) -> None:
         # On POSIX/HFS a backslash is a valid filename byte. The

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -28,6 +28,7 @@ import tempfile
 from unittest import skipIf
 
 from dulwich.errors import CommitError
+from dulwich.index import InvalidPathError
 from dulwich.index import get_unstaged_changes as _get_unstaged_changes
 from dulwich.object_store import tree_lookup_path
 from dulwich.objects import Blob, Tree
@@ -342,18 +343,10 @@ class WorkTreeResetTests(WorkTreeTestCase):
         tree[b"ok.txt"] = (stat.S_IFREG | 0o644, good.id)
         self.repo.object_store.add_objects([(evil, None), (good, None), (tree, None)])
 
-        self.worktree.reset_index(tree.id)
-
-        # git~1 was dropped by the NTFS validator; ok.txt survived. On NTFS
-        # the path "git~1" is the 8.3 short-name alias of the real .git
-        # directory, so a bare os.path.exists() check is always true there;
-        # assert instead that no regular file carrying the evil blob was
-        # materialized.
-        evil_path = os.path.join(self.repo.path, "git~1")
-        if os.path.isfile(evil_path):
-            with open(evil_path, "rb") as f:
-                self.assertNotEqual(b"evil", f.read())
-        self.assertTrue(os.path.exists(os.path.join(self.repo.path, "ok.txt")))
+        # The invalid entry aborts the reset; nothing is written, not even
+        # the benign ok.txt.
+        self.assertRaises(InvalidPathError, self.worktree.reset_index, tree.id)
+        self.assertFalse(os.path.exists(os.path.join(self.repo.path, "ok.txt")))
 
     def test_reset_index_defaults_to_protectNTFS(self):
         """core.protectNTFS defaults to True on every platform.
@@ -370,13 +363,8 @@ class WorkTreeResetTests(WorkTreeTestCase):
         tree[b"ok.txt"] = (stat.S_IFREG | 0o644, good.id)
         self.repo.object_store.add_objects([(evil, None), (good, None), (tree, None)])
 
-        self.worktree.reset_index(tree.id)
-
-        evil_path = os.path.join(self.repo.path, "git~1")
-        if os.path.isfile(evil_path):
-            with open(evil_path, "rb") as f:
-                self.assertNotEqual(b"evil", f.read())
-        self.assertTrue(os.path.exists(os.path.join(self.repo.path, "ok.txt")))
+        self.assertRaises(InvalidPathError, self.worktree.reset_index, tree.id)
+        self.assertFalse(os.path.exists(os.path.join(self.repo.path, "ok.txt")))
 
 
 class WorkTreeSparseCheckoutTests(WorkTreeTestCase):


### PR DESCRIPTION
The NTFS path-element validator rejected any element containing ':' or '\', so files with a colon in their name (e.g. with:colon.txt) were silently dropped on clone. Reject only the '.git'/'git~1' alternate-data- stream spellings instead, like git: a bare colon is accepted, and a backslash is only rejected as a separator on Windows while still terminating the .git scan on every platform.

When a tree entry's path is genuinely invalid, abort the checkout rather than silently skipping the entry.

Fixes #2205