### PR TITLE
pack: reject OFS_DELTA with delta_base_offset of 0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+1.2.9	UNRELEASED
+
+ * SECURITY: Reject ``OFS_DELTA`` pack entries whose ``delta_base_offset``
+   is zero. Such an entry references itself, so ``Pack.resolve_object``
+   would loop forever growing its delta stack until the process ran out
+   of memory. ``unpack_object`` now raises ``ApplyDeltaError`` at parse
+   time, matching git's ``delta offset == 0 is invalid`` guard.
+   (reported by Luke Banto, Jelmer Vernooĳ)
+
 1.2.8	2026-07-05
 
  * Enumerate the objects to push before the HTTP ``git-receive-pack``

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1485,6 +1485,11 @@ def unpack_object(
             delta_base_offset += 1
             delta_base_offset <<= 7
             delta_base_offset += byte & 0x7F
+        if delta_base_offset == 0:
+            # A zero offset makes the delta reference itself, which would
+            # loop forever in resolve_object. git's C client rejects this
+            # with "delta offset == 0 is invalid".
+            raise ApplyDeltaError("OFS_DELTA has delta_base_offset of 0")
         delta_base = delta_base_offset
     elif type_num == REF_DELTA:
         # Determine hash size from hash_func

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1035,6 +1035,20 @@ class WritePackTests(TestCase):
         finally:
             f.close()
 
+    def test_unpack_object_rejects_zero_ofs_delta(self) -> None:
+        # An OFS_DELTA with delta_base_offset == 0 would reference itself
+        # and cause resolve_object to loop forever. Reject at parse time.
+        header = bytes([(OFS_DELTA << 4) | 0])
+        ofs_bytes = bytes([0x00])
+        body = zlib.compress(b"")
+        f = BytesIO(header + ofs_bytes + body)
+        self.assertRaises(
+            ApplyDeltaError,
+            unpack_object,
+            f.read,
+            DEFAULT_OBJECT_FORMAT.hash_func,
+        )
+
     def test_write_pack_object_sha(self) -> None:
         f = BytesIO()
         f.write(b"header")


### PR DESCRIPTION
Such an entry references itself, so Pack.resolve_object would loop forever growing its delta stack until the process ran out of memory. Reject at parse time in unpack_object, matching git's "delta offset == 0 is invalid" guard.