### PR TITLE
don't write a regular file through a symlink in build_file_from_blob

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -1866,6 +1866,13 @@ def build_file_from_blob(
         else:
             (symlink_fn or symlink)(contents, target_path)
     else:
+        if oldstat is not None and stat.S_ISLNK(oldstat.st_mode):
+            # A symlink left at the target path must not be written through.
+            # open(..., "wb") would follow it and clobber whatever it points
+            # at, possibly outside the work tree. Replace it with a fresh
+            # regular file, like git does on checkout.
+            _remove_file_with_readonly_handling(target_path)
+            oldstat = None
         if oldstat is not None and oldstat.st_size == len(contents):
             with open(target_path, "rb") as f:
                 if f.read() == contents:

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -695,6 +695,54 @@ class BuildIndexTests(TestCase):
             self.assertTrue(os.path.exists(colon_path))
             self.assertFileContents(colon_path, b"foo\n")
 
+    @skipIf(not can_symlink(), "Requires symlink support")
+    def test_regular_file_replaces_symlink(self) -> None:
+        # A symlink left in the work tree by an earlier checkout must be
+        # replaced when the same path becomes a regular file, not written
+        # through. Otherwise a tree that first materializes ``foo`` as a
+        # symlink pointing outside the work tree and then as a regular file
+        # would overwrite the link target, an arbitrary file. C git never
+        # writes a tracked file through a symlink.
+
+        repo_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, repo_dir)
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir)
+        outside_file = os.path.join(outside_dir, "secret")
+        with open(outside_file, "wb") as f:
+            f.write(b"original")
+
+        with Repo.init(repo_dir) as repo:
+            link = Blob.from_string(os.fsencode(outside_file))
+            regular = Blob.from_string(b"payload")
+
+            tree_link = Tree()
+            tree_link[b"foo"] = (stat.S_IFLNK, link.id)
+            tree_file = Tree()
+            tree_file[b"foo"] = (stat.S_IFREG | 0o644, regular.id)
+            repo.object_store.add_objects(
+                [(o, None) for o in [link, regular, tree_link, tree_file]]
+            )
+
+            # First checkout leaves ``foo`` as a symlink pointing outside.
+            build_index_from_tree(
+                repo.path, repo.index_path(), repo.object_store, tree_link.id
+            )
+            foo_path = os.path.join(repo.path, "foo")
+            self.assertTrue(os.path.islink(foo_path))
+
+            # Second checkout makes ``foo`` a regular file.
+            build_index_from_tree(
+                repo.path, repo.index_path(), repo.object_store, tree_file.id
+            )
+
+            # The link target outside the work tree is untouched and the
+            # path is now a real file holding the blob content.
+            self.assertFalse(os.path.islink(foo_path))
+            self.assertFileContents(foo_path, b"payload")
+            with open(outside_file, "rb") as f:
+                self.assertEqual(f.read(), b"original")
+
     def test_nonempty(self) -> None:
         repo_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, repo_dir)


### PR DESCRIPTION
1. build_file_from_blob writes a regular file with open(target_path, "wb"), but unlike the symlink branch above it never removes an entry already present at that path as a symlink.
2. if an earlier checkout left a symlink there (materialized from a cloned or fetched commit's tree), the open follows the link and overwrites its target, which can sit outside the work tree.
3. the direct callers reach this with no pre-removal step: build_index_from_tree, porcelain.reset_file, stash apply, and filter-branch. update_working_tree is unaffected because _transition_to_file already unlinks the old entry first.

Replaced a leftover symlink with a fresh regular file inside build_file_from_blob before the write, matching git's checkout behavior, and added a regression test that fails on the old code.
