### PR TITLE
avoid quadratic buffering in web ChunkReader.read

### DIFF
--- a/dulwich/web.py
+++ b/dulwich/web.py
@@ -470,6 +470,7 @@ class ChunkReader:
         """
         self._iter = _chunk_iter(f)
         self._buffer: list[bytes] = []
+        self._buffered = 0
 
     def read(self, n: int) -> bytes:
         """Read n bytes from the chunked stream.
@@ -480,14 +481,17 @@ class ChunkReader:
         Returns:
           Up to n bytes of data
         """
-        while sum(map(len, self._buffer)) < n:
+        while self._buffered < n:
             try:
-                self._buffer.append(next(self._iter))
+                chunk = next(self._iter)
             except StopIteration:
                 break
+            self._buffer.append(chunk)
+            self._buffered += len(chunk)
         f = b"".join(self._buffer)
         ret = f[:n]
         self._buffer = [f[n:]]
+        self._buffered = len(f) - len(ret)
         return ret
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -38,6 +38,7 @@ from dulwich.web import (
     HTTP_FORBIDDEN,
     HTTP_NOT_FOUND,
     HTTP_OK,
+    ChunkReader,
     GunzipFilter,
     HTTPGitApplication,
     HTTPGitRequest,
@@ -435,6 +436,42 @@ class LengthLimitedFileTestCase(TestCase):
         self.assertEqual(b"fo", f.read(2))
         self.assertEqual(b"o", f.read(2))
         self.assertEqual(b"", f.read())
+
+
+class ChunkReaderTestCase(TestCase):
+    @staticmethod
+    def _encode(chunks: list[bytes]) -> bytes:
+        parts = []
+        for chunk in chunks:
+            parts.append(b"%x\r\n" % len(chunk) + chunk + b"\r\n")
+        parts.append(b"0\r\n\r\n")
+        return b"".join(parts)
+
+    def test_single_chunk(self) -> None:
+        r = ChunkReader(BytesIO(self._encode([b"foobar"])))
+        self.assertEqual(b"foobar", r.read(6))
+
+    def test_reassembles_across_chunks(self) -> None:
+        data = b"abcdefghijklmnopqrstuvwxyz0123456789"
+        chunks = [data[i : i + 3] for i in range(0, len(data), 3)]
+        r = ChunkReader(BytesIO(self._encode(chunks)))
+        out = b""
+        for n in (1, 5, 4, 10, 100):
+            out += r.read(n)
+        self.assertEqual(data, out)
+
+    def test_read_past_end(self) -> None:
+        r = ChunkReader(BytesIO(self._encode([b"foo"])))
+        self.assertEqual(b"foo", r.read(100))
+        self.assertEqual(b"", r.read(100))
+
+    def test_many_small_chunks(self) -> None:
+        # A body split into a large number of single-byte chunks must still
+        # reassemble correctly. Reading it used to be quadratic in the number
+        # of chunks because the buffered length was recomputed on every step.
+        count = 20000
+        r = ChunkReader(BytesIO(self._encode([b"x"] * count)))
+        self.assertEqual(b"x" * count, r.read(count))
 
 
 class HTTPGitRequestTestCase(WebTestCase):


### PR DESCRIPTION
1. ChunkReader.read recomputed `sum(map(len, self._buffer))` on every loop iteration while pulling chunks to satisfy a read, so a single read is quadratic in the number of chunks it consumes.
2. The reader wraps the request body for `Transfer-Encoding: chunked`, and ReceivableProtocol.recv reads in 64 KiB blocks, so a client streaming the body as many one-byte chunks drives O(n^2) work in the server before authentication (upload-pack on a public repo is anonymous). 64000 one-byte chunks (about 384 KiB on the wire) took roughly 17s of CPU here and scaled with the square of the chunk count.
3. Track a running buffered length instead of re-summing the buffer each step, which restores linear reads (about 0.016s for the same input) with identical output.

Verified reassembly is unchanged for mixed chunk and read sizes, reads past EOF, and the many-small-chunks case; added those as tests in test_web.py.