### PR TITLE
reject internal addresses when fetching bundle uris

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.2.7	2026-06-12
 
+ * SECURITY: Refuse to fetch a bundle URI that resolves to a loopback,
+   link-local, private or otherwise non-public address, and validate every
+   redirect hop, so a hostile bundle list can no longer point ``clone`` at
+   internal services (SSRF). (netliomax25-code)
+
  * Verify that an object retrieved by id actually hashes to the requested
    id, raising ``ChecksumMismatch`` otherwise. (Jelmer Vernooĳ, #2223)
 

--- a/dulwich/bundle_uri.py
+++ b/dulwich/bundle_uri.py
@@ -36,11 +36,16 @@ __all__ = [
     "parse_bundle_list",
 ]
 
+import ipaddress
+import socket
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse
+
+# Maximum number of redirects to follow when fetching a bundle URI.
+_MAX_BUNDLE_REDIRECTS = 5
 
 if TYPE_CHECKING:
     from .bundle import Bundle
@@ -244,6 +249,76 @@ def _is_bundle_file(data: bytes) -> bool:
     return data.startswith((b"# v2 git bundle\n", b"# v3 git bundle\n"))
 
 
+def _is_internal_address(ip: "ipaddress.IPv4Address | ipaddress.IPv6Address") -> bool:
+    """Return True if ``ip`` is a non-public address we must not fetch from."""
+    mapped = getattr(ip, "ipv4_mapped", None)
+    if mapped is not None:
+        # Treat ::ffff:127.0.0.1 and friends as their embedded IPv4 address.
+        ip = mapped
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def _resolve_host_addresses(
+    host: str,
+) -> list["ipaddress.IPv4Address | ipaddress.IPv6Address"]:
+    """Resolve ``host`` to the list of IP addresses it points at."""
+    try:
+        return [ipaddress.ip_address(host)]
+    except ValueError:
+        pass
+
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return []
+    for info in infos:
+        address = info[4][0]
+        if not isinstance(address, str):
+            continue
+        raw = address.split("%", 1)[0]
+        try:
+            addresses.append(ipaddress.ip_address(raw))
+        except ValueError:
+            continue
+    return addresses
+
+
+def _check_bundle_uri_safe(uri: str) -> None:
+    """Validate a bundle URI before fetching it.
+
+    The bundle list is supplied by an untrusted remote, so its entry URIs are
+    rejected unless they use http/https and resolve to a public address. This
+    keeps a hostile list from pointing us at loopback, link-local (the cloud
+    metadata endpoint 169.254.169.254) or other internal hosts (SSRF).
+
+    Raises:
+        BundleURIError: if the URI scheme is unsupported, the host is missing
+            or unresolvable, or it resolves to a non-public address.
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme not in ("http", "https"):
+        raise BundleURIError(f"Unsupported URI scheme: {parsed.scheme}")
+    host = parsed.hostname
+    if not host:
+        raise BundleURIError(f"Bundle URI has no host: {uri}")
+    addresses = _resolve_host_addresses(host)
+    if not addresses:
+        raise BundleURIError(f"Could not resolve bundle URI host: {host}")
+    for ip in addresses:
+        if _is_internal_address(ip):
+            raise BundleURIError(
+                f"Refusing to fetch bundle from non-public address {ip} ({host})"
+            )
+
+
 def fetch_bundle_uri(
     uri: str,
     progress: Callable[[bytes], None] | None = None,
@@ -269,18 +344,27 @@ def fetch_bundle_uri(
 
     from .bundle import read_bundle
 
-    parsed = urlparse(uri)
-    if parsed.scheme not in ("http", "https"):
-        raise BundleURIError(f"Unsupported URI scheme: {parsed.scheme}")
-
     http = urllib3.PoolManager(timeout=timeout)
+    current = uri
     try:
-        response = http.request("GET", uri)
-
-        if response.status != 200:
-            raise BundleURIError(f"HTTP error {response.status} fetching {uri}")
-
-        data = response.data
+        # Follow redirects manually so every hop is validated; urllib3's
+        # automatic redirect following would otherwise let a public host
+        # bounce us to an internal one.
+        for _ in range(_MAX_BUNDLE_REDIRECTS + 1):
+            _check_bundle_uri_safe(current)
+            response = http.request("GET", current, redirect=False)
+            if response.status in (301, 302, 303, 307, 308):
+                location = response.headers.get("Location")
+                if not location:
+                    raise BundleURIError(f"Redirect without Location from {current}")
+                current = urljoin(current, location)
+                continue
+            if response.status != 200:
+                raise BundleURIError(f"HTTP error {response.status} fetching {current}")
+            data = response.data
+            break
+        else:
+            raise BundleURIError(f"Too many redirects fetching {uri}")
     except urllib3.exceptions.HTTPError as e:
         raise BundleURIError(f"HTTP error fetching {uri}: {e}") from e
     finally:

--- a/tests/test_bundle_uri.py
+++ b/tests/test_bundle_uri.py
@@ -23,14 +23,17 @@
 
 import os
 import tempfile
+from unittest import mock
 
 from dulwich.bundle_uri import (
     BundleList,
     BundleListEntry,
     BundleURIError,
+    _check_bundle_uri_safe,
     _filter_bundle_entries,
     _is_absolute_uri,
     _resolve_relative_uri,
+    fetch_bundle_uri,
     parse_bundle_list,
 )
 
@@ -245,6 +248,42 @@ class URIResolutionTests(TestCase):
             _resolve_relative_uri(base, "../other/daily.bundle"),
             "https://example.com/git/other/daily.bundle",
         )
+
+
+class BundleURISafetyTests(TestCase):
+    def test_check_rejects_internal_addresses(self) -> None:
+        internal_uris = [
+            "http://127.0.0.1/x.bundle",
+            "http://169.254.169.254/latest/meta-data/",
+            "http://10.0.0.5/x.bundle",
+            "http://192.168.1.1/x.bundle",
+            "http://[::1]/x.bundle",
+            "http://[::ffff:127.0.0.1]/x.bundle",
+            "http://0.0.0.0/x.bundle",
+        ]
+        for uri in internal_uris:
+            with self.assertRaises(BundleURIError):
+                _check_bundle_uri_safe(uri)
+
+    def test_check_rejects_unsupported_scheme(self) -> None:
+        for uri in ("file:///etc/passwd", "ftp://example.com/x", "gopher://1.1.1.1/"):
+            with self.assertRaises(BundleURIError):
+                _check_bundle_uri_safe(uri)
+
+    def test_check_allows_public_address(self) -> None:
+        # Public literal addresses pass the safety check (no DNS needed).
+        _check_bundle_uri_safe("http://93.184.216.34/x.bundle")
+        _check_bundle_uri_safe("https://1.1.1.1/x.bundle")
+
+    def test_fetch_blocks_internal_before_request(self) -> None:
+        # A hostile bundle list pointing at an internal address must be
+        # rejected before any HTTP request is issued.
+        with mock.patch("urllib3.PoolManager") as pool_manager:
+            pool_manager.return_value.request.side_effect = AssertionError(
+                "request must not be issued for an internal address"
+            )
+            with self.assertRaises(BundleURIError):
+                fetch_bundle_uri("http://169.254.169.254/latest/meta-data/")
 
 
 class BundleFilteringTests(TestCase):


### PR DESCRIPTION
1. fetch_bundle_uri validated only the URI scheme, so the entry URIs in a bundle list (served by an untrusted remote) were fetched with no check on the destination host.
2. apply_bundle_uri fetches each of those entries during clone(bundle_uri=...), and urllib3 follows redirects by default, so a hostile list (or a redirect from a public host) could drive GET requests at loopback, link-local 169.254.169.254, or private addresses (SSRF).
3. validate the resolved address at the fetch chokepoint, rejecting private/loopback/link-local/reserved/multicast/unspecified targets (including IPv4-mapped IPv6), and follow redirects manually so each hop is validated too.

Confirmed with a local server: before the change, fetch_bundle_uri("http://127.0.0.1:<port>/x") issued the request; after, it raises BundleURIError without connecting.