### PR TITLE
escape repository path in ssh command to match git sq_quote

### DIFF
--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3834,18 +3834,6 @@ class PLinkSSHVendor(SSHVendor):
 get_ssh_vendor: Callable[[], SSHVendor] = SubprocessSSHVendor
 
 
-def _quote_remote_path(path: bytes) -> bytes:
-    r"""Single-quote a repository path for the remote shell over SSH.
-
-    The git command we hand to the SSH vendor is run by the remote login
-    shell, so the path has to be quoted the way git does it (sq_quote): wrap
-    it in single quotes and rewrite every embedded single quote as ``'\\''``.
-    Wrapping in single quotes without escaping lets a path containing a quote
-    close the quoting and have the remainder run as shell.
-    """
-    return b"'" + path.replace(b"'", b"'\\''") + b"'"
-
-
 class SSHGitClient(TraditionalGitClient):
     """Git client that connects over SSH."""
 
@@ -4000,10 +3988,15 @@ class SSHGitClient(TraditionalGitClient):
             path = path.decode(self._remote_path_encoding)
         if path.startswith("/~"):
             path = path[1:]
+        import shlex
+
+        # The git command is run by the remote login shell, so the path has
+        # to be quoted to stop an embedded single quote from closing the
+        # quoting and having the remainder interpreted as shell.
         argv = (
             self._get_cmd_path(cmd)
             + b" "
-            + _quote_remote_path(path.encode(self._remote_path_encoding))
+            + shlex.quote(path).encode(self._remote_path_encoding)
         )
         kwargs = {}
         if self.password is not None:

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3834,6 +3834,18 @@ class PLinkSSHVendor(SSHVendor):
 get_ssh_vendor: Callable[[], SSHVendor] = SubprocessSSHVendor
 
 
+def _quote_remote_path(path: bytes) -> bytes:
+    r"""Single-quote a repository path for the remote shell over SSH.
+
+    The git command we hand to the SSH vendor is run by the remote login
+    shell, so the path has to be quoted the way git does it (sq_quote): wrap
+    it in single quotes and rewrite every embedded single quote as ``'\\''``.
+    Wrapping in single quotes without escaping lets a path containing a quote
+    close the quoting and have the remainder run as shell.
+    """
+    return b"'" + path.replace(b"'", b"'\\''") + b"'"
+
+
 class SSHGitClient(TraditionalGitClient):
     """Git client that connects over SSH."""
 
@@ -3990,9 +4002,8 @@ class SSHGitClient(TraditionalGitClient):
             path = path[1:]
         argv = (
             self._get_cmd_path(cmd)
-            + b" '"
-            + path.encode(self._remote_path_encoding)
-            + b"'"
+            + b" "
+            + _quote_remote_path(path.encode(self._remote_path_encoding))
         )
         kwargs = {}
         if self.password is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1153,6 +1153,20 @@ class SSHGitClientTests(TestCase):
         finally:
             proto.close()
 
+    def test_connect_escapes_quote_in_path(self) -> None:
+        # A path containing a single quote must not be able to close the
+        # quoting and have the remainder interpreted by the remote shell.
+        server = self.server
+        client = self.client
+
+        proto, _, _ = client._connect(b"command", b"/repo'; touch pwned; '")
+        try:
+            self.assertEqual(
+                b"git-command '/repo'\\''; touch pwned; '\\'''", server.command
+            )
+        finally:
+            proto.close()
+
     def test_ssh_command_precedence(self) -> None:
         # GIT_SSH / GIT_SSH_COMMAND are read at the CLI layer
         # (dulwich.cli._ssh_command_from_env); SSHGitClient itself should

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1143,7 +1143,7 @@ class SSHGitClientTests(TestCase):
         try:
             self.assertEqual(b"username", server.username)
             self.assertEqual(1337, server.port)
-            self.assertEqual(b"git-command '/path/to/repo'", server.command)
+            self.assertEqual(b"git-command /path/to/repo", server.command)
         finally:
             proto.close()
 
@@ -1162,7 +1162,7 @@ class SSHGitClientTests(TestCase):
         proto, _, _ = client._connect(b"command", b"/repo'; touch pwned; '")
         try:
             self.assertEqual(
-                b"git-command '/repo'\\''; touch pwned; '\\'''", server.command
+                b"git-command '/repo'\"'\"'; touch pwned; '\"'\"''", server.command
             )
         finally:
             proto.close()


### PR DESCRIPTION
1. `SSHGitClient._connect` wraps the repository path in single quotes but does not escape an embedded single quote, so a path containing a quote closes the quoting.
2. the SSH vendor passes that command string to the remote login shell, so the bytes after the closed quote run as shell. The path comes from the clone/fetch URL and is attacker-controllable, for example a malicious repo's `.gitmodules` `ssh://` submodule url during a recursive clone.

dulwich already rejects option-like (dash-prefixed) hosts but never escaped the path. Escaped embedded quotes the way git's `sq_quote` does (`'` becomes `'\\''`) so the remote shell receives the path verbatim. A path like `/repo'; touch pwned; '` no longer breaks out.