### PR TITLE
reject unsigned objects in verify_commit/verify_tag when keyids set

### DIFF
--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -2729,12 +2729,21 @@ def verify_commit(
       gpg.errors.MissingSignatures: if commit was not signed by a key
         specified in keyids
     """
-    from dulwich.signature import get_signature_vendor_for_signature
+    from dulwich.signature import (
+        UntrustedSignature,
+        get_signature_vendor_for_signature,
+    )
 
     with open_repo_closing(repo) as r:
         commit = parse_commit(r, committish)
         payload, signature, _sig_type = commit.extract_signature()
         if signature is None:
+            if keyids:
+                raise UntrustedSignature(
+                    "commit is not signed by any of the trusted keys: "
+                    "no signature present",
+                    trusted_keys=list(keyids),
+                )
             return
 
         vendor = get_signature_vendor_for_signature(

--- a/dulwich/porcelain/tag.py
+++ b/dulwich/porcelain/tag.py
@@ -67,7 +67,10 @@ def verify_tag(
       gpg.errors.MissingSignatures: if tag was not signed by a key
         specified in keyids
     """
-    from dulwich.signature import get_signature_vendor_for_signature
+    from dulwich.signature import (
+        UntrustedSignature,
+        get_signature_vendor_for_signature,
+    )
 
     from . import Error, open_repo_closing
 
@@ -82,6 +85,12 @@ def verify_tag(
 
         payload, signature, _sig_type = tag_obj.extract_signature()
         if signature is None:
+            if keyids:
+                raise UntrustedSignature(
+                    "tag is not signed by any of the trusted keys: "
+                    "no signature present",
+                    trusted_keys=list(keyids),
+                )
             return
 
         vendor = get_signature_vendor_for_signature(

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -1021,6 +1021,32 @@ class VerifyCommitTests(PorcelainGpgTestCase):
         # Verify should not raise for unsigned commits
         porcelain.verify_commit(self.repo.path, sha)
 
+    def test_verify_commit_unsigned_with_keyids(self) -> None:
+        """Test that an unsigned commit is rejected when trusted keyids are required."""
+        from dulwich.signature import UntrustedSignature
+
+        _c1, _c2, c3 = build_commit_graph(
+            self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
+        )
+        self.repo.refs[b"HEAD"] = c3.id
+
+        sha = porcelain.commit(
+            self.repo.path,
+            message="Unsigned commit",
+            author="Joe <joe@example.com>",
+            committer="Bob <bob@example.com>",
+            sign=False,
+        )
+
+        # Caller demands a trusted signer; an unsigned commit satisfies none.
+        self.assertRaises(
+            UntrustedSignature,
+            porcelain.verify_commit,
+            self.repo.path,
+            sha,
+            keyids=[PorcelainGpgTestCase.DEFAULT_KEY_ID],
+        )
+
 
 @skipIf(
     platform.python_implementation() == "PyPy" or sys.platform == "win32",
@@ -1103,6 +1129,33 @@ class VerifyTagTests(PorcelainGpgTestCase):
 
         # Verify should not raise for unsigned tags
         porcelain.verify_tag(self.repo.path, b"unsigned-tag")
+
+    def test_verify_tag_unsigned_with_keyids(self) -> None:
+        """Test that an unsigned tag is rejected when trusted keyids are required."""
+        from dulwich.signature import UntrustedSignature
+
+        _c1, _c2, c3 = build_commit_graph(
+            self.repo.object_store, [[1], [2, 1], [3, 1, 2]]
+        )
+        self.repo.refs[b"HEAD"] = c3.id
+
+        porcelain.tag_create(
+            self.repo.path,
+            b"unsigned-tag",
+            b"Tagger <tagger@example.com>",
+            b"Unsigned tag message",
+            annotated=True,
+            sign=False,
+        )
+
+        # Caller demands a trusted signer; an unsigned tag satisfies none.
+        self.assertRaises(
+            UntrustedSignature,
+            porcelain.verify_tag,
+            self.repo.path,
+            b"unsigned-tag",
+            keyids=[PorcelainGpgTestCase.DEFAULT_KEY_ID],
+        )
 
 
 class TimezoneTests(PorcelainTestCase):


### PR DESCRIPTION
1. `verify_commit` and `verify_tag` return on `signature is None` before consulting the caller-supplied `keyids`, so an unsigned commit or tag passes verification even when the caller required a trusted signer.
2. both docstrings already state that verification raises when the object was not signed by a key in `keyids`; an unsigned object satisfies no key, so a caller using these helpers as a trust gate would accept an attacker's unsigned object (for example one from a fetched or cloned repository) as if it were signed by a trusted key.
3. raise `UntrustedSignature` when `keyids` is set and no signature is present, at both call sites. The no-keyids case still returns without raising, so the existing unsigned-object behavior is unchanged.

Confirmed before the change that `verify_commit`/`verify_tag` with `keyids=[...]` returned `None` for an unsigned object; after the change they raise. Added a regression test for each next to the existing unsigned tests.