### PR TITLE
stash: reject writes through intermediate symlink on pop

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -103,6 +103,12 @@
    an ancestor commit redirect a descendant's writes outside the work tree.
    (reported by zx (Jace), Jelmer Vernooĳ)
 
+ * SECURITY: Refuse to write a stash entry through an intermediate symlink
+   on ``stash.pop``. The old ``os.path.exists`` check followed symlinks, so
+   a crafted stash whose parent path was a symlink already present in the
+   worktree (e.g. ``link`` -> ``.git/hooks``) let the subsequent write land
+   outside the work tree. (reported by zx (Jace), Jelmer Vernooĳ)
+
 1.2.6	2026-05-31
 
  * SECURITY: Honor ``core.protectNTFS``/``core.protectHFS`` on all

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -28,6 +28,7 @@ __all__ = [
 ]
 
 import os
+import stat
 from typing import TYPE_CHECKING, TypedDict
 
 from .diff_tree import tree_changes
@@ -64,6 +65,52 @@ class CommitKwargs(TypedDict, total=False):
 
 
 DEFAULT_STASH_REF = Ref(b"refs/stash")
+
+
+def _verify_leading_dirs(
+    tree_path: bytes,
+    safe_prefix: list[bytes],
+    repo_path: bytes,
+) -> None:
+    """Reject writes whose leading path resolves through a symlink.
+
+    ``iter_tree_contents`` yields paths in sorted order, so consecutive
+    siblings share a long prefix. ``safe_prefix`` tracks the deepest chain
+    of directory components already verified to be real directories (or
+    absent), starting at the worktree root; each call only ``lstat``s the
+    components that differ from that chain. Mirrors git's
+    ``lstat_cache_matchlen`` (see CVE-2021-21300).
+
+    Raises ``InvalidPathError`` if any leading component is a symlink.
+    """
+    slash = tree_path.rfind(b"/")
+    if slash <= 0:
+        return
+    components = tree_path[:slash].split(b"/")
+
+    common = 0
+    while (
+        common < len(safe_prefix)
+        and common < len(components)
+        and safe_prefix[common] == components[common]
+    ):
+        common += 1
+    del safe_prefix[common:]
+
+    current = repo_path
+    for part in components[:common]:
+        current = os.path.join(current, part)
+    for part in components[common:]:
+        current = os.path.join(current, part)
+        try:
+            st = os.lstat(current)
+        except FileNotFoundError:
+            # Anything below here doesn't exist yet; makedirs will create
+            # it under a verified-real-directory prefix.
+            break
+        if stat.S_ISLNK(st.st_mode):
+            raise InvalidPathError(tree_path)
+        safe_prefix.append(part)
 
 
 class Stash:
@@ -217,6 +264,7 @@ class Stash:
                 repo_index[tree_entry.path] = index_entry_from_stat(st, tree_entry.sha)
 
         # Apply working tree changes from the stash
+        safe_prefix: list[bytes] = []
         tree_entry2: TreeEntry
         for tree_entry2 in iter_tree_contents(self._repo.object_store, stash_tree_id):
             assert (
@@ -226,6 +274,11 @@ class Stash:
             )
             if not validate_path(tree_entry2.path, validate_path_element):
                 raise InvalidPathError(tree_entry2.path)
+
+            # Refuse writes whose leading path goes through a symlink left
+            # in the worktree (e.g. ``link`` -> ``.git/hooks``); the cache
+            # keeps the total cost to one ``lstat`` per unique directory.
+            _verify_leading_dirs(tree_entry2.path, safe_prefix, repo_path)
 
             full_path = _tree_to_fs_path(repo_path, tree_entry2.path)
 

--- a/tests/test_stash.py
+++ b/tests/test_stash.py
@@ -23,8 +23,11 @@
 
 import os
 import shutil
+import sys
 import tempfile
+import unittest
 
+from dulwich.index import InvalidPathError
 from dulwich.objects import Blob, Tree
 from dulwich.repo import Repo
 from dulwich.stash import DEFAULT_STASH_REF, Stash
@@ -223,6 +226,66 @@ class StashTests(TestCase):
         # Verify index has the staged changes
         index = self.repo.open_index()
         self.assertIn(b"new.txt", index)
+
+    @unittest.skipIf(
+        sys.platform == "win32", "symlink creation requires privileges on Windows"
+    )
+    def test_pop_rejects_symlink_traversal(self) -> None:
+        """A stash whose parent path is a symlink must not write through it.
+
+        Regression test for CVE-style path traversal via ``stash.pop``: an
+        intermediate directory component that is a symlink (e.g.
+        ``link -> .git/hooks``) previously passed ``os.path.exists`` and the
+        subsequent ``open`` followed the symlink, writing attacker content
+        outside the worktree.
+        """
+        stash = Stash.from_repo(self.repo)
+
+        os.makedirs(os.path.join(self.repo.commondir(), "logs"), exist_ok=True)
+        hooks_dir = os.path.join(self.repo.commondir(), "hooks")
+        os.makedirs(hooks_dir, exist_ok=True)
+
+        # Point the symlink at the hooks directory relative to the worktree.
+        link_target = os.path.relpath(hooks_dir, self.repo_dir)
+        os.symlink(link_target, os.path.join(self.repo_dir, "link"))
+
+        payload = Blob()
+        payload.data = b"#!/bin/sh\necho pwned\n"
+        self.repo.object_store.add_object(payload)
+
+        subtree = Tree()
+        subtree.add(b"post-checkout", 0o100755, payload.id)
+        self.repo.object_store.add_object(subtree)
+
+        stash_tree = Tree()
+        stash_tree.add(b"link", 0o040000, subtree.id)
+        self.repo.object_store.add_object(stash_tree)
+
+        index_commit_id = self.repo.get_worktree().commit(
+            tree=stash_tree.id,
+            message=b"Index stash",
+            merge_heads=[self.repo.head()],
+            no_verify=True,
+            sign=False,
+            ref=None,
+        )
+        self.repo.refs[DEFAULT_STASH_REF] = self.repo.head()
+        stash_commit_id = self.repo.get_worktree().commit(
+            ref=DEFAULT_STASH_REF,
+            tree=stash_tree.id,
+            message=b"malicious stash",
+            merge_heads=[index_commit_id],
+            no_verify=True,
+            sign=False,
+        )
+        self.assertIsNotNone(stash_commit_id)
+        self.assertEqual(1, len(stash))
+
+        with self.assertRaises(InvalidPathError):
+            stash.pop(0)
+
+        # The payload must not have been written through the symlink.
+        self.assertFalse(os.path.exists(os.path.join(hooks_dir, "post-checkout")))
 
 
 class StashInWorktreeTest(StashTests):


### PR DESCRIPTION
Reported by zx (Jace).