### PR TITLE
don't expand config includes when parsing bundle lists

### DIFF
--- a/dulwich/bundle_uri.py
+++ b/dulwich/bundle_uri.py
@@ -109,7 +109,11 @@ def parse_bundle_list(data: bytes, base_uri: str | None = None) -> BundleList:
     from .config import ConfigFile
 
     try:
-        config = ConfigFile.from_file(BytesIO(data))
+        # The bundle list is served by a remote (untrusted) bundle-uri host;
+        # do not expand include/includeIf directives so a hostile list cannot
+        # make us open and parse arbitrary paths on disk, matching the handling
+        # of the equally untrusted .gitmodules in read_submodules.
+        config = ConfigFile.from_file(BytesIO(data), expand_includes=False)
     except Exception as e:
         raise BundleURIError(f"Failed to parse bundle list as config: {e}") from e
 

--- a/tests/test_bundle_uri.py
+++ b/tests/test_bundle_uri.py
@@ -21,6 +21,9 @@
 
 """Tests for bundle URI support."""
 
+import os
+import tempfile
+
 from dulwich.bundle_uri import (
     BundleList,
     BundleListEntry,
@@ -187,6 +190,27 @@ class BundleURIParsingTests(TestCase):
 
         absolute_path = next(e for e in bundle_list.entries if e.id == "absolute-path")
         self.assertEqual(absolute_path.uri, "https://example.com/bundles/weekly.bundle")
+
+    def test_parse_bundle_list_ignores_includes(self) -> None:
+        """A bundle list from a remote host must not expand include directives."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            included = os.path.join(tmpdir, "included.cfg")
+            with open(included, "wb") as f:
+                f.write(b'[bundle "injected"]\n\turi = https://evil.example/x.bundle\n')
+
+            data = (
+                b"[bundle]\n"
+                b"\tversion = 1\n"
+                b"\tmode = all\n"
+                b"[include]\n"
+                b"\tpath = " + included.encode() + b"\n"
+                b'[bundle "real"]\n'
+                b"\turi = https://example.com/real.bundle\n"
+            )
+            bundle_list = parse_bundle_list(data)
+
+        ids = {e.id for e in bundle_list.entries}
+        self.assertEqual(ids, {"real"})
 
 
 class URIResolutionTests(TestCase):


### PR DESCRIPTION
1. parse_bundle_list reads the bundle list served by a remote bundle-uri host as a git config, with include/includeIf expansion left enabled.
2. a hostile list using `[include] path=/some/local/file` then makes a clone(bundle_uri=...) or fetch_with_bundle_uri open and parse arbitrary files on the victim's disk while it is being parsed.

Passing `expand_includes=False` keeps the list to its own contents. This mirrors `read_submodules`, which already disables include expansion for the equally untrusted .gitmodules. Verified with a parse test that a bundle entry defined only in an included file no longer leaks into the result.