### PR TITLE
contain working-tree diff reads within the work tree

### DIFF
--- a/dulwich/diff.py
+++ b/dulwich/diff.py
@@ -94,6 +94,28 @@ def should_include_path(path: bytes, paths: Sequence[bytes] | None) -> bool:
     return any(path == p or path.startswith(p + b"/") for p in paths)
 
 
+def _worktree_fs_path(repo_path: str, tree_path: bytes) -> str:
+    """Resolve a tree/index path to a work-tree file path within the work tree.
+
+    Tree and index entries can come from an attacker-controlled object (a
+    fetched or cloned commit), so an entry named ``..`` would otherwise let the
+    working-tree diff read a file outside the work tree through ``os.path.join``
+    and disclose its contents in the diff output. The path is normalized
+    lexically with ``os.path.abspath`` rather than ``os.path.realpath`` so a
+    committed symlink whose target lies outside the tree is still diffed as a
+    symlink instead of being followed.
+
+    Raises:
+      ValueError: if the resolved path falls outside the work tree.
+    """
+    full_path = os.path.join(repo_path, tree_path.decode("utf-8"))
+    root = os.path.abspath(repo_path)
+    resolved = os.path.abspath(full_path)
+    if resolved != root and not resolved.startswith(root + os.sep):
+        raise ValueError(f"path escapes work tree: {tree_path!r}")
+    return full_path
+
+
 def diff_index_to_tree(
     repo: Repo,
     outstream: BinaryIO,
@@ -188,7 +210,7 @@ def diff_working_tree_to_tree(
             continue
 
         processed_paths.add(path)
-        full_path = os.path.join(repo.path, path.decode("utf-8"))
+        full_path = _worktree_fs_path(repo.path, path)
 
         # Get the old file from tree
         old_mode = entry.mode
@@ -339,7 +361,7 @@ def diff_working_tree_to_tree(
         if not should_include_path(path, paths):
             continue
 
-        full_path = os.path.join(repo.path, path.decode("utf-8"))
+        full_path = _worktree_fs_path(repo.path, path)
 
         try:
             # Use lstat to handle symlinks properly
@@ -442,7 +464,7 @@ def diff_working_tree_to_index(
         else:
             old_blob = None
 
-        full_path = os.path.join(repo.path, tree_path.decode("utf-8"))
+        full_path = _worktree_fs_path(repo.path, tree_path)
         try:
             # Use lstat to handle symlinks properly
             st = os.lstat(full_path)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -22,9 +22,17 @@
 """Tests for diff functionality."""
 
 import io
+import os
+import shutil
+import tempfile
 import unittest
 
-from dulwich.diff import ColorizedDiffStream
+from dulwich.diff import (
+    ColorizedDiffStream,
+    diff_working_tree_to_tree,
+)
+from dulwich.objects import Blob, Commit, Tree
+from dulwich.repo import Repo
 
 from . import TestCase
 
@@ -182,3 +190,67 @@ class MockColorizedDiffStreamTests(TestCase):
         # Test that some output was produced
         result = self.output.getvalue()
         self.assertGreaterEqual(len(result), 0)
+
+
+class WorkingTreeDiffPathTraversalTests(TestCase):
+    """Tests that working-tree diffs stay inside the work tree."""
+
+    def setUp(self):
+        super().setUp()
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.test_dir)
+        self.repo_path = os.path.join(self.test_dir, "work")
+        os.mkdir(self.repo_path)
+        self.repo = Repo.init(self.repo_path)
+        self.addCleanup(self.repo.close)
+
+    def _commit_tree(self, tree):
+        commit = Commit()
+        commit.tree = tree.id
+        commit.author = commit.committer = b"Test <test@example.com>"
+        commit.author_time = commit.commit_time = 1
+        commit.author_timezone = commit.commit_timezone = 0
+        commit.message = b"x"
+        self.repo.object_store.add_object(commit)
+        return commit
+
+    def test_diff_does_not_escape_work_tree(self):
+        # A secret file living next to the work tree, not in it.
+        secret = os.path.join(self.test_dir, "secret.txt")
+        with open(secret, "wb") as f:
+            f.write(b"SECRET-OUTSIDE-WORKTREE")
+
+        # Craft a tree whose entry name is ".." so the path resolves outside
+        # the work tree (objects/<..>/secret.txt).
+        blob = Blob.from_string(b"placeholder\n")
+        self.repo.object_store.add_object(blob)
+        inner = Tree()
+        inner.add(b"secret.txt", 0o100644, blob.id)
+        self.repo.object_store.add_object(inner)
+        outer = Tree()
+        outer.add(b"..", 0o040000, inner.id)
+        self.repo.object_store.add_object(outer)
+        commit = self._commit_tree(outer)
+
+        out = io.BytesIO()
+        self.assertRaises(
+            ValueError, diff_working_tree_to_tree, self.repo, out, commit.id
+        )
+        self.assertNotIn(b"SECRET-OUTSIDE-WORKTREE", out.getvalue())
+
+    def test_diff_allows_normal_path(self):
+        blob = Blob.from_string(b"old\n")
+        self.repo.object_store.add_object(blob)
+        tree = Tree()
+        tree.add(b"a", 0o100644, blob.id)
+        self.repo.object_store.add_object(tree)
+        commit = self._commit_tree(tree)
+
+        with open(os.path.join(self.repo_path, "a"), "wb") as f:
+            f.write(b"new\n")
+
+        out = io.BytesIO()
+        diff_working_tree_to_tree(self.repo, out, commit.id)
+        data = out.getvalue()
+        self.assertIn(b"-old", data)
+        self.assertIn(b"+new", data)


### PR DESCRIPTION
1. diff_working_tree_to_tree and diff_working_tree_to_index join each tree/index entry path onto repo.path and then lstat/open/readlink the result.
2. a fetched commit's tree is untrusted, and an entry named ".." resolves outside the work tree, so `dulwich diff <commit>` reads an arbitrary file like ../secret.txt and copies its contents into the diff output.
3. added _worktree_fs_path to resolve the joined path with os.path.abspath (lexical, not realpath, so a committed symlink pointing outside the tree is still diffed as a symlink instead of being followed) and reject anything outside the work tree, at all three working-tree read sites.

Checked with a commit whose tree carries a ".." entry: before the change the out-of-tree file contents show up in the diff; after it the read is refused with a clear error. Regression test added.