### PR TITLE
filter-branch: build index in memory instead of materializing to CWD

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -97,6 +97,12 @@
    (e.g. into ``.git/hooks``) on ``checkout``. (reported by zx (Jace),
    Jelmer Vernooĳ)
 
+ * SECURITY(GHSA-5fqc-mrg8-w798): Build the temporary index for
+   ``filter-branch --index-filter`` in memory instead of materializing tree
+   entries into CWD. Persisted entries between commits let a symlink from
+   an ancestor commit redirect a descendant's writes outside the work tree.
+   (reported by zx (Jace), Jelmer Vernooĳ)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/filter_branch.py
+++ b/dulwich/filter_branch.py
@@ -33,9 +33,9 @@ import warnings
 from collections.abc import Callable, Sequence
 from typing import TypedDict
 
-from .index import Index, build_index_from_tree, validate_path_element_ntfs
-from .object_store import BaseObjectStore
-from .objects import Commit, ObjectID, Tag, Tree
+from .index import Index, index_entry_from_tree_entry
+from .object_store import BaseObjectStore, iter_tree_contents
+from .objects import S_ISGITLINK, Commit, ObjectID, Tag, Tree
 from .refs import Ref, RefsContainer, local_tag_name
 
 
@@ -203,24 +203,28 @@ class CommitFilter:
             self._tree_cache[tree_sha] = tree_sha
             return tree_sha
 
-        # Create temporary index file
         with tempfile.NamedTemporaryFile(delete=False) as tmp_index:
             tmp_index_path = tmp_index.name
 
         try:
-            # Build index from tree
-            build_index_from_tree(
-                ".",
-                tmp_index_path,
-                self.object_store,
-                tree_sha,
-                validate_path_element=validate_path_element_ntfs,
-            )
+            index = Index(tmp_index_path, read=False)
+            for entry in iter_tree_contents(self.object_store, tree_sha):
+                assert (
+                    entry.path is not None
+                    and entry.mode is not None
+                    and entry.sha is not None
+                )
+                if S_ISGITLINK(entry.mode):
+                    size = 0
+                else:
+                    size = self.object_store[entry.sha].raw_length()
+                index[entry.path] = index_entry_from_tree_entry(
+                    entry.mode, entry.sha, size
+                )
+            index.write()
 
-            # Run index filter
             new_tree_sha = self.index_filter(tree_sha, tmp_index_path)
             if new_tree_sha is None:
-                # Read back the modified index and create new tree
                 index = Index(tmp_index_path)
                 new_tree_sha = index.commit(self.object_store)
 

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -64,6 +64,7 @@ __all__ = [
     "get_path_element_validator",
     "get_unstaged_changes",
     "index_entry_from_stat",
+    "index_entry_from_tree_entry",
     "make_path_normalizer",
     "pathjoin",
     "pathsplit",
@@ -1768,6 +1769,40 @@ def index_entry_from_stat(
         uid=stat_val.st_uid,
         gid=stat_val.st_gid,
         size=stat_val.st_size,
+        sha=ObjectID(hex_sha),
+        flags=0,
+        extended_flags=0,
+    )
+
+
+def index_entry_from_tree_entry(
+    mode: int,
+    hex_sha: bytes,
+    size: int = 0,
+) -> IndexEntry:
+    """Create an index entry from a tree entry, with zeroed stat fields.
+
+    Use this when populating an index directly from a tree without touching
+    the filesystem, matching ``git read-tree``. The stat-derived fields
+    (ctime/mtime/dev/ino/uid/gid) are zeroed; git treats such entries as
+    stat-unmerged and refreshes them on the next stat.
+
+    Args:
+      mode: File mode from the tree entry
+      hex_sha: Hex sha of the object
+      size: Size of the object (0 for gitlinks or when unknown)
+    """
+    from dulwich.objects import ObjectID
+
+    return IndexEntry(
+        ctime=0,
+        mtime=0,
+        dev=0,
+        ino=0,
+        mode=mode,
+        uid=0,
+        gid=0,
+        size=size,
         sha=ObjectID(hex_sha),
         flags=0,
         extended_flags=0,

--- a/tests/test_filter_branch.py
+++ b/tests/test_filter_branch.py
@@ -21,11 +21,14 @@
 
 """Tests for dulwich.filter_branch."""
 
+import os
+import stat
+import tempfile
 import unittest
 
 from dulwich.filter_branch import CommitFilter, filter_refs
 from dulwich.object_store import MemoryObjectStore
-from dulwich.objects import ZERO_SHA, Commit, Tree
+from dulwich.objects import ZERO_SHA, Blob, Commit, Tree
 from dulwich.refs import DictRefsContainer
 
 
@@ -125,6 +128,71 @@ class CommitFilterTests(unittest.TestCase):
 
         new_parent = self.store[new_parent_sha]
         self.assertEqual(new_parent.author, b"New Author <new@example.com>")
+
+    def test_index_filter_does_not_touch_working_dir(self):
+        """Index filter must not materialize files to the working directory.
+
+        Regression test for a symlink traversal vulnerability: previously
+        ``_apply_index_filter`` called ``build_index_from_tree(".", ...)``,
+        which wrote tree entries into the caller's CWD and left them there
+        across commits. When an ancestor commit contained a symlink named
+        ``evil`` and a descendant commit contained a regular file at
+        ``evil/payload``, processing the descendant would write through
+        the persisted symlink to arbitrary filesystem locations.
+        """
+        payload = Blob.from_string(b"attacker content")
+        self.store.add_object(payload)
+
+        with tempfile.TemporaryDirectory() as target_dir:
+            symlink_blob = Blob.from_string(target_dir.encode())
+            self.store.add_object(symlink_blob)
+
+            ancestor_tree = Tree()
+            ancestor_tree.add(b"evil", stat.S_IFLNK | 0o777, symlink_blob.id)
+            self.store.add_object(ancestor_tree)
+
+            evil_subtree = Tree()
+            evil_subtree.add(b"payload", stat.S_IFREG | 0o644, payload.id)
+            self.store.add_object(evil_subtree)
+            descendant_tree = Tree()
+            descendant_tree.add(b"evil", stat.S_IFDIR, evil_subtree.id)
+            self.store.add_object(descendant_tree)
+
+            ancestor = Commit()
+            ancestor.tree = ancestor_tree.id
+            ancestor.author = ancestor.committer = b"Test <test@example.com>"
+            ancestor.author_time = ancestor.commit_time = 1000
+            ancestor.author_timezone = ancestor.commit_timezone = 0
+            ancestor.message = b"ancestor"
+            self.store.add_object(ancestor)
+
+            descendant = Commit()
+            descendant.tree = descendant_tree.id
+            descendant.parents = [ancestor.id]
+            descendant.author = descendant.committer = b"Test <test@example.com>"
+            descendant.author_time = descendant.commit_time = 2000
+            descendant.author_timezone = descendant.commit_timezone = 0
+            descendant.message = b"descendant"
+            self.store.add_object(descendant)
+
+            def identity_index_filter(tree_sha, index_path):
+                return None
+
+            with tempfile.TemporaryDirectory() as cwd:
+                old_cwd = os.getcwd()
+                os.chdir(cwd)
+                try:
+                    filter = CommitFilter(
+                        self.store, index_filter=identity_index_filter
+                    )
+                    filter.process_commit(descendant.id)
+                    written_target = os.listdir(target_dir)
+                    written_cwd = os.listdir(cwd)
+                finally:
+                    os.chdir(old_cwd)
+
+            self.assertEqual([], written_target)
+            self.assertEqual([], written_cwd)
 
 
 class FilterRefsTests(unittest.TestCase):


### PR DESCRIPTION
_apply_index_filter used build_index_from_tree(".", ...), writing tree entries into the caller's working directory and leaving them there between commits. An attacker could exploit this with a repository whose ancestor commit places a symlink named e.g. ``evil`` and whose descendant commit places a regular file at ``evil/payload``: processing the descendant would follow the persisted symlink and write outside the work tree.

Match git's actual filter-branch semantics -- --index-filter does not check out the tree -- by populating the temporary index directly from the tree with zeroed stat fields.

Reported by zx (Jace).