### PR TITLE
collapse consecutive wildcards in glob to regex translation

### DIFF
--- a/dulwich/attrs.py
+++ b/dulwich/attrs.py
@@ -124,18 +124,22 @@ def _translate_pattern(pattern: bytes) -> bytes:
         i += 1
 
         if c == b"*":
-            if i < n and pattern[i : i + 1] == b"*":
-                # Double asterisk
+            # Consume the whole run of '*' so consecutive stars collapse to
+            # a single wildcard. Emitting one quantifier per star produces
+            # adjacent unbounded quantifiers (e.g. '.*.*.*') that backtrack
+            # catastrophically on non-matching input (ReDoS); collapsing is
+            # also semantically correct since repeated '*' are redundant.
+            double = i < n and pattern[i : i + 1] == b"*"
+            while i < n and pattern[i : i + 1] == b"*":
                 i += 1
+            if double:
+                # Double asterisk - matches across directory separators
                 if i < n and pattern[i : i + 1] == b"/":
                     # **/ - match zero or more directories
                     res += b"(?:.*/)??"
                     i += 1
-                elif i == n:
-                    # ** at end - match everything
-                    res += b".*"
                 else:
-                    # ** in middle
+                    # ** at end or in the middle
                     res += b".*"
             else:
                 # Single * - match any character except /

--- a/dulwich/config.py
+++ b/dulwich/config.py
@@ -153,6 +153,11 @@ def match_glob_pattern(value: str, pattern: str) -> bool:
     Raises:
         ValueError: If the pattern is invalid
     """
+    # Collapse a run of consecutive '*' to at most '**'. Repeated stars are
+    # redundant, and translating each into its own quantifier would emit
+    # adjacent unbounded quantifiers (e.g. '.*.*') that backtrack
+    # catastrophically on non-matching input (ReDoS).
+    pattern = re.sub(r"\*\*+", "**", pattern)
     # Convert glob pattern to regex
     pattern_escaped = re.escape(pattern)
     # Replace escaped \*\* with .* (match anything)

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -167,6 +167,13 @@ def _translate_segment(segment: bytes) -> bytes:
         c = segment[i : i + 1]
         i += 1
         if c == b"*":
+            # Collapse a run of consecutive '*' into a single quantifier.
+            # Within a segment repeated '*' are redundant ([^/]*[^/]* is
+            # equivalent to [^/]*), and emitting one quantifier per star
+            # builds a regex with adjacent unbounded quantifiers that
+            # backtracks catastrophically on non-matching input (ReDoS).
+            while i < n and segment[i : i + 1] == b"*":
+                i += 1
             res += b"[^/]*"
         elif c == b"?":
             res += b"[^/]"

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -267,6 +267,15 @@ class PatternTests(TestCase):
         self.assertTrue(pattern.match(b"/README.txt"))
         self.assertFalse(pattern.match(b"src/README.txt"))
 
+    def test_consecutive_stars_no_redos(self):
+        """A run of '*' must not produce a catastrophically backtracking regex."""
+        # Many single '*' collapse to one [^/]* ...
+        pattern = Pattern(b"*" * 50 + b"x")
+        self.assertFalse(pattern.match(b"a" * 80))
+        # ... and a run of '**' collapses to a single cross-slash wildcard.
+        pattern = Pattern(b"**" * 25 + b"x")
+        self.assertFalse(pattern.match(b"a" * 80))
+
 
 class MatchPathTests(TestCase):
     """Test the match_path function."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,7 @@ from dulwich.config import (
     apply_instead_of,
     env_config,
     get_git_proxy_command,
+    match_glob_pattern,
     parse_submodules,
     read_submodules,
 )
@@ -1584,3 +1585,21 @@ class ConfigFileSetTests(TestCase):
         self.assertEqual(1, content.count(b"sshCommand"))
         self.assertIn(b"sshCommand = ssh -i ~/.ssh/id_rsa2", content)
         self.assertNotIn(b"id_rsa1", content)
+
+
+class MatchGlobPatternTests(TestCase):
+    """Tests for match_glob_pattern."""
+
+    def test_single_star(self) -> None:
+        self.assertTrue(match_glob_pattern("foo", "*"))
+        self.assertFalse(match_glob_pattern("a/b", "*"))
+
+    def test_double_star(self) -> None:
+        self.assertTrue(match_glob_pattern("a/b", "**"))
+        self.assertTrue(match_glob_pattern("a/x/b", "a**b"))
+
+    def test_consecutive_stars_no_redos(self) -> None:
+        # A run of '*' collapses to a single quantifier so the regex does
+        # not contain adjacent unbounded quantifiers that backtrack
+        # exponentially on non-matching input.
+        self.assertFalse(match_glob_pattern("a" * 80, "*" * 50 + "x"))

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -102,6 +102,18 @@ class TranslateTests(TestCase):
                 f"orig pattern: {pattern!r}, regex: {translate(pattern)!r}, expected: {regex!r}",
             )
 
+    def test_collapses_consecutive_stars(self) -> None:
+        # A run of '*' in a segment is redundant and must collapse to a
+        # single quantifier so the regex does not contain adjacent
+        # unbounded quantifiers that backtrack catastrophically.
+        self.assertEqual(b"(?ms)(.*/)?[^/]*x/?\\Z", translate(b"****x"))
+
+    def test_consecutive_stars_no_redos(self) -> None:
+        # A pattern of many '*' matched against a long non-matching path
+        # used to backtrack exponentially; it must now return promptly.
+        pattern = Pattern(b"*" * 50 + b"x", False)
+        self.assertFalse(pattern.match(b"a" * 80))
+
 
 class ReadIgnorePatterns(TestCase):
     def test_read_file(self) -> None:


### PR DESCRIPTION
1. `ignore._translate_segment`, `attrs._translate_pattern`, and `config.match_glob_pattern` translate a glob into a regex by emitting one quantifier per `*`, so a run of `*` turns into adjacent unbounded quantifiers (`[^/]*[^/]*...` or `.*.*...`).
2. Matching that regex against a longer non-matching string backtracks exponentially. The ignore/attrs patterns come from a cloned repository's `.gitignore`/`.gitattributes` and are walked during status/checkout/add, and `match_glob_pattern` is public API backing `includeIf` `onbranch:`/`hasconfig:`, so a tiny pattern can stall those paths.
3. Collapsed a run of `*` to a single wildcard in each translator. Consecutive `*` are redundant, so matching behavior is unchanged.

Before, a 50-star pattern (`b"*"*50 + b"x"`) matched against 80 `a`s ran for well over 5s in each of the three functions; after the change it returns in under a millisecond. Existing ignore/attrs/config tests pass and I added a regression in each suite.