### PR TITLE
fix quadratic header accumulation in _parse_message

### DIFF
--- a/dulwich/objects.py
+++ b/dulwich/objects.py
@@ -1013,7 +1013,7 @@ def _parse_message(
     """
     f = BytesIO(b"".join(chunks))
     k = None
-    v = b""
+    v: list[bytes] = []
     eof = False
 
     def _strip_last_newline(value: bytes) -> bytes:
@@ -1025,19 +1025,23 @@ def _parse_message(
     # Parse the headers
     #
     # Headers can contain newlines. The next line is indented with a space.
-    # We store the latest key as 'k', and the accumulated value as 'v'.
+    # We store the latest key as 'k', and the accumulated value chunks as 'v'.
+    # The chunks are joined only once per header (rather than with ``+=`` per
+    # continuation line) so a value split across many indented lines stays
+    # linear instead of quadratic.
     for line in f:
         if line.startswith(b" "):
             # Indented continuation of the previous line
-            v += line[1:]
+            v.append(line[1:])
         else:
             if k is not None:
                 # We parsed a new header, return its value
-                yield (k, _strip_last_newline(v))
+                yield (k, _strip_last_newline(b"".join(v)))
             if line == b"\n":
                 # Empty line indicates end of headers
                 break
-            (k, v) = line.split(b" ", 1)
+            (k, rest) = line.split(b" ", 1)
+            v = [rest]
 
     else:
         # We reached end of file before the headers ended. We still need to
@@ -1045,7 +1049,7 @@ def _parse_message(
         # the text.
         eof = True
         if k is not None:
-            yield (k, _strip_last_newline(v))
+            yield (k, _strip_last_newline(b"".join(v)))
         yield (None, None)
 
     if not eof:

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -42,6 +42,7 @@ from dulwich.objects import (
     Tag,
     Tree,
     TreeEntry,
+    _parse_message,
     _parse_tree_py,
     _sorted_tree_items_py,
     check_hexsha,
@@ -841,6 +842,18 @@ nHxksHfeNln9RKseIDcy4b2ATjhDNIJZARHNfr6oy4u3XPW4svRqtBsLoMiIeuI=
         self.assertEqual(pre_sig + post_sig, c.raw_without_sig())
         self.assertEqual(gpgsig, c.gpgsig)
         self.assertEqual(b"3.3.0 version bump and docs\n", c.message)
+
+    def test_parse_header_many_continuation_lines(self) -> None:
+        # A header value may be split across indented continuation lines. A
+        # value spread over a large number of them must still be reassembled
+        # exactly, and in linear time (the accumulation used to be quadratic).
+        n = 50000
+        body = b"".join(b" line%d\n" % i for i in range(n))
+        text = b"tree " + b"0" * 40 + b"\ngpgsig first\n" + body + b"\nthe message\n"
+        fields = dict((k, v) for (k, v) in _parse_message([text]) if k is not None)
+        expected = b"first\n" + b"".join(b"line%d\n" % i for i in range(n))
+        expected = expected[:-1]  # trailing newline is stripped from the value
+        self.assertEqual(expected, fields[b"gpgsig"])
 
     def test_commit_extract_signature_pgp(self) -> None:
         gpgsig = b"""-----BEGIN PGP SIGNATURE-----


### PR DESCRIPTION
1. A header value that spans indented continuation lines is accumulated in `_parse_message` with `v += line[1:]` once per line. CPython does not optimize in-place `bytes` concatenation, so this is O(n^2) in the size of the value.
2. Commit and tag objects come from an untrusted remote during clone/fetch and are re-parsed on log, checkout, graph walks, and server-side want-satisfaction. A crafted object whose header (for example `gpgsig`) is split across a large number of continuation lines makes each parse cost quadratic time.
3. Collect the continuation chunks in a list and join once per header, which keeps the parsed value byte-for-byte identical while making parsing linear.

Validation: with the old code, doubling the number of continuation lines roughly quadrupled parse time (20k/40k/80k/160k lines took 0.005/0.024/0.119/0.363s); after the change it scales linearly (0.001s at 20k, 0.037s at 640k). Existing commit/tag parse and serialization tests still pass, and I added a reassembly test in `tests/test_objects.py` that parses a value spread over many continuation lines.