### PR TITLE
checkout: write blobs via build_file_from_blob for path-restricted checkout

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -90,6 +90,13 @@
    patch ``new file mode`` could otherwise set setuid/setgid/sticky or
    world-writable bits on a materialized file. (netliomax25-code)
 
+ * SECURITY(GHSA-8w8g-wq8h-fq33): Write files through ``build_file_from_blob``
+   in path-restricted ``porcelain.checkout(paths=...)`` instead of a raw
+   ``os.open``. The old path followed a symlink left at the target, so a
+   crafted repository could write attacker content outside the work tree
+   (e.g. into ``.git/hooks``) on ``checkout``. (reported by zx (Jace),
+   Jelmer Vernooĳ)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -5661,18 +5661,17 @@ def checkout(
                     # Create directories if needed
                     os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
-                    # Write the file content
+                    # Write the file content. Route through build_file_from_blob
+                    # rather than a raw os.open: it replaces a symlink left at the
+                    # target instead of following it, so a malicious repository
+                    # cannot use a symlink to write outside the work tree.
                     if stat.S_ISREG(mode):
                         # Apply checkout filters (smudge)
                         if blob_normalizer:
                             obj = blob_normalizer.checkout_normalize(obj, path)
-
-                        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-                        if sys.platform == "win32":
-                            flags |= os.O_BINARY
-
-                        with os.fdopen(os.open(file_path, flags, mode), "wb") as f:
-                            f.write(obj.data)
+                        build_file_from_blob(obj, mode, file_path)
+                    elif stat.S_ISLNK(mode):
+                        build_file_from_blob(obj, mode, file_path)
 
                     # Update the index
                     worktree.stage(path, config=r.get_config_stack())

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -4976,6 +4976,44 @@ class CheckoutTests(PorcelainTestCase):
         hook = os.path.join(self.repo.path, ".git", "hooks", "post-checkout")
         self.assertFalse(os.path.exists(hook))
 
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_checkout_paths_replaces_symlink_target(self) -> None:
+        # A path-specific checkout must not follow a symlink already present at
+        # the target path. Otherwise a malicious tree that first lands a symlink
+        # pointing outside the work tree, then a regular file at the same path,
+        # could write attacker content anywhere the user can write.
+        outside = os.path.join(self.test_dir, "outside")
+        with open(outside, "w") as f:
+            f.write("original\n")
+
+        file_blob = Blob.from_string(b"payload\n")
+        file_tree = Tree()
+        file_tree.add(b"trigger", 0o100644, file_blob.id)
+        self.repo.object_store.add_object(file_blob)
+        self.repo.object_store.add_object(file_tree)
+        file_sha = self.repo.get_worktree().commit(
+            message=b"regular file",
+            tree=file_tree.id,
+            committer=b"Jane <jane@example.com>",
+            author=b"John <john@example.com>",
+        )
+
+        # Simulate an attacker-controlled work tree that already carries a
+        # symlink at the path about to be restored, pointing outside the repo.
+        trigger = os.path.join(self.repo.path, "trigger")
+        os.symlink(os.path.join("..", "outside"), trigger)
+        self.assertTrue(os.path.islink(trigger))
+
+        porcelain.checkout(self.repo, file_sha, paths=[b"trigger"])
+
+        # The file outside the work tree must be untouched, and the work tree
+        # path must now be a regular file holding the payload.
+        with open(outside) as f:
+            self.assertEqual("original\n", f.read())
+        self.assertFalse(os.path.islink(trigger))
+        with open(trigger) as f:
+            self.assertEqual("payload\n", f.read())
+
     def test_checkout_to_head(self) -> None:
         new_sha = self._commit_something_wrong()
 


### PR DESCRIPTION
The paths= branch of porcelain.checkout wrote through a raw os.open(file_path, O_WRONLY|O_CREAT|O_TRUNC), which follows a symlink already present at the target. A crafted repository could leave a symlink pointing outside the work tree at a path and then have checkout restore a regular file there, writing attacker content anywhere the user can write (e.g. into .git/hooks). Route the write through build_file_from_blob, which replaces such a symlink instead of following it and canonicalizes the file mode, matching the sibling reset_file path.

GHSA-8w8g-wq8h-fq33, reported by zx (Jace).