### PR TITLE
canonicalize file mode before chmod on checkout and patch apply

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -85,6 +85,11 @@
 
  * Support ``http.postBuffer``. (Jelmer Vernooĳ, #2248)
 
+ * SECURITY: Canonicalize file modes to ``0o644``/``0o755`` before ``chmod``
+   on checkout and patch apply, matching git. An untrusted tree entry or
+   patch ``new file mode`` could otherwise set setuid/setgid/sticky or
+   world-writable bits on a materialized file. (netliomax25-code)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -1876,7 +1876,11 @@ def build_file_from_blob(
             f.write(contents)
 
         if honor_filemode:
-            os.chmod(target_path, mode)
+            # Canonicalize to the permission bits git honors (0o644/0o755).
+            # The mode comes from a tree/index entry, which for an untrusted
+            # repository can carry setuid/setgid/sticky or world-writable bits;
+            # git reduces every regular-file mode to 0o644 or 0o755 on checkout.
+            os.chmod(target_path, cleanup_mode(mode))
 
     return os.lstat(target_path)
 

--- a/dulwich/patch.py
+++ b/dulwich/patch.py
@@ -1411,7 +1411,12 @@ def _apply_rename_or_copy(
         - ``original_lines``: Content lines if hunks need to be applied, None otherwise
         - ``should_continue``: True to skip to next patch, False to continue processing
     """
-    from .index import ConflictedIndexEntry, IndexEntry, index_entry_from_stat
+    from .index import (
+        ConflictedIndexEntry,
+        IndexEntry,
+        cleanup_mode,
+        index_entry_from_stat,
+    )
 
     # Strip path components
     src_stripped = src_path
@@ -1471,7 +1476,7 @@ def _apply_rename_or_copy(
         with open(dst_fs_path, "wb") as f:
             f.write(content)
         if patch.new_mode is not None:
-            os.chmod(dst_fs_path, patch.new_mode)
+            os.chmod(dst_fs_path, cleanup_mode(patch.new_mode))
 
     # Update index
     index = r.open_index(config=config)
@@ -1535,7 +1540,12 @@ def apply_patches(
     Raises:
         ValueError: If patch cannot be applied
     """
-    from .index import ConflictedIndexEntry, IndexEntry, index_entry_from_stat
+    from .index import (
+        ConflictedIndexEntry,
+        IndexEntry,
+        cleanup_mode,
+        index_entry_from_stat,
+    )
 
     if config is None:
         config = r.get_config_stack()
@@ -1635,7 +1645,7 @@ def apply_patches(
                     with open(fs_path, "wb") as f:
                         f.write(binary_content)
                     if patch.new_mode is not None:
-                        os.chmod(fs_path, patch.new_mode)
+                        os.chmod(fs_path, cleanup_mode(patch.new_mode))
 
                 # Update index
                 index = r.open_index(config=config)
@@ -1803,7 +1813,7 @@ def apply_patches(
 
                 # Update file mode if specified
                 if patch.new_mode is not None:
-                    os.chmod(fs_path, patch.new_mode)
+                    os.chmod(fs_path, cleanup_mode(patch.new_mode))
 
             # Update index
             index = r.open_index(config=config)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -627,6 +627,36 @@ class BuildIndexTests(TestCase):
             self.assertFalse(os.path.exists(os.path.join(repo.path, ".git", "a")))
             self.assertFalse(os.path.exists(os.path.join(repo.path, "c", "e")))
 
+    @skipIf(sys.platform == "win32", "Requires POSIX file modes")
+    def test_canonicalize_file_mode(self) -> None:
+        # A tree entry's mode is attacker-controlled for an untrusted repo.
+        # git reduces every regular-file mode to 0o644/0o755 on checkout, so
+        # setuid/setgid/sticky and world-writable bits from a hostile tree
+        # must never reach the working tree.
+
+        repo_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, repo_dir)
+        with Repo.init(repo_dir) as repo:
+            blob = Blob.from_string(b"#!/bin/sh\n")
+            tree = Tree()
+            # setuid + world-writable executable
+            tree[b"evil"] = (0o104777, blob.id)
+            # world-writable, non-executable
+            tree[b"plain"] = (0o100666, blob.id)
+            repo.object_store.add_objects([(o, None) for o in [blob, tree]])
+
+            build_index_from_tree(
+                repo.path, repo.index_path(), repo.object_store, tree.id
+            )
+
+            evil_mode = os.lstat(os.path.join(repo.path, "evil")).st_mode
+            self.assertEqual(stat.S_IMODE(evil_mode), 0o755)
+            self.assertFalse(evil_mode & stat.S_ISUID)
+            self.assertFalse(evil_mode & stat.S_IWOTH)
+
+            plain_mode = os.lstat(os.path.join(repo.path, "plain")).st_mode
+            self.assertEqual(stat.S_IMODE(plain_mode), 0o644)
+
     def test_ntfs_malicious_entry_aborts_checkout(self) -> None:
         # A tree authored on POSIX containing an entry that would resolve to
         # ``.git`` on NTFS (a ``.git\`` prefix, the ``git~1`` 8.3 short

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -23,6 +23,8 @@
 
 import os
 import shutil
+import stat
+import sys
 import tempfile
 from io import BytesIO, StringIO
 from typing import NoReturn
@@ -51,7 +53,7 @@ from dulwich.patch import (
 from dulwich.repo import Repo
 from dulwich.tests.utils import make_commit
 
-from . import DependencyMissing, SkipTest, TestCase
+from . import DependencyMissing, SkipTest, TestCase, skipIf
 
 
 class WriteCommitPatchTests(TestCase):
@@ -1576,3 +1578,24 @@ class ApplyPatchesPathTests(TestCase):
         )
         apply_patches(r, parse_unified_diff(diff), strip=1)
         self.assertTrue(os.path.exists(os.path.join(r.path, "sub", "x")))
+
+    @skipIf(sys.platform == "win32", "Requires POSIX file modes")
+    def test_canonicalizes_new_file_mode(self) -> None:
+        # The mode in a patch's "new file mode" header is attacker-controlled
+        # (e.g. an emailed patch applied via git am). Like git, apply_patches
+        # must only honor the 0o644/0o755 distinction, never setuid/setgid or
+        # world-writable bits.
+        r = self._make_repo()
+        diff = (
+            b"diff --git a/x b/x\n"
+            b"new file mode 104777\n"
+            b"--- /dev/null\n"
+            b"+++ b/x\n"
+            b"@@ -0,0 +1 @@\n"
+            b"+owned\n"
+        )
+        apply_patches(r, parse_unified_diff(diff), strip=1)
+        mode = os.lstat(os.path.join(r.path, "x")).st_mode
+        self.assertEqual(stat.S_IMODE(mode), 0o755)
+        self.assertFalse(mode & stat.S_ISUID)
+        self.assertFalse(mode & stat.S_IWOTH)


### PR DESCRIPTION
1. build_file_from_blob (checkout/restore/stash) and the apply_patches/_apply_rename_or_copy sinks in patch.py chmod a materialized file to the raw tree- or patch-supplied mode.
2. that mode is attacker-controlled for an untrusted repo or patch, so a crafted entry like 100777 or 104755 sets world-writable, setuid, setgid, or sticky bits on checkout; git instead reduces every regular-file mode to 0o644/0o755 (git mktree even rewrites 104777 to 100755).
3. routed the four chmod sites through cleanup_mode, dulwich's existing equivalent of git's create_ce_mode, so only the 0o644/0o755 distinction is honored.

Checked that a 100777/104755 tree entry now checks out as 0755 and a 100666 entry as 0644, with the same canonicalization on the patch-apply path; legitimate 0o644/0o755 modes are unchanged.