### PR TITLE
filter-branch: build index in memory instead of materializing to CWD

### DIFF
--- a/dulwich/filter_branch.py
+++ b/dulwich/filter_branch.py
@@ -33,9 +33,9 @@ import warnings
 from collections.abc import Callable, Sequence
 from typing import TypedDict
 
-from .index import Index, build_index_from_tree, validate_path_element_ntfs
-from .object_store import BaseObjectStore
-from .objects import Commit, ObjectID, Tag, Tree
+from .index import Index, index_entry_from_tree_entry
+from .object_store import BaseObjectStore, iter_tree_contents
+from .objects import S_ISGITLINK, Commit, ObjectID, Tag, Tree
 from .refs import Ref, RefsContainer, local_tag_name
 
 
@@ -203,24 +203,28 @@ class CommitFilter:
             self._tree_cache[tree_sha] = tree_sha
             return tree_sha
 
-        # Create temporary index file
         with tempfile.NamedTemporaryFile(delete=False) as tmp_index:
             tmp_index_path = tmp_index.name
 
         try:
-            # Build index from tree
-            build_index_from_tree(
-                ".",
-                tmp_index_path,
-                self.object_store,
-                tree_sha,
-                validate_path_element=validate_path_element_ntfs,
-            )
+            index = Index(tmp_index_path, read=False)
+            for entry in iter_tree_contents(self.object_store, tree_sha):
+                assert (
+                    entry.path is not None
+                    and entry.mode is not None
+                    and entry.sha is not None
+                )
+                if S_ISGITLINK(entry.mode):
+                    size = 0
+                else:
+                    size = self.object_store[entry.sha].raw_length()
+                index[entry.path] = index_entry_from_tree_entry(
+                    entry.mode, entry.sha, size
+                )
+            index.write()
 
-            # Run index filter
             new_tree_sha = self.index_filter(tree_sha, tmp_index_path)
             if new_tree_sha is None:
-                # Read back the modified index and create new tree
                 index = Index(tmp_index_path)
                 new_tree_sha = index.commit(self.object_store)
 

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -64,6 +64,7 @@ __all__ = [
     "get_path_element_validator",
     "get_unstaged_changes",
     "index_entry_from_stat",
+    "index_entry_from_tree_entry",
     "make_path_normalizer",
     "pathjoin",
     "pathsplit",
@@ -1768,6 +1769,40 @@ def index_entry_from_stat(
         uid=stat_val.st_uid,
         gid=stat_val.st_gid,
         size=stat_val.st_size,
+        sha=ObjectID(hex_sha),
+        flags=0,
+        extended_flags=0,
+    )
+
+
+def index_entry_from_tree_entry(
+    mode: int,
+    hex_sha: bytes,
+    size: int = 0,
+) -> IndexEntry:
+    """Create an index entry from a tree entry, with zeroed stat fields.
+
+    Use this when populating an index directly from a tree without touching
+    the filesystem, matching ``git read-tree``. The stat-derived fields
+    (ctime/mtime/dev/ino/uid/gid) are zeroed; git treats such entries as
+    stat-unmerged and refreshes them on the next stat.
+
+    Args:
+      mode: File mode from the tree entry
+      hex_sha: Hex sha of the object
+      size: Size of the object (0 for gitlinks or when unknown)
+    """
+    from dulwich.objects import ObjectID
+
+    return IndexEntry(
+        ctime=0,
+        mtime=0,
+        dev=0,
+        ino=0,
+        mode=mode,
+        uid=0,
+        gid=0,
+        size=size,
         sha=ObjectID(hex_sha),
         flags=0,
         extended_flags=0,


### PR DESCRIPTION
_apply_index_filter used build_index_from_tree(".", ...), which checked the tree out into the caller's working directory just to populate the temporary index. Match git's --index-filter semantics by populating the temporary index directly from the tree with zeroed stat fields, avoiding the filesystem round-trip.