### PR TITLE
validate object ids received from the server

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -1932,6 +1932,12 @@ class DiskObjectStore(PackBasedObjectStore):
         return new_packs
 
     def _get_shafile_path(self, sha: ObjectID | RawObjectID) -> str:
+        # Reject anything that is neither a valid hex object id nor a raw
+        # binary oid before building a path. Otherwise a malformed id (e.g.
+        # one containing path separators) would be joined into a filename
+        # that escapes the objects directory.
+        if not valid_hexsha(sha) and len(sha) != self.object_format.oid_length:
+            raise ValueError(f"Invalid object id {sha!r}")
         # Check from object dir
         return hex_to_filename(os.fspath(self.path), sha)
 

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -426,6 +426,18 @@ class RefsContainer:
             return
         raise RefFormatError(name)
 
+    def _check_ref_value(self, ref: ObjectID) -> None:
+        """Ensure a ref value is a valid object id or a symref.
+
+        Args:
+          ref: The value a ref is being set to.
+
+        Raises:
+          ValueError: if the value is neither a valid sha nor a symref.
+        """
+        if not (valid_hexsha(ref) or ref.startswith(SYMREF)):
+            raise ValueError(f"{ref!r} must be a valid sha (40 chars) or a symref")
+
     def read_ref(self, refname: Ref) -> bytes | None:
         """Read a reference without following any references.
 
@@ -549,8 +561,7 @@ class RefsContainer:
           name: The refname to set.
           ref: The new sha the refname will refer to.
         """
-        if not (valid_hexsha(ref) or ref.startswith(SYMREF)):
-            raise ValueError(f"{ref!r} must be a valid sha (40 chars) or a symref")
+        self._check_ref_value(ref)
         self.set_if_equals(name, None, ref)
 
     def remove_if_equals(
@@ -728,6 +739,7 @@ class DictRefsContainer(RefsContainer):
         Returns:
           True if the set was successful, False otherwise.
         """
+        self._check_ref_value(new_ref)
         if old_ref is not None and self._refs.get(name, ZERO_SHA) != old_ref:
             return False
         # Only update the specific ref requested, not the whole chain
@@ -768,6 +780,7 @@ class DictRefsContainer(RefsContainer):
         Returns:
           True if the add was successful, False otherwise.
         """
+        self._check_ref_value(ref)
         if name in self._refs:
             return False
         self._refs[name] = ref
@@ -1164,6 +1177,7 @@ class DiskRefsContainer(RefsContainer):
         Returns: True if the set was successful, False otherwise.
         """
         self._check_refname(name)
+        self._check_ref_value(new_ref)
         try:
             realnames, _ = self.follow(name)
             realname = realnames[-1]
@@ -1244,6 +1258,7 @@ class DiskRefsContainer(RefsContainer):
           message: Optional message for reflog
         Returns: True if the add was successful, False otherwise.
         """
+        self._check_ref_value(ref)
         try:
             realnames, contents = self.follow(name)
             if contents is not None:

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -205,6 +205,17 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         TestCase.tearDown(self)
         PackBasedObjectStoreTests.tearDown(self)
 
+    def test_contains_rejects_invalid_sha(self) -> None:
+        # A malformed object id (e.g. one advertised by a malicious server)
+        # must not be turned into a path that escapes the objects directory.
+        for bad in (b"../../config", b"../../../../etc/passwd"):
+            self.assertRaises(ValueError, self.store.__contains__, bad)
+
+    def test_get_shafile_path_rejects_invalid_sha(self) -> None:
+        self.assertRaises(
+            ValueError, self.store._get_shafile_path, b"../../../../etc/passwd"
+        )
+
     def test_loose_compression_level(self) -> None:
         alternate_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, alternate_dir)

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -290,6 +290,25 @@ class RefsContainerTests:
         self.assertTrue(self._refs.add_if_new(b"refs/some/ref", nines))
         self.assertEqual(nines, self._refs[b"refs/some/ref"])
 
+    def test_set_if_equals_rejects_invalid_value(self) -> None:
+        # A non-hex value (e.g. one advertised by a malicious server) must be
+        # rejected before it is stored or used in a path.
+        self.assertRaises(
+            ValueError,
+            self._refs.set_if_equals,
+            b"refs/heads/master",
+            None,
+            b"../../../../etc/passwd",
+        )
+
+    def test_add_if_new_rejects_invalid_value(self) -> None:
+        self.assertRaises(
+            ValueError,
+            self._refs.add_if_new,
+            b"refs/heads/new",
+            b"../../config",
+        )
+
     def test_set_symbolic_ref(self) -> None:
         self._refs.set_symbolic_ref(b"refs/heads/symbolic", b"refs/heads/master")
         self.assertEqual(


### PR DESCRIPTION
A malformed object id advertised by a remote (e.g. one containing path separators like `../../config`) could be fed into object-store membership checks and stored as a ref value during fetch/clone.

1. `DiskObjectStore._get_shafile_path` joined the id straight into a filename via `hex_to_filename`. Because `os.path.join` drops the prefix once the tail is absolute, an id like `../../config` escaped the objects directory, letting a hostile server use a `sha in object_store` check as an existence/parse oracle for arbitrary local paths.
2. On the refs side, `RefsContainer.__setitem__` already validated values, but `set_if_equals`/`add_if_new` (used by `import_refs` during fetch) did not, so a bad advertised id was persisted as a ref.

Fix keeps the rejection in the layers that consume the id, not the protocol parser:

1. `_get_shafile_path` now rejects an id that is neither valid hex nor a raw oid before building the path.
2. `set_if_equals`/`add_if_new` validate the new value through a shared `_check_ref_value` helper (the same check `__setitem__` already used), so the object store and the refs container refuse malformed ids regardless of caller.

Added regression tests in `tests/test_object_store.py` and `tests/test_refs.py`.
