### PR TITLE
diff: skip invalid tree paths in working-tree diffs instead of reading them

### DIFF
--- a/dulwich/diff.py
+++ b/dulwich/diff.py
@@ -58,14 +58,19 @@ import logging
 import os
 import stat
 import sys
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from typing import TYPE_CHECKING, BinaryIO
 
 if TYPE_CHECKING:
     from .config import Config
 
 from ._typing import Buffer
-from .index import ConflictedIndexEntry, commit_index
+from .index import (
+    ConflictedIndexEntry,
+    commit_index,
+    get_path_element_validator,
+    validate_path,
+)
 from .object_store import iter_tree_contents
 from .objects import S_ISGITLINK, Blob, Commit, ObjectID
 from .patch import write_blob_diff, write_object_diff
@@ -92,6 +97,35 @@ def should_include_path(path: bytes, paths: Sequence[bytes] | None) -> bool:
     if not paths:
         return True
     return any(path == p or path.startswith(p + b"/") for p in paths)
+
+
+def _worktree_fs_path(
+    repo_path: str,
+    tree_path: bytes,
+    element_validator: Callable[[bytes], bool],
+) -> str | None:
+    """Resolve a tree/index path to a work-tree file path, or skip it.
+
+    Tree and index entries can come from an untrusted object (a fetched or
+    cloned commit), so an entry containing ``..`` or ``.git`` would otherwise
+    let a working-tree diff read a file outside the work tree and disclose its
+    contents in the diff output. Like C git, such paths are never touched on the
+    filesystem; the work-tree side is treated as absent instead of erroring, so
+    the rest of the diff is still produced.
+
+    Args:
+      repo_path: Work-tree root.
+      tree_path: Path of the tree/index entry, relative to the work tree.
+      element_validator: Path-element validator, as returned by
+        ``get_path_element_validator`` for the repository configuration.
+
+    Returns:
+      The joined work-tree path, or ``None`` if the path is invalid and should
+      not be read from the filesystem.
+    """
+    if not validate_path(tree_path, element_validator):
+        return None
+    return os.path.join(repo_path, tree_path.decode("utf-8"))
 
 
 def diff_index_to_tree(
@@ -172,6 +206,7 @@ def diff_working_tree_to_tree(
     tree = commit.tree
     normalizer = repo.get_blob_normalizer(config=config)
     filter_callback = normalizer.checkin_normalize if normalizer is not None else None
+    validate_element = get_path_element_validator(config)
 
     # Get index for tracking new files
     index = repo.open_index(config=config)
@@ -188,13 +223,19 @@ def diff_working_tree_to_tree(
             continue
 
         processed_paths.add(path)
-        full_path = os.path.join(repo.path, path.decode("utf-8"))
+        full_path = _worktree_fs_path(repo.path, path, validate_element)
 
         # Get the old file from tree
         old_mode = entry.mode
         old_sha = entry.sha
         old_blob = repo.object_store[old_sha]
         assert isinstance(old_blob, Blob)
+
+        if full_path is None:
+            # Invalid path (e.g. ``..`` or ``.git``); like C git, don't read the
+            # filesystem for it. Show the committed entry as removed.
+            write_blob_diff(outstream, (path, old_mode, old_blob), (None, None, None))
+            continue
 
         try:
             # Use lstat to handle symlinks properly
@@ -339,7 +380,10 @@ def diff_working_tree_to_tree(
         if not should_include_path(path, paths):
             continue
 
-        full_path = os.path.join(repo.path, path.decode("utf-8"))
+        full_path = _worktree_fs_path(repo.path, path, validate_element)
+        if full_path is None:
+            # Invalid path; like C git, don't read the filesystem for it.
+            continue
 
         try:
             # Use lstat to handle symlinks properly
@@ -419,6 +463,7 @@ def diff_working_tree_to_index(
     index = repo.open_index(config=config)
     normalizer = repo.get_blob_normalizer(config=config)
     filter_callback = normalizer.checkin_normalize if normalizer is not None else None
+    validate_element = get_path_element_validator(config)
 
     # Process each file in the index
     for tree_path, entry in index.iteritems():
@@ -442,7 +487,14 @@ def diff_working_tree_to_index(
         else:
             old_blob = None
 
-        full_path = os.path.join(repo.path, tree_path.decode("utf-8"))
+        full_path = _worktree_fs_path(repo.path, tree_path, validate_element)
+        if full_path is None:
+            # Invalid path (e.g. ``..`` or ``.git``); like C git, don't read the
+            # filesystem for it. Show the index entry as removed.
+            write_blob_diff(
+                outstream, (tree_path, old_mode, old_blob), (None, None, None)
+            )
+            continue
         try:
             # Use lstat to handle symlinks properly
             st = os.lstat(full_path)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -22,9 +22,17 @@
 """Tests for diff functionality."""
 
 import io
+import os
+import shutil
+import tempfile
 import unittest
 
-from dulwich.diff import ColorizedDiffStream
+from dulwich.diff import (
+    ColorizedDiffStream,
+    diff_working_tree_to_tree,
+)
+from dulwich.objects import Blob, Commit, Tree
+from dulwich.repo import Repo
 
 from . import TestCase
 
@@ -182,3 +190,106 @@ class MockColorizedDiffStreamTests(TestCase):
         # Test that some output was produced
         result = self.output.getvalue()
         self.assertGreaterEqual(len(result), 0)
+
+
+class WorkingTreeDiffPathTraversalTests(TestCase):
+    """Working-tree diffs must not read files outside the work tree.
+
+    A tree from an untrusted commit may carry an entry named ``..`` (or
+    ``.git``), so joining it onto the work-tree root would otherwise let the
+    diff read an arbitrary file. Like C git, the invalid path is not touched on
+    the filesystem; its work-tree side is treated as absent and the rest of the
+    diff is still produced.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.test_dir)
+        self.repo_path = os.path.join(self.test_dir, "work")
+        os.mkdir(self.repo_path)
+        self.repo = Repo.init(self.repo_path)
+        self.addCleanup(self.repo.close)
+
+    def _commit_tree(self, tree):
+        commit = Commit()
+        commit.tree = tree.id
+        commit.author = commit.committer = b"Test <test@example.com>"
+        commit.author_time = commit.commit_time = 1
+        commit.author_timezone = commit.commit_timezone = 0
+        commit.message = b"x"
+        self.repo.object_store.add_object(commit)
+        return commit
+
+    def test_diff_does_not_escape_work_tree(self):
+        # A secret file living next to the work tree, not in it.
+        secret = os.path.join(self.test_dir, "secret.txt")
+        with open(secret, "wb") as f:
+            f.write(b"SECRET-OUTSIDE-WORKTREE")
+
+        # Craft a tree whose entry name is ".." so the path would resolve to
+        # ../secret.txt outside the work tree.
+        old_blob = Blob.from_string(b"OLD-COMMITTED-CONTENT\n")
+        self.repo.object_store.add_object(old_blob)
+        inner = Tree()
+        inner.add(b"secret.txt", 0o100644, old_blob.id)
+        self.repo.object_store.add_object(inner)
+        outer = Tree()
+        outer.add(b"..", 0o040000, inner.id)
+        # Also include a legitimate path so we can confirm the diff continues.
+        good_blob = Blob.from_string(b"old\n")
+        self.repo.object_store.add_object(good_blob)
+        outer.add(b"a", 0o100644, good_blob.id)
+        self.repo.object_store.add_object(outer)
+        commit = self._commit_tree(outer)
+
+        with open(os.path.join(self.repo_path, "a"), "wb") as f:
+            f.write(b"new\n")
+
+        out = io.BytesIO()
+        diff_working_tree_to_tree(self.repo, out, commit.id)
+
+        # Like C git: the ".." entry is shown as removed against its committed
+        # blob (the on-disk secret is never read), and the legitimate file
+        # still diffs.
+        self.assertEqual(
+            b"diff --git a/../secret.txt b/../secret.txt\n"
+            b"deleted file mode 100644\n"
+            b"index 9cd170c..0000000\n"
+            b"--- a/../secret.txt\n"
+            b"+++ /dev/null\n"
+            b"@@ -1 +0,0 @@\n"
+            b"-OLD-COMMITTED-CONTENT\n"
+            b"diff --git a/a b/a\n"
+            b"index 3367afd..3e75765 100644\n"
+            b"--- a/a\n"
+            b"+++ b/a\n"
+            b"@@ -1 +1 @@\n"
+            b"-old\n"
+            b"+new\n",
+            out.getvalue(),
+        )
+
+    def test_diff_allows_normal_path(self):
+        blob = Blob.from_string(b"old\n")
+        self.repo.object_store.add_object(blob)
+        tree = Tree()
+        tree.add(b"a", 0o100644, blob.id)
+        self.repo.object_store.add_object(tree)
+        commit = self._commit_tree(tree)
+
+        with open(os.path.join(self.repo_path, "a"), "wb") as f:
+            f.write(b"new\n")
+
+        out = io.BytesIO()
+        diff_working_tree_to_tree(self.repo, out, commit.id)
+        self.assertEqual(
+            b"diff --git a/a b/a\n"
+            b"index 3367afd..3e75765 100644\n"
+            b"--- a/a\n"
+            b"+++ b/a\n"
+            b"@@ -1 +1 @@\n"
+            b"-old\n"
+            b"+new\n",
+            out.getvalue(),
+        )


### PR DESCRIPTION
Reported by netliomax25-code in #2246

Replaces #2246