### PR TITLE
validate pkt-line length prefix in read_pkt_line and PktLineParser

### DIFF
--- a/dulwich/protocol.py
+++ b/dulwich/protocol.py
@@ -377,6 +377,33 @@ def pkt_seq(*seq: bytes | None) -> bytes:
     return b"".join([pkt_line(s) for s in seq]) + pkt_line(None)
 
 
+_HEX_DIGITS = frozenset(b"0123456789abcdefABCDEF")
+
+
+def _parse_pkt_line_length(sizestr: bytes) -> int:
+    """Parse the four-byte length prefix of a pkt-line.
+
+    Mirrors git's ``packet_length()``: the prefix must be exactly four
+    hexadecimal digits. ``int(sizestr, 16)`` on its own also accepts a leading
+    ``+``/``-``, surrounding whitespace, an ``0x`` prefix and digit-group
+    underscores, none of which git allows. Accepting a ``-``-prefixed prefix is
+    the dangerous case: the resulting negative length turns the following
+    ``read(size - 4)`` into a ``read()`` with a negative argument (which reads
+    the rest of the stream into memory) and makes the incremental
+    :class:`PktLineParser` loop without ever consuming its buffer.
+
+    Args:
+      sizestr: The four raw length bytes read from the wire.
+    Returns: The length encoded by the prefix.
+
+    Raises:
+      GitProtocolError: if the prefix is not four hexadecimal digits.
+    """
+    if len(sizestr) != 4 or not _HEX_DIGITS.issuperset(sizestr):
+        raise GitProtocolError(f"Invalid pkt-line length prefix: {sizestr!r}")
+    return int(sizestr, 16)
+
+
 class Protocol:
     """Class for interacting with a remote git process over the wire.
 
@@ -464,12 +491,14 @@ class Protocol:
             sizestr = read(4)
             if not sizestr:
                 raise HangupException
-            size = int(sizestr, 16)
+            size = _parse_pkt_line_length(sizestr)
             if size == 0 or size == 1:  # flush-pkt or delim-pkt
                 if self.report_activity:
                     self.report_activity(4, "read")
                 logger.debug("git< %s", sizestr.decode("ascii"))
                 return None
+            if size < 4:
+                raise GitProtocolError(f"Invalid pkt-line length: {size:04x}")
             if self.report_activity:
                 self.report_activity(size, "read")
             pkt_contents = read(size - 4)
@@ -871,10 +900,12 @@ class PktLineParser:
         if len(buf) < 4:
             return
         while len(buf) >= 4:
-            size = int(buf[:4], 16)
+            size = _parse_pkt_line_length(buf[:4])
             if size == 0:
                 self.handle_pkt(None)
                 buf = buf[4:]
+            elif size < 4:
+                raise GitProtocolError(f"Invalid pkt-line length: {size:04x}")
             elif size <= len(buf):
                 self.handle_pkt(buf[4:size])
                 buf = buf[size:]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -583,7 +583,7 @@ class GitClientTests(TestCase):
             b"0070310ca9477129b8586fa2afc779c1f57cf64bba6c "
             b"refs/heads/master\x00report-status delete-refs ofs-delta push-options\n"
             b"0000000eunpack ok\n"
-            b"001aok refs/heads/blah12\n"
+            b"0019ok refs/heads/blah12\n"
             b"0000"
         )
         self.rin.seek(0)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -119,6 +119,29 @@ class BaseProtocolTests:
         self.rin.seek(0)
         self.assertRaises(GitProtocolError, self.proto.read_pkt_line)
 
+    def test_read_pkt_line_non_hex_length(self) -> None:
+        # git's packet_length rejects any non-hex length byte; int(_, 16)
+        # would silently accept these (and the "0x" form) as a length.
+        for prefix in (b"+abc", b"0x0e", b" abc"):
+            self.rin.seek(0)
+            self.rin.truncate()
+            self.rin.write(prefix + b"payload")
+            self.rin.seek(0)
+            self.assertRaises(GitProtocolError, self.proto.read_pkt_line)
+
+    def test_read_pkt_line_negative_length(self) -> None:
+        # A "-"-prefixed length parses to a negative int; read(size - 4) would
+        # then be read() with a negative argument and consume the whole stream.
+        self.rin.write(b"-004" + b"A" * 4096)
+        self.rin.seek(0)
+        self.assertRaises(GitProtocolError, self.proto.read_pkt_line)
+
+    def test_read_pkt_line_short_length(self) -> None:
+        # 0002/0003 are not valid data-line lengths (read(size - 4) < 0).
+        self.rin.write(b"0003a")
+        self.rin.seek(0)
+        self.assertRaises(GitProtocolError, self.proto.read_pkt_line)
+
     def test_write_sideband(self) -> None:
         self.proto.write_sideband(3, b"bloe")
         self.assertEqual(self.rout.getvalue(), b"0009\x03bloe")
@@ -351,6 +374,17 @@ class PktLineParserTests(TestCase):
         parser.parse(b"0005z0006aba")
         self.assertEqual(pktlines, [b"z", b"ab"])
         self.assertEqual(b"a", parser.get_tail())
+
+    def test_negative_length(self) -> None:
+        # A negative length whose magnitude exceeds the buffer made
+        # buf = buf[size:] a no-op, so parse() looped forever. It now rejects
+        # the non-hex prefix instead of hanging.
+        parser = PktLineParser(lambda pkt: None)
+        self.assertRaises(GitProtocolError, parser.parse, b"-fff" + b"C" * 8)
+
+    def test_non_hex_length(self) -> None:
+        parser = PktLineParser(lambda pkt: None)
+        self.assertRaises(GitProtocolError, parser.parse, b"+abcpayload")
 
 
 class CapabilitiesTests(TestCase):


### PR DESCRIPTION
1. `read_pkt_line` and `PktLineParser.parse` parse the 4-byte pkt-line length with `int(sizestr, 16)`, which also accepts a leading `+`/`-`, surrounding whitespace, an `0x` prefix and underscores that git's `packet_length` refuses (it requires exactly four hex digits).
2. the length is read off the wire from an untrusted peer (`PktLineParser` parses the server's report-status after a push, and `read_pkt_line` backs every wire read on both client and server). A `-`-prefixed length is negative, so `read_pkt_line` calls `read(size - 4)` with a negative argument and pulls the rest of the stream into memory, while `PktLineParser.parse` does `buf = buf[size:]`, which stops shrinking the buffer and loops forever.
3. added `_parse_pkt_line_length` requiring exactly four hex digits, used at both sites, and reject the 2/3 lengths that would still make `read(size - 4)` negative.

The push-options client test carried a `001a` prefix for a 21-byte status line (the sibling atomic test uses the correct `0019`); the old lenient parser masked it by reading the trailing bytes as a short flush, so I corrected the fixture.