### PR TITLE
client: enumerate objects to push before HTTP request body streams

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -76,6 +76,13 @@
    ``objects/info/packs`` but returned 404 for the pack itself.
    (Jelmer Vernooĳ)
 
+ * Enumerate the objects to push before the HTTP ``git-receive-pack``
+   request body starts streaming. ``generate_pack_data`` previously ran
+   lazily inside the body generator, after the header pkt-lines were
+   already on the wire, so on large repositories the request stalled
+   mid-body while objects were counted and servers such as GitHub aborted
+   the push with a timeout / "broken pipe". (synman, Jelmer Vernooĳ, #2248)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -4765,21 +4765,33 @@ class AbstractHttpGitClient(GitClient):
         if self.dumb:
             raise NotImplementedError(self.fetch_pack)
 
+        header_handler = _v1ReceivePackHeader(
+            list(negotiated_capabilities),
+            old_refs_typed,
+            new_refs,
+            push_options=push_options,
+        )
+        header_pkts = [pkt_line(pkt) for pkt in header_handler]
+
+        # Enumerate the objects to send before the request body starts
+        # streaming. generate_pack_data runs MissingObjectFinder, which can
+        # take several seconds on large repositories. If it ran lazily inside
+        # the body generator (after the header pkt-lines were already on the
+        # wire) the request would stall mid-body, and some servers (notably
+        # GitHub's git-receive-pack) abort such a stalled upload with a timeout
+        # or "broken pipe". Running it here keeps the body streaming -- so
+        # memory stays bounded -- while ensuring the slow phase happens before
+        # any bytes are sent. See https://github.com/jelmer/dulwich/issues/586
+        # and https://github.com/jelmer/dulwich/issues/2248.
+        pack_data_count, pack_data = generate_pack_data(
+            header_handler.have,
+            header_handler.want,
+            ofs_delta=(CAPABILITY_OFS_DELTA in negotiated_capabilities),
+            progress=progress,
+        )
+
         def body_generator() -> Iterator[bytes]:
-            header_handler = _v1ReceivePackHeader(
-                list(negotiated_capabilities),
-                old_refs_typed,
-                new_refs,
-                push_options=push_options,
-            )
-            for pkt in header_handler:
-                yield pkt_line(pkt)
-            pack_data_count, pack_data = generate_pack_data(
-                header_handler.have,
-                header_handler.want,
-                ofs_delta=(CAPABILITY_OFS_DELTA in negotiated_capabilities),
-                progress=progress,
-            )
+            yield from header_pkts
             if self._should_send_pack(new_refs):
                 yield from PackChunkGenerator(
                     # TODO: Don't hardcode object format

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1965,6 +1965,61 @@ class HttpGitClientTests(TestCase):
         client = HttpGitClient(clone_url, pool_manager=PoolManagerMock(), config=None)
         self.assertTrue(client._smart_request("git-upload-pack", clone_url, data=None))
 
+    def test_send_pack_enumerates_objects_before_request(self) -> None:
+        """generate_pack_data runs before the request body starts streaming.
+
+        On large repositories MissingObjectFinder is slow, and if it ran lazily
+        inside the body generator the request would stall mid-body and some
+        servers abort the push. See https://github.com/jelmer/dulwich/issues/2248.
+        """
+        events: list[str] = []
+
+        commit = Commit()
+        tree = Tree()
+        commit.tree = tree.id
+        commit.parents = []
+        commit.author = commit.committer = b"test user"
+        commit.commit_time = commit.author_time = 1174773719
+        commit.commit_timezone = commit.author_timezone = 0
+        commit.encoding = b"UTF-8"
+        commit.message = b"test message"
+
+        class _Client(HttpGitClient):
+            def _discover_references(
+                self, service, base_url, protocol_version=None, ref_prefix=None
+            ):
+                refs = {
+                    b"refs/heads/master": (b"310ca9477129b8586fa2afc779c1f57cf64bba6c")
+                }
+                caps = {b"report-status", b"ofs-delta"}
+                return refs, caps, base_url, {}, {}
+
+            def _smart_request(self, service, url, data):
+                events.append("smart_request")
+                # The body generator must still stream lazily; consuming it
+                # here mimics the real HTTP request reading the body.
+                for _chunk in data:
+                    pass
+                read = BytesIO(b"000eunpack ok\n0019ok refs/heads/master\n0000").read
+                resp = MagicMock()
+                resp.close = lambda: None
+                return resp, read
+
+        client = _Client("https://example.com/repo.git/")
+
+        def update_refs(refs):
+            return {b"refs/heads/master": commit.id}
+
+        def generate_pack_data(have, want, *, ofs_delta=False, progress=None):
+            events.append("generate_pack_data")
+            return pack_objects_to_data([(commit, None), (tree, b"")])
+
+        client.send_pack("/", update_refs, generate_pack_data)
+
+        # generate_pack_data must have been called before _smart_request, i.e.
+        # the objects are enumerated before the request body starts streaming.
+        self.assertEqual(["generate_pack_data", "smart_request"], events)
+
     def test_urllib3_protocol_error(self) -> None:
         from urllib3.exceptions import ProtocolError
         from urllib3.response import HTTPResponse


### PR DESCRIPTION
generate_pack_data ran lazily inside the body generator, after the header pkt-lines were already on the wire. On large repositories the slow MissingObjectFinder phase then stalled the request mid-body, and some servers (notably GitHub's git-receive-pack) abort such a stalled upload. Run it before any bytes are sent while still streaming the body, so memory stays bounded.

Fixes #2248