### PR TITLE
fix quadratic backtracking in _find_scissors_line regex

### DIFF
--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -956,8 +956,18 @@ def _find_scissors_line(lines: list[bytes]) -> int | None:
     Returns:
         Index of scissors line, or None if not found
     """
+    # The perforation alternatives are written so no two unbounded ``-+``
+    # quantifiers are separated by an optional/empty subpattern. The earlier
+    # form ``(?:>?\s*-+\s*)?(?:8<|>8)?\s*-+\s*`` let a single run of dashes be
+    # split between two ``-+`` groups, so a long non-matching line of dashes
+    # backtracked quadratically (ReDoS) when fed through ``mailinfo`` /
+    # ``git am --scissors`` on an untrusted mailbox. Here a marker is the
+    # mandatory pivot between the two dash runs, and the marker-less case uses a
+    # bounded ``(?:\s+-+)?`` second run, keeping the match linear.
     scissors_pattern = re.compile(
-        rb"^(?:>?\s*-+\s*)?(?:8<|>8)?\s*-+\s*$|^(?:>?\s*-+\s*)(?:cut here|scissors)(?:\s*-+)?$",
+        rb"^>?\s*-+(?:\s+-+)?\s*$"
+        rb"|^>?\s*(?:-+\s*)?(?:8<|>8)\s*-+\s*$"
+        rb"|^(?:>?\s*-+\s*)(?:cut here|scissors)(?:\s*-+)?$",
         re.IGNORECASE,
     )
 

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1081,6 +1081,42 @@ diff --git a/file.txt b/file.txt
         self.assertIn("Keep this part", result.message)
         self.assertNotIn("Ignore this part", result.message)
 
+    def test_scissors_formats(self):
+        """Recognized scissors line formats keep matching after the rewrite."""
+        from dulwich.patch import _find_scissors_line
+
+        for marker in [
+            b"-- >8 --",
+            b"--- 8< ---",
+            b"-->8--",
+            b"-- cut here --",
+            b"-- scissors --",
+            b"------------",
+        ]:
+            self.assertEqual(
+                0, _find_scissors_line([marker]), f"should match {marker!r}"
+            )
+        for non_marker in [b"", b"plain text", b"> quoted reply"]:
+            self.assertIsNone(
+                _find_scissors_line([non_marker]), f"should not match {non_marker!r}"
+            )
+
+    def test_scissors_line_not_quadratic(self):
+        """A long perforation-like line must not backtrack quadratically.
+
+        The previous pattern split one run of dashes between two unbounded
+        ``-+`` groups, so a non-matching line of N dashes took O(N**2) time
+        through ``git am --scissors`` on an untrusted mailbox.
+        """
+        import time
+
+        from dulwich.patch import _find_scissors_line
+
+        line = b"-" * 200000 + b"x"
+        start = time.monotonic()
+        self.assertIsNone(_find_scissors_line([line]))
+        self.assertLess(time.monotonic() - start, 2.0)
+
     def test_message_id(self):
         """Test -m flag (include Message-ID)."""
         from io import BytesIO


### PR DESCRIPTION
1. `_find_scissors_line` builds its perforation regex with two unbounded `-+` groups separated only by optional or empty subpatterns (`(?:>?\s*-+\s*)?(?:8<|>8)?\s*-+\s*`), so a single run of dashes can be partitioned between them.
2. against a long line of dashes that does not match, the engine tries every partition and runs in O(n^2): a 64KB line takes about 23s on my machine, and `mailinfo()` / `git am --scissors` feed every line of an untrusted mailbox through this matcher, so a crafted patch is a denial of service.
3. reworked the perforation alternatives so an `8<`/`>8` marker is the mandatory pivot between the two dash runs and the marker-less case uses a bounded `(?:\s+-+)?` second run, which keeps matching linear.

I checked every input up to length 10 over the perforation alphabet: the new pattern still matches every line the old one did (the recognized formats like `-- >8 --`, `--- 8< ---`, `-- cut here --` are unchanged), so this only removes the backtracking. Added a regression test covering the formats and the linear-time behavior.