### PR TITLE
porcelain: reject writes through intermediate symlink in checkout paths

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -33,6 +33,12 @@
    worktree (e.g. ``link`` -> ``.git/hooks``) let the subsequent write land
    outside the work tree. (reported by zx (Jace), Jelmer Vernooĳ)
 
+ * SECURITY: Refuse path-restricted ``porcelain.checkout``, ``restore`` and
+   ``reset_file`` writes whose leading directory is an existing symlink, so
+   a crafted repository can no longer land ``sub`` as a link to
+   ``.git/hooks`` and have a write to ``sub/anything`` traverse it.
+   (reported by zx (Jace), Jelmer Vernooĳ)
+
  * SECURITY: Reject non-hex pkt-line length prefixes in the protocol parser.
    ``int(sizestr, 16)`` accepted a leading ``-``, whose negative length made
    the following ``read(size - 4)`` slurp the rest of the stream and caused

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -2181,6 +2181,59 @@ def validate_path(
         return True
 
 
+def verify_leading_dirs(
+    tree_path: bytes,
+    safe_prefix: list[bytes],
+    repo_path: bytes,
+) -> None:
+    """Reject writes whose leading path resolves through a symlink.
+
+    Callers that materialize many paths in sorted order can pass a shared
+    ``safe_prefix`` list to cache the deepest chain of directory components
+    already verified to be real directories (or absent); each call only
+    ``lstat``s the components that differ from that chain. Callers that only
+    verify a single path can pass an empty list. Mirrors git's
+    ``lstat_cache_matchlen`` (see CVE-2021-21300).
+
+    Args:
+      tree_path: Tree-form path (``/``-separated) about to be written.
+      safe_prefix: Mutable cache of directory components already verified
+        under ``repo_path``. Updated in place.
+      repo_path: Filesystem path to the work-tree root.
+
+    Raises:
+      InvalidPathError: If any leading component is a symlink.
+    """
+    slash = tree_path.rfind(b"/")
+    if slash <= 0:
+        return
+    components = tree_path[:slash].split(b"/")
+
+    common = 0
+    while (
+        common < len(safe_prefix)
+        and common < len(components)
+        and safe_prefix[common] == components[common]
+    ):
+        common += 1
+    del safe_prefix[common:]
+
+    current = repo_path
+    for part in components[:common]:
+        current = os.path.join(current, part)
+    for part in components[common:]:
+        current = os.path.join(current, part)
+        try:
+            st = os.lstat(current)
+        except FileNotFoundError:
+            # Anything below here doesn't exist yet; makedirs will create
+            # it under a verified-real-directory prefix.
+            break
+        if stat.S_ISLNK(st.st_mode):
+            raise InvalidPathError(tree_path)
+        safe_prefix.append(part)
+
+
 def build_index_from_tree(
     root_path: str | bytes,
     index_path: str | bytes,

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -607,6 +607,12 @@ def _checked_worktree_path(repo: "Repo", tree_path: bytes) -> bytes:
     outside the work tree or into the control directory, matching the bar git
     applies to its own path operands.
 
+    In addition to the name-based validation, refuse any path whose leading
+    directory components already exist in the work tree as a symlink. A
+    malicious repository could otherwise leave e.g. ``sub`` as a symlink to
+    ``.git/hooks`` and then have ``checkout(paths=["sub/post-checkout"])``
+    write attacker content through it.
+
     Args:
       repo: Repository the path is relative to.
       tree_path: Path in tree form (``/``-separated), as produced by
@@ -616,10 +622,16 @@ def _checked_worktree_path(repo: "Repo", tree_path: bytes) -> bytes:
       The filesystem path under the repository root, as bytes.
 
     Raises:
-      Error: If the path is absolute or carries a component the configured
-        ``core.protectNTFS``/``core.protectHFS`` validator rejects.
+      Error: If the path is absolute, carries a component the configured
+        ``core.protectNTFS``/``core.protectHFS`` validator rejects, or resolves
+        through a symlink already present in the work tree.
     """
-    from ..index import get_path_element_validator, validate_path
+    from ..index import (
+        InvalidPathError,
+        get_path_element_validator,
+        validate_path,
+        verify_leading_dirs,
+    )
 
     # Tree paths always use "/" as the separator; a leading "/" or "\\" would
     # make os.path.join discard the repository root, so treat it as absolute.
@@ -628,7 +640,12 @@ def _checked_worktree_path(repo: "Repo", tree_path: bytes) -> bytes:
     validator = get_path_element_validator(repo.get_config_stack())
     if not validate_path(tree_path, validator):
         raise Error(f"refusing to write unsafe path: {tree_path!r}")
-    return os.path.join(os.fsencode(repo.path), tree_path)
+    repo_path = os.fsencode(repo.path)
+    try:
+        verify_leading_dirs(tree_path, [], repo_path)
+    except InvalidPathError:
+        raise Error(f"refusing to write through symlink: {tree_path!r}")
+    return os.path.join(repo_path, tree_path)
 
 
 def parse_timezone_format(tz_str: str) -> int:

--- a/dulwich/stash.py
+++ b/dulwich/stash.py
@@ -28,7 +28,6 @@ __all__ = [
 ]
 
 import os
-import stat
 from typing import TYPE_CHECKING, TypedDict
 
 from .diff_tree import tree_changes
@@ -45,6 +44,7 @@ from .index import (
     symlink,
     update_working_tree,
     validate_path,
+    verify_leading_dirs,
 )
 from .object_store import iter_tree_contents
 from .objects import S_IFGITLINK, Blob, Commit, ObjectID, TreeEntry
@@ -65,52 +65,6 @@ class CommitKwargs(TypedDict, total=False):
 
 
 DEFAULT_STASH_REF = Ref(b"refs/stash")
-
-
-def _verify_leading_dirs(
-    tree_path: bytes,
-    safe_prefix: list[bytes],
-    repo_path: bytes,
-) -> None:
-    """Reject writes whose leading path resolves through a symlink.
-
-    ``iter_tree_contents`` yields paths in sorted order, so consecutive
-    siblings share a long prefix. ``safe_prefix`` tracks the deepest chain
-    of directory components already verified to be real directories (or
-    absent), starting at the worktree root; each call only ``lstat``s the
-    components that differ from that chain. Mirrors git's
-    ``lstat_cache_matchlen`` (see CVE-2021-21300).
-
-    Raises ``InvalidPathError`` if any leading component is a symlink.
-    """
-    slash = tree_path.rfind(b"/")
-    if slash <= 0:
-        return
-    components = tree_path[:slash].split(b"/")
-
-    common = 0
-    while (
-        common < len(safe_prefix)
-        and common < len(components)
-        and safe_prefix[common] == components[common]
-    ):
-        common += 1
-    del safe_prefix[common:]
-
-    current = repo_path
-    for part in components[:common]:
-        current = os.path.join(current, part)
-    for part in components[common:]:
-        current = os.path.join(current, part)
-        try:
-            st = os.lstat(current)
-        except FileNotFoundError:
-            # Anything below here doesn't exist yet; makedirs will create
-            # it under a verified-real-directory prefix.
-            break
-        if stat.S_ISLNK(st.st_mode):
-            raise InvalidPathError(tree_path)
-        safe_prefix.append(part)
 
 
 class Stash:
@@ -278,7 +232,7 @@ class Stash:
             # Refuse writes whose leading path goes through a symlink left
             # in the worktree (e.g. ``link`` -> ``.git/hooks``); the cache
             # keeps the total cost to one ``lstat`` per unique directory.
-            _verify_leading_dirs(tree_entry2.path, safe_prefix, repo_path)
+            verify_leading_dirs(tree_entry2.path, safe_prefix, repo_path)
 
             full_path = _tree_to_fs_path(repo_path, tree_entry2.path)
 

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -5014,6 +5014,47 @@ class CheckoutTests(PorcelainTestCase):
         with open(trigger) as f:
             self.assertEqual("payload\n", f.read())
 
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_checkout_paths_rejects_intermediate_symlink(self) -> None:
+        # A path-specific checkout of ``sub/victim`` must refuse to write when
+        # ``sub`` already exists in the work tree as a symlink pointing
+        # elsewhere. Otherwise ``os.makedirs`` and the subsequent write would
+        # both traverse the symlink and land content outside the work tree.
+        outside_dir = os.path.join(self.test_dir, "outside")
+        os.makedirs(outside_dir)
+        outside_file = os.path.join(outside_dir, "victim")
+        with open(outside_file, "w") as f:
+            f.write("original\n")
+
+        payload = Blob.from_string(b"PWNED\n")
+        subdir_tree = Tree()
+        subdir_tree.add(b"victim", 0o100644, payload.id)
+        root_tree = Tree()
+        root_tree.add(b"sub", stat.S_IFDIR, subdir_tree.id)
+        for obj in (payload, subdir_tree, root_tree):
+            self.repo.object_store.add_object(obj)
+        sha = self.repo.get_worktree().commit(
+            message=b"malicious",
+            tree=root_tree.id,
+            committer=b"Jane <jane@example.com>",
+            author=b"John <john@example.com>",
+        )
+
+        os.symlink(
+            os.path.join("..", "outside"),
+            os.path.join(self.repo.path, "sub"),
+        )
+
+        self.assertRaises(
+            porcelain.Error,
+            porcelain.checkout,
+            self.repo,
+            sha,
+            paths=[b"sub/victim"],
+        )
+        with open(outside_file) as f:
+            self.assertEqual("original\n", f.read())
+
     def test_checkout_to_head(self) -> None:
         new_sha = self._commit_something_wrong()
 
@@ -5311,6 +5352,20 @@ class CheckWorktreePathTests(PorcelainTestCase):
         self.assertEqual(
             os.path.join(root, b".github/workflows/ci.yml"),
             _checked_worktree_path(self.repo, b".github/workflows/ci.yml"),
+        )
+
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_rejects_intermediate_symlink(self) -> None:
+        # A leading directory component that already exists in the work tree
+        # as a symlink must be refused: a crafted repository could otherwise
+        # leave ``sub`` as a symlink to ``.git/hooks`` and then have a
+        # subsequent write to ``sub/anything`` land through the link.
+        os.symlink(".git/hooks", os.path.join(self.repo.path, "sub"))
+        self.assertRaises(
+            porcelain.Error,
+            _checked_worktree_path,
+            self.repo,
+            b"sub/post-checkout",
         )
 
 


### PR DESCRIPTION
Reported by zx (Jace).