### PR TITLE
cap decompressed size of gzip request bodies

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,13 @@
    ``LimitedInputFilter`` also caps requests that omit ``Content-Length``.
    (Jelmer Vernooĳ)
 
+ * SECURITY: Cap the decompressed size of gzip-encoded request bodies in
+   ``dulwich.web``. ``GunzipFilter`` inflated ``Content-Encoding: gzip``
+   bodies with no bound on the output size, so a small compressed POST
+   could expand to gigabytes in server memory. Bodies inflating past
+   10 MiB are now rejected with ``413 Request Entity Too Large``.
+   (netliomax25-code)
+
 1.2.8	2026-07-05
 
  * Enumerate the objects to push before the HTTP ``git-receive-pack``

--- a/NEWS
+++ b/NEWS
@@ -240,6 +240,13 @@
    ``LimitedInputFilter`` also caps requests that omit ``Content-Length``.
    (Jelmer Vernooĳ)
 
+ * SECURITY: Cap the decompressed size of gzip-encoded request bodies in
+   ``dulwich.web``. ``GunzipFilter`` inflated ``Content-Encoding: gzip``
+   bodies with no bound on the output size, so a small compressed POST
+   could expand to gigabytes in server memory. Bodies inflating past
+   10 MiB are now rejected with ``413 Request Entity Too Large``.
+   (netliomax25-code)
+
 1.2.8	2026-07-05
 
  * Enumerate the objects to push before the HTTP ``git-receive-pack``

--- a/dulwich/web.py
+++ b/dulwich/web.py
@@ -26,7 +26,9 @@ __all__ = [
     "HTTP_FORBIDDEN",
     "HTTP_NOT_FOUND",
     "HTTP_OK",
+    "HTTP_REQUEST_ENTITY_TOO_LARGE",
     "MAX_CHUNK_SIZE",
+    "MAX_DECOMPRESSED_REQUEST_SIZE",
     "MAX_REQUEST_SIZE",
     "ChunkedEncodingError",
     "GunzipFilter",
@@ -160,6 +162,7 @@ logger = log_utils.getLogger(__name__)
 HTTP_OK = "200 OK"
 HTTP_NOT_FOUND = "404 Not Found"
 HTTP_FORBIDDEN = "403 Forbidden"
+HTTP_REQUEST_ENTITY_TOO_LARGE = "413 Request Entity Too Large"
 HTTP_ERROR = "500 Internal Server Error"
 
 
@@ -798,12 +801,37 @@ class HTTPGitApplication:
         return handler(req, self.backend, mat)
 
 
-class GunzipFilter:
-    """WSGI middleware that unzips gzip-encoded requests before passing on to the underlying application."""
+# Upper bound on the decompressed size of a gzip-encoded request body.
+# ``LimitedInputFilter`` only bounds the compressed body, and DEFLATE expands
+# up to ~1000x, so a tiny request could otherwise inflate to gigabytes in
+# memory. C git has no direct equivalent: http-backend buffers the compressed
+# body (bounded by GIT_HTTP_MAX_REQUEST_BUFFER) and streams the inflated bytes
+# into a separate service process, while dulwich inflates in-process. Requests
+# inflating past the cap are rejected with 413.
+MAX_DECOMPRESSED_REQUEST_SIZE = 10 * 1024 * 1024
 
-    def __init__(self, application: WSGIApplication) -> None:
-        """Initialize GunzipFilter with WSGI application."""
+
+class GunzipFilter:
+    """WSGI middleware that unzips gzip-encoded requests before passing on to the underlying application.
+
+    Bodies whose decompressed size exceeds ``max_decompressed_size`` are
+    rejected with ``413 Request Entity Too Large``.
+    """
+
+    def __init__(
+        self,
+        application: WSGIApplication,
+        max_decompressed_size: int = MAX_DECOMPRESSED_REQUEST_SIZE,
+    ) -> None:
+        """Initialize GunzipFilter with WSGI application.
+
+        Args:
+          application: The wrapped WSGI application.
+          max_decompressed_size: Maximum decompressed size of a gzip-encoded
+            request body; larger bodies are rejected with 413.
+        """
         self.app = application
+        self.max_decompressed_size = max_decompressed_size
 
     def __call__(
         self,
@@ -814,9 +842,28 @@ class GunzipFilter:
         import gzip
 
         if environ.get("HTTP_CONTENT_ENCODING", "") == "gzip":
-            environ["wsgi.input"] = gzip.GzipFile(
+            # Inflate the body up front so its size can be checked before the
+            # request is dispatched; handlers start their response before
+            # reading the body, at which point a 413 is no longer possible.
+            zfile = gzip.GzipFile(
                 filename=None, fileobj=environ["wsgi.input"], mode="rb"
             )
+            buf = BytesIO()
+            while True:
+                chunk = zfile.read(65536)
+                if not chunk:
+                    break
+                if buf.tell() + len(chunk) > self.max_decompressed_size:
+                    zfile.close()
+                    start_response(
+                        HTTP_REQUEST_ENTITY_TOO_LARGE,
+                        [("Content-Type", "text/plain")],
+                    )
+                    return [b"decompressed request body exceeds maximum size\n"]
+                buf.write(chunk)
+            zfile.close()
+            buf.seek(0)
+            environ["wsgi.input"] = buf
             del environ["HTTP_CONTENT_ENCODING"]
             environ.pop("CONTENT_LENGTH", None)
 

--- a/dulwich/web.py
+++ b/dulwich/web.py
@@ -26,7 +26,9 @@ __all__ = [
     "HTTP_FORBIDDEN",
     "HTTP_NOT_FOUND",
     "HTTP_OK",
+    "HTTP_REQUEST_ENTITY_TOO_LARGE",
     "MAX_CHUNK_SIZE",
+    "MAX_DECOMPRESSED_REQUEST_SIZE",
     "MAX_REQUEST_SIZE",
     "ChunkedEncodingError",
     "GunzipFilter",
@@ -160,6 +162,7 @@ logger = log_utils.getLogger(__name__)
 HTTP_OK = "200 OK"
 HTTP_NOT_FOUND = "404 Not Found"
 HTTP_FORBIDDEN = "403 Forbidden"
+HTTP_REQUEST_ENTITY_TOO_LARGE = "413 Request Entity Too Large"
 HTTP_ERROR = "500 Internal Server Error"
 
 
@@ -812,12 +815,37 @@ class HTTPGitApplication:
         return handler(req, self.backend, mat)
 
 
-class GunzipFilter:
-    """WSGI middleware that unzips gzip-encoded requests before passing on to the underlying application."""
+# Upper bound on the decompressed size of a gzip-encoded request body.
+# ``LimitedInputFilter`` only bounds the compressed body, and DEFLATE expands
+# up to ~1000x, so a tiny request could otherwise inflate to gigabytes in
+# memory. C git has no direct equivalent: http-backend buffers the compressed
+# body (bounded by GIT_HTTP_MAX_REQUEST_BUFFER) and streams the inflated bytes
+# into a separate service process, while dulwich inflates in-process. Requests
+# inflating past the cap are rejected with 413.
+MAX_DECOMPRESSED_REQUEST_SIZE = 10 * 1024 * 1024
 
-    def __init__(self, application: WSGIApplication) -> None:
-        """Initialize GunzipFilter with WSGI application."""
+
+class GunzipFilter:
+    """WSGI middleware that unzips gzip-encoded requests before passing on to the underlying application.
+
+    Bodies whose decompressed size exceeds ``max_decompressed_size`` are
+    rejected with ``413 Request Entity Too Large``.
+    """
+
+    def __init__(
+        self,
+        application: WSGIApplication,
+        max_decompressed_size: int = MAX_DECOMPRESSED_REQUEST_SIZE,
+    ) -> None:
+        """Initialize GunzipFilter with WSGI application.
+
+        Args:
+          application: The wrapped WSGI application.
+          max_decompressed_size: Maximum decompressed size of a gzip-encoded
+            request body; larger bodies are rejected with 413.
+        """
         self.app = application
+        self.max_decompressed_size = max_decompressed_size
 
     def __call__(
         self,
@@ -828,9 +856,28 @@ class GunzipFilter:
         import gzip
 
         if environ.get("HTTP_CONTENT_ENCODING", "") == "gzip":
-            environ["wsgi.input"] = gzip.GzipFile(
+            # Inflate the body up front so its size can be checked before the
+            # request is dispatched; handlers start their response before
+            # reading the body, at which point a 413 is no longer possible.
+            zfile = gzip.GzipFile(
                 filename=None, fileobj=environ["wsgi.input"], mode="rb"
             )
+            buf = BytesIO()
+            while True:
+                chunk = zfile.read(65536)
+                if not chunk:
+                    break
+                if buf.tell() + len(chunk) > self.max_decompressed_size:
+                    zfile.close()
+                    start_response(
+                        HTTP_REQUEST_ENTITY_TOO_LARGE,
+                        [("Content-Type", "text/plain")],
+                    )
+                    return [b"decompressed request body exceeds maximum size\n"]
+                buf.write(chunk)
+            zfile.close()
+            buf.seek(0)
+            environ["wsgi.input"] = buf
             del environ["HTTP_CONTENT_ENCODING"]
             environ.pop("CONTENT_LENGTH", None)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -752,3 +752,48 @@ class GunzipTestCase(HTTPGitApplicationTestCase):
             MinimalistWSGIInputStream2(zstream.read()),
             zlength,
         )
+
+    def test_decompression_bomb_rejected(self) -> None:
+        """A body inflating past the cap gets a 413 and never reaches the app."""
+        cap = 4096
+        called = []
+        statuses = []
+
+        def app(environ, start_response):
+            called.append(True)
+            return []
+
+        def start_response(status, headers):
+            statuses.append(status)
+
+        raw = b"\x00" * (1024 * 1024)
+        zstream, zlength = self._get_zstream(raw)
+        self.assertLess(zlength, cap)
+        environ = {
+            "wsgi.input": zstream,
+            "HTTP_CONTENT_ENCODING": "gzip",
+            "CONTENT_LENGTH": str(zlength),
+        }
+        body = GunzipFilter(app, max_decompressed_size=cap)(environ, start_response)
+        self.assertEqual(["413 Request Entity Too Large"], statuses)
+        self.assertEqual([], called)
+        self.assertNotEqual([], list(body))
+
+    def test_decompression_exactly_at_cap_allowed(self) -> None:
+        """A body whose decompressed size equals the cap passes through."""
+        cap = 4096
+        captured = {}
+
+        def app(environ, start_response):
+            captured["read"] = environ["wsgi.input"].read()
+            return []
+
+        raw = b"\x00" * cap
+        zstream, zlength = self._get_zstream(raw)
+        environ = {
+            "wsgi.input": zstream,
+            "HTTP_CONTENT_ENCODING": "gzip",
+            "CONTENT_LENGTH": str(zlength),
+        }
+        GunzipFilter(app, max_decompressed_size=cap)(environ, None)
+        self.assertEqual(raw, captured["read"])

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -815,3 +815,48 @@ class GunzipTestCase(HTTPGitApplicationTestCase):
             MinimalistWSGIInputStream2(zstream.read()),
             zlength,
         )
+
+    def test_decompression_bomb_rejected(self) -> None:
+        """A body inflating past the cap gets a 413 and never reaches the app."""
+        cap = 4096
+        called = []
+        statuses = []
+
+        def app(environ, start_response):
+            called.append(True)
+            return []
+
+        def start_response(status, headers):
+            statuses.append(status)
+
+        raw = b"\x00" * (1024 * 1024)
+        zstream, zlength = self._get_zstream(raw)
+        self.assertLess(zlength, cap)
+        environ = {
+            "wsgi.input": zstream,
+            "HTTP_CONTENT_ENCODING": "gzip",
+            "CONTENT_LENGTH": str(zlength),
+        }
+        body = GunzipFilter(app, max_decompressed_size=cap)(environ, start_response)
+        self.assertEqual(["413 Request Entity Too Large"], statuses)
+        self.assertEqual([], called)
+        self.assertNotEqual([], list(body))
+
+    def test_decompression_exactly_at_cap_allowed(self) -> None:
+        """A body whose decompressed size equals the cap passes through."""
+        cap = 4096
+        captured = {}
+
+        def app(environ, start_response):
+            captured["read"] = environ["wsgi.input"].read()
+            return []
+
+        raw = b"\x00" * cap
+        zstream, zlength = self._get_zstream(raw)
+        environ = {
+            "wsgi.input": zstream,
+            "HTTP_CONTENT_ENCODING": "gzip",
+            "CONTENT_LENGTH": str(zlength),
+        }
+        GunzipFilter(app, max_decompressed_size=cap)(environ, None)
+        self.assertEqual(raw, captured["read"])


### PR DESCRIPTION
1. `LimitedInputFilter` caps the gzip-encoded request body at Content-Length, but `GunzipFilter` then decompresses it with no bound on the output size.
2. DEFLATE expands by up to ~1000x, so a small compressed POST body (a git client sends `Content-Encoding: gzip` on upload-pack requests, reachable before authentication on a public repo) is a decompression bomb: a ~200 KiB body inflates to ~200 MiB that the handler reads into memory.

`GunzipFilter` now inflates the body up front, bounded at 10 MiB by default, and rejects anything larger with `413 Request Entity Too Large`. The check happens before the request is dispatched because handlers call `start_response` before reading the body, at which point a 413 can no longer be sent. Added regression tests and a NEWS entry.

Note c git doesn't cap the decompressed size itself; http-backend bounds the compressed body it buffers (`GIT_HTTP_MAX_REQUEST_BUFFER`) and streams the inflated bytes into a separate service process, while dulwich inflates in-process.
