### PR TITLE
verify gpg signing key from status-fd, not human-readable text

### DIFF
--- a/dulwich/signature.py
+++ b/dulwich/signature.py
@@ -49,6 +49,32 @@ __all__ = [
 ]
 
 
+def _parse_status_fingerprints(status: bytes) -> list[str]:
+    """Extract signing key fingerprints from gpg/gpgsm --status-fd output.
+
+    Only the VALIDSIG status line is consulted. Its first argument is the
+    fingerprint of the signing key and its last argument is the primary key
+    fingerprint; both are produced by gpg and are not attacker-controlled,
+    unlike the human-readable "Good signature from <user id>" text on stderr.
+
+    Args:
+      status: Raw bytes written by gpg/gpgsm to the status file descriptor.
+
+    Returns:
+      List of fingerprints found (signing key and primary key).
+    """
+    fingerprints: list[str] = []
+    prefix = "[GNUPG:] "
+    for line in status.decode("utf-8", errors="replace").splitlines():
+        if not line.startswith(prefix):
+            continue
+        fields = line[len(prefix) :].split()
+        if len(fields) >= 2 and fields[0] == "VALIDSIG":
+            fingerprints.append(fields[1])
+            fingerprints.append(fields[-1])
+    return fingerprints
+
+
 # Signature verification exceptions
 class SignatureVerificationError(Exception):
     """Base exception for signature verification failures."""
@@ -423,7 +449,13 @@ class GPGCliSignatureVendor(SignatureSigner, SignatureVerifier):
             data_file.write(data)
             data_file.flush()
 
-            args = [self.gpg_command, "--verify", sig_file.name, data_file.name]
+            args = [
+                self.gpg_command,
+                "--status-fd=1",
+                "--verify",
+                sig_file.name,
+                data_file.name,
+            ]
 
             try:
                 result = subprocess.run(
@@ -438,33 +470,18 @@ class GPGCliSignatureVendor(SignatureSigner, SignatureVerifier):
 
             # If keyids are specified, check that the signature was made by one of them
             if self.keyids:
-                # Parse stderr to extract the key fingerprint/ID that made the signature
-                stderr_text = result.stderr.decode("utf-8", errors="replace")
-
-                # GPG outputs both subkey and primary key fingerprints
-                # Collect both to check against trusted keyids
-                signing_keys = []
-                for line in stderr_text.split("\n"):
-                    if (
-                        "using RSA key" in line
-                        or "using DSA key" in line
-                        or "using EDDSA key" in line
-                        or "using ECDSA key" in line
-                    ):
-                        # Extract the key ID from lines like "gpg: using RSA key ABCD1234..."
-                        parts = line.split()
-                        if "key" in parts:
-                            key_idx = parts.index("key")
-                            if key_idx + 1 < len(parts):
-                                signing_keys.append(parts[key_idx + 1])
-                    elif "Primary key fingerprint:" in line:
-                        # Extract fingerprint
-                        fpr = line.split(":", 1)[1].strip().replace(" ", "")
-                        signing_keys.append(fpr)
+                # Read the signing key from gpg's machine-readable status output
+                # (--status-fd) rather than the human-readable stderr. The
+                # VALIDSIG status line carries the signing key fingerprint and
+                # the primary key fingerprint, both computed by gpg. The stderr
+                # "Good signature from <user id>" / "aka" lines echo the key's
+                # user id, which the signer controls and can populate with text
+                # like "using RSA key <trusted-id>" to impersonate a trusted key.
+                signing_keys = _parse_status_fingerprints(result.stdout)
 
                 if not signing_keys:
                     raise UntrustedSignature(
-                        "Could not determine signing key from GPG output"
+                        "Could not determine signing key from GPG status output"
                     )
 
                 # Check if any of the signing keys (subkey or primary) match the trusted keyids
@@ -602,7 +619,13 @@ class X509SignatureVendor(SignatureSigner, SignatureVerifier):
             data_file.write(data)
             data_file.flush()
 
-            args = [self.gpgsm_command, "--verify", sig_file.name, data_file.name]
+            args = [
+                self.gpgsm_command,
+                "--status-fd=1",
+                "--verify",
+                sig_file.name,
+                data_file.name,
+            ]
 
             try:
                 result = subprocess.run(
@@ -617,26 +640,16 @@ class X509SignatureVendor(SignatureSigner, SignatureVerifier):
 
             # If keyids are specified, check that the signature was made by one of them
             if self.keyids:
-                # Parse stderr to extract the certificate fingerprint/ID that made the signature
-                stderr_text = result.stderr.decode("utf-8", errors="replace")
-
-                # Collect signing certificate IDs
-                signing_certs = []
-                for line in stderr_text.split("\n"):
-                    if "using certificate ID" in line or "Good signature from" in line:
-                        # Extract certificate ID from the output
-                        parts = line.split()
-                        for i, part in enumerate(parts):
-                            if part.upper().startswith("0x"):
-                                signing_certs.append(part[2:])
-                            elif len(part) >= 8 and all(
-                                c in "0123456789ABCDEF" for c in part.upper()
-                            ):
-                                signing_certs.append(part)
+                # Read the certificate fingerprint from gpgsm's machine-readable
+                # status output (--status-fd) instead of the human-readable
+                # "Good signature from <subject>" line on stderr. The subject DN
+                # is attacker-controlled, so a certificate whose subject contains
+                # a trusted key id as a token would otherwise be accepted.
+                signing_certs = _parse_status_fingerprints(result.stdout)
 
                 if not signing_certs:
                     raise UntrustedSignature(
-                        "Could not determine signing certificate from gpgsm output"
+                        "Could not determine signing certificate from gpgsm status output"
                     )
 
                 # Check if any of the signing certs match the trusted keyids

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -316,38 +316,56 @@ class GPGCliSignatureVendorTests(unittest.TestCase):
 class KeyIDMatchingTests(unittest.TestCase):
     """Tests for trusted key ID matching, independent of an installed gpg."""
 
-    def _run_with_stderr(self, vendor, stderr: str) -> None:
+    def _run_with_status(self, vendor, status: bytes, stderr: bytes = b"") -> None:
         completed = subprocess.CompletedProcess(
-            ["gpg"], 0, stdout=b"", stderr=stderr.encode()
+            ["gpg"], 0, stdout=status, stderr=stderr
         )
         with mock.patch("subprocess.run", return_value=completed):
             vendor.verify(b"data", b"signature")
 
+    @staticmethod
+    def _validsig(fpr: str, primary: str | None = None) -> bytes:
+        primary = primary or fpr
+        return (
+            f"[GNUPG:] VALIDSIG {fpr} 2020-01-01 0 0 4 0 1 8 00 {primary}\n"
+        ).encode()
+
     def test_gpg_rejects_keyid_embedded_in_fingerprint(self) -> None:
         """A trusted ID buried inside an untrusted fingerprint is not a match."""
         vendor = GPGCliSignatureVendor(keyids=["DEADBEEF"])
-        stderr = (
-            "gpg: Good signature\n"
-            "Primary key fingerprint: 1111 1111 1111 1111 1111  "
-            "1111 1111 DEAD BEEF 1111\n"
-        )
+        status = self._validsig("1111111111111111111111111111DEADBEEF1111")
         with self.assertRaises(UntrustedSignature):
-            self._run_with_stderr(vendor, stderr)
+            self._run_with_status(vendor, status)
 
     def test_gpg_accepts_short_keyid_suffix(self) -> None:
-        """A short key ID reported by gpg matches a trusted full fingerprint."""
-        trusted = "AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555"
-        vendor = GPGCliSignatureVendor(keyids=[trusted])
-        stderr = f"gpg: Good signature\ngpg: using RSA key {trusted[-16:]}\n"
+        """A short trusted key ID matches the suffix of the reported fingerprint."""
+        fpr = "AAAA1111BBBB2222CCCC3333DDDD4444EEEE5555"
+        vendor = GPGCliSignatureVendor(keyids=[fpr[-16:]])
         # Should not raise.
-        self._run_with_stderr(vendor, stderr)
+        self._run_with_status(vendor, self._validsig(fpr))
+
+    def test_gpg_ignores_spoofed_user_id_on_stderr(self) -> None:
+        """A trusted id echoed in the signer-controlled user id is not trusted."""
+        vendor = GPGCliSignatureVendor(keyids=["DEADBEEF1234"])
+        status = self._validsig("9999AAAA8888BBBB7777CCCC6666DDDD5555EEEE")
+        stderr = b'gpg: Good signature from "evil <x using RSA key DEADBEEF1234 >"\n'
+        with self.assertRaises(UntrustedSignature):
+            self._run_with_status(vendor, status, stderr=stderr)
 
     def test_x509_rejects_keyid_embedded_in_fingerprint(self) -> None:
         """Same suffix rule applies to the gpgsm/X.509 path."""
         vendor = X509SignatureVendor(keyids=["DEADBEEF"])
-        stderr = "gpgsm: Good signature from 1111DEADBEEF1111\n"
+        status = self._validsig("1111DEADBEEF1111111111111111111111111111")
         with self.assertRaises(UntrustedSignature):
-            self._run_with_stderr(vendor, stderr)
+            self._run_with_status(vendor, status)
+
+    def test_x509_ignores_spoofed_subject_on_stderr(self) -> None:
+        """A trusted id placed in the signer-controlled cert subject is not trusted."""
+        vendor = X509SignatureVendor(keyids=["DEADBEEF1234"])
+        status = self._validsig("9999AAAA8888BBBB7777CCCC6666DDDD5555EEEE")
+        stderr = b"gpgsm: Good signature from CN = DEADBEEF1234\n"
+        with self.assertRaises(UntrustedSignature):
+            self._run_with_status(vendor, status, stderr=stderr)
 
 
 class X509SignatureVendorTests(unittest.TestCase):


### PR DESCRIPTION
1. GPGCliSignatureVendor.verify and X509SignatureVendor.verify pick the signing key/certificate id out of gpg/gpgsm's human-readable stderr (the "Good signature from <user id>", "using RSA key ...", and "aka ..." lines).
2. The user id and certificate subject in those lines are chosen by the signer, so a key gpg/gpgsm already accepts can carry a trusted key id as a standalone token (user id `x using RSA key DEADBEEF1234 `, or subject `CN = DEADBEEF1234`). With keyids set, verify() then extracts that token as the signer and accepts the signature as if it came from the trusted key. The suffix matching added in #2221 does not help here, since the spoofed token is the whole reported id.
3. Both vendors now read the signing key from gpg's machine-readable `--status-fd` VALIDSIG line (the signing-key and primary-key fingerprints, computed by gpg) through a shared `_parse_status_fingerprints` helper; the keyid suffix comparison is unchanged.

Validation: mock-based tests in KeyIDMatchingTests cover the spoofed user id and certificate subject (now rejected), plus the existing embedded-vs-suffix behavior against the VALIDSIG fingerprint. American English throughout.