### PR TITLE
validate object id in LFS server request handlers

### DIFF
--- a/dulwich/lfs_server.py
+++ b/dulwich/lfs_server.py
@@ -29,12 +29,23 @@ __all__ = [
 
 import hashlib
 import json
+import re
 import tempfile
 import typing
 from collections.abc import Mapping
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from .lfs import LFSStore
+
+# LFS object ids are SHA-256 digests, i.e. 64 lowercase hex characters. The
+# store maps an oid onto a path (objects/<oid[:2]>/<oid[2:4]>/<oid>), so an oid
+# taken from the request path must be checked before it reaches the filesystem.
+_VALID_OID = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def _is_valid_oid(oid: str) -> bool:
+    """Return whether ``oid`` is a well-formed LFS object id."""
+    return _VALID_OID.match(oid) is not None
 
 
 class LFSRequestHandler(BaseHTTPRequestHandler):
@@ -154,6 +165,9 @@ class LFSRequestHandler(BaseHTTPRequestHandler):
             return
 
         oid = path_parts[1]
+        if not _is_valid_oid(oid):
+            self.send_error(404, "Not Found")
+            return
 
         try:
             with self.lfs_server.lfs_store.open_object(oid) as f:
@@ -176,6 +190,10 @@ class LFSRequestHandler(BaseHTTPRequestHandler):
             return
 
         oid = path_parts[1]
+        if not _is_valid_oid(oid):
+            self.send_error(404, "Not Found")
+            return
+
         content_length = int(self.headers["Content-Length"])
 
         # Read content in chunks
@@ -215,6 +233,10 @@ class LFSRequestHandler(BaseHTTPRequestHandler):
             return
 
         oid = path_parts[1]
+        if not _is_valid_oid(oid):
+            self.send_error(404, "Not Found")
+            return
+
         content_length = int(self.headers.get("Content-Length", 0))
 
         if content_length > 0:

--- a/tests/test_lfs.py
+++ b/tests/test_lfs.py
@@ -1005,9 +1005,9 @@ class LFSServerTests(TestCase):
         from urllib.error import HTTPError
         from urllib.request import Request, urlopen
 
-        # Upload with wrong OID
+        # Upload with a well-formed OID that does not match the content
         upload_req = Request(
-            f"{self.server_url}/objects/wrongoid123",
+            f"{self.server_url}/objects/{'0' * 64}",
             data=b"test content",
             headers={"Content-Type": "application/octet-stream"},
             method="PUT",
@@ -1176,9 +1176,9 @@ class LFSClientTests(TestCase):
             )
         self.assertIn("Object not found", str(cm.exception))
 
-        # Test uploading with wrong OID
+        # Test uploading with a well-formed OID that does not match the content
         with self.assertRaises(HTTPError) as cm:
-            self.client.upload("wrong_oid", 5, b"hello")
+            self.client.upload("0" * 64, 5, b"hello")
         # Server should reject due to OID mismatch
         self.assertIn("OID mismatch", str(cm.exception))
 

--- a/tests/test_lfs_server.py
+++ b/tests/test_lfs_server.py
@@ -1,0 +1,94 @@
+# test_lfs_server.py -- Tests for the LFS server
+# Copyright (C) 2024 Jelmer Vernooij <jelmer@jelmer.uk>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Tests for the LFS server."""
+
+import http.client
+import os
+import shutil
+import tempfile
+import threading
+
+from dulwich.lfs_server import run_lfs_server
+
+from . import TestCase
+
+
+class LFSServerOidValidationTests(TestCase):
+    """Tests that the server rejects object ids that escape the store."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.base = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.base)
+        lfs_dir = os.path.join(self.base, "lfs")
+        self.server, self.url = run_lfs_server(lfs_dir=lfs_dir)
+        thread = threading.Thread(target=self.server.serve_forever)
+        thread.daemon = True
+        thread.start()
+
+        def stop() -> None:
+            self.server.shutdown()
+            thread.join()
+            self.server.server_close()
+
+        self.addCleanup(stop)
+        host, port = self.server.server_address[:2]
+        self.host = host
+        self.port = port
+
+    def _get(self, path: str) -> tuple[int, bytes]:
+        # Use a raw connection so the request path is sent verbatim and not
+        # normalized/percent-encoded by a higher level client.
+        conn = http.client.HTTPConnection(self.host, self.port)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            return resp.status, resp.read()
+        finally:
+            conn.close()
+
+    def test_valid_object_is_served(self) -> None:
+        oid = self.server.lfs_store.write_object([b"hello"])
+        status, body = self._get(f"/objects/{oid}")
+        self.assertEqual(200, status)
+        self.assertEqual(b"hello", body)
+
+    def test_traversing_oid_is_rejected(self) -> None:
+        # ``_sha_path`` joins objects/<oid[:2]>/<oid[2:4]>/<oid>, so an oid of
+        # ".." for the first two components climbs out of the store. Plant a
+        # file where ``....`` would resolve and confirm it is not served.
+        secret = os.path.join(self.base, "....")
+        with open(secret, "wb") as f:
+            f.write(b"secret")
+        status, body = self._get("/objects/....")
+        self.assertEqual(404, status)
+        self.assertNotIn(b"secret", body)
+
+    def test_backslash_oid_is_rejected(self) -> None:
+        # On Windows the backslash is a path separator, so this would traverse;
+        # it must be refused on every platform.
+        status, _ = self._get("/objects/..\\..\\..\\secret")
+        self.assertEqual(404, status)
+
+    def test_non_hex_oid_is_rejected(self) -> None:
+        status, _ = self._get("/objects/" + "z" * 64)
+        self.assertEqual(404, status)


### PR DESCRIPTION
1. The `/objects/<oid>` handlers (`handle_download`, `handle_upload`, and `handle_verify` via `_object_exists`) read the object id straight from the request path and pass it to `LFSStore.open_object`.
2. `open_object` maps the id onto a file with `_sha_path` (`objects/<oid[:2]>/<oid[2:4]>/<oid>`), so an unvalidated id escapes the store: `GET /objects/....` resolves above the objects directory, and on Windows a backslash id like `..\..\..\..\Windows\win.ini` traverses to an arbitrary file and is returned to the client.
3. Validate the id is a 64-character lowercase hex sha256 at each handler before it reaches the store, returning 404 otherwise. Upload still computes the real digest and reports the mismatch as before.

Added a regression test that plants a file where `....` would resolve and confirms it is no longer served, plus checks for backslash and non-hex ids.