### PR TITLE
reject option-like host before invoking git proxy command

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -2656,6 +2656,13 @@ class TCPGitClient(TraditionalGitClient):
         assert self._proxy_command is not None
         import shlex
 
+        # The host comes from the URL (e.g. a submodule's git:// URL) and is
+        # passed to the proxy command as an argument. Reject a host that looks
+        # like a command-line option so the proxy program can't be tricked into
+        # interpreting it as one, matching the SubprocessSSHVendor guard.
+        if self._host.startswith("-"):
+            raise StrangeHostname(hostname=self._host)
+
         argv = [*shlex.split(self._proxy_command), self._host, str(self._port)]
         p = subprocess.Popen(
             argv,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2518,6 +2518,18 @@ class TCPGitClientTests(TestCase):
         c = TCPGitClient("example.com", proxy_command="my-proxy")
         self.assertEqual("my-proxy", c._proxy_command)
 
+    def test_connect_via_proxy_rejects_dashed_host(self) -> None:
+        c = TCPGitClient("-oProxyCommand=evil", proxy_command="my-proxy")
+        with patch.object(
+            client.subprocess, "Popen", side_effect=AssertionError("spawned")
+        ):
+            self.assertRaises(
+                StrangeHostname,
+                c._connect_via_proxy,
+                b"upload-pack",
+                b"/repo",
+            )
+
     def test_from_parsedurl_with_proxy_config(self) -> None:
         from io import BytesIO
         from urllib.parse import urlparse


### PR DESCRIPTION
1. TCPGitClient._connect_via_proxy passes the URL-derived host straight into the configured proxy command's argv, while SubprocessSSHVendor and PLinkSSHVendor already refuse a host that starts with "-" (StrangeHostname).
2. urlparse turns a git:// URL such as a submodule's url into a hostname like "-oProxyCommand=evil", so with core.gitProxy set the proxy program receives the attacker-controlled host as an option-looking argument (the argument-injection class git addressed in CVE-2017-1000117).
3. Reject a host beginning with "-" in _connect_via_proxy before building argv, raising StrangeHostname like the SSH vendors.

Added a regression test in TCPGitClientTests; the existing test_client.py suite still passes.