### PR TITLE
index: reject DOS drive-letter prefix in checkout paths on Windows

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,11 @@
 1.2.9	UNRELEASED
 
+ * SECURITY: On Windows, reject checkout paths whose leading component
+   is a DOS drive-letter prefix like `C:`. `os.path.join(root, "C:...")`
+   discards `root` and writes to the absolute drive path, so a tree entry
+   named `C:` could otherwise write arbitrary files outside the work tree.
+   (reported by Luke Baton, Jelmer Vernooĳ)
+
  * SECURITY: Reject ``OFS_DELTA`` pack entries whose ``delta_base_offset``
    is zero. Such an entry references itself, so ``Pack.resolve_object``
    would loop forever growing its delta stack until the process ran out

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -2075,6 +2075,17 @@ def _is_reserved_windows_device_name(normalized: bytes) -> bool:
     return stem in RESERVED_WINDOWS_DEVICE_NAMES
 
 
+def _has_dos_drive_prefix(name: bytes) -> bool:
+    """Return True if name begins with a DOS drive-letter prefix like 'C:'.
+
+    Any ASCII byte followed by a colon counts, matching the ASCII branch of
+    C git's win32_has_dos_drive_prefix: subst allows non-alphabetic drives.
+    """
+    if len(name) < 2 or name[1:2] != b":":
+        return False
+    return name[0] < 0x80
+
+
 def validate_path_element_ntfs(element: bytes) -> bool:
     """Validate a path element using NTFS filesystem rules.
 
@@ -2173,6 +2184,11 @@ def validate_path(
     element_validator: Callable[[bytes], bool] = validate_path_element_default,
 ) -> bool:
     """Default path validator that just checks for .git/."""
+    # A leading drive-letter prefix lets os.path.join discard the work-tree
+    # root on Windows. Matches C git's verify_path, whose has_dos_drive_prefix
+    # is a no-op stub on non-Windows.
+    if os.name == "nt" and _has_dos_drive_prefix(path):
+        return False
     parts = path.split(b"/")
     for p in parts:
         if not element_validator(p):

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -628,14 +628,19 @@ def _checked_worktree_path(repo: "Repo", tree_path: bytes) -> bytes:
     """
     from ..index import (
         InvalidPathError,
+        _has_dos_drive_prefix,
         get_path_element_validator,
         validate_path,
         verify_leading_dirs,
     )
 
-    # Tree paths always use "/" as the separator; a leading "/" or "\\" would
-    # make os.path.join discard the repository root, so treat it as absolute.
-    if tree_path.startswith((b"/", b"\\")):
+    # Tree paths use "/" as the separator, so a leading "/", "\\" or (on
+    # Windows) drive-letter prefix would make os.path.join discard the
+    # repository root.
+    absolute = tree_path.startswith((b"/", b"\\")) or (
+        os.name == "nt" and _has_dos_drive_prefix(tree_path)
+    )
+    if absolute:
         raise Error(f"refusing to write path outside repository: {tree_path!r}")
     validator = get_path_element_validator(repo.get_config_stack())
     if not validate_path(tree_path, validator):

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -5339,6 +5339,11 @@ class CheckWorktreePathTests(PorcelainTestCase):
         ):
             self.assertRaises(porcelain.Error, _checked_worktree_path, self.repo, bad)
 
+    @skipIf(os.name != "nt", "drive prefix is only rejected on Windows")
+    def test_rejects_dos_drive_prefix_on_windows(self) -> None:
+        for bad in (b"C:/Users/victim/evil.txt", b"C:", b"c:evil"):
+            self.assertRaises(porcelain.Error, _checked_worktree_path, self.repo, bad)
+
     def test_allows_ordinary_paths(self) -> None:
         root = os.fsencode(self.repo.path)
         self.assertEqual(

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -61,6 +61,7 @@ from dulwich.index import (
     _ensure_parent_dir_exists,
     _fs_to_tree_path,
     _has_directory_changed,
+    _has_dos_drive_prefix,
     _tree_to_fs_path,
     build_index_from_tree,
     cleanup_mode,
@@ -77,6 +78,7 @@ from dulwich.index import (
     read_index_dict,
     read_submodule_head,
     update_working_tree,
+    validate_path,
     validate_path_element_default,
     validate_path_element_hfs,
     validate_path_element_ntfs,
@@ -694,6 +696,33 @@ class BuildIndexTests(TestCase):
 
                 # Nothing was written, including the benign entry.
                 self.assertEqual(os.listdir(repo.path), [".git"])
+
+    @skipIf(os.name != "nt", "drive prefix is only rejected on Windows")
+    def test_dos_drive_prefix_aborts_checkout(self) -> None:
+        # A "C:" entry at the top of the tree makes Windows' os.path.join
+        # discard the work-tree root. Nested trees because a single tree
+        # entry cannot contain a slash.
+        repo_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, repo_dir)
+        with Repo.init(repo_dir) as repo:
+            blob = Blob.from_string(b"payload\n")
+            inner = Tree()
+            inner[b"evil.txt"] = (stat.S_IFREG | 0o644, blob.id)
+            outer = Tree()
+            outer[b"C:"] = (stat.S_IFDIR, inner.id)
+            repo.object_store.add_objects([(o, None) for o in [blob, inner, outer]])
+
+            self.assertRaises(
+                InvalidPathError,
+                build_index_from_tree,
+                repo.path,
+                repo.index_path(),
+                repo.object_store,
+                outer.id,
+                validate_path_element=validate_path_element_ntfs,
+            )
+
+            self.assertEqual(os.listdir(repo.path), [".git"])
 
     def test_ntfs_colon_filename_checked_out(self) -> None:
         # A file whose name merely contains a colon (an NTFS-hostile
@@ -1724,6 +1753,79 @@ class TestValidatePathElement(TestCase):
         self.assertTrue(validate_path_element_ntfs(b"com0"))
         self.assertTrue(validate_path_element_ntfs(b"com10"))
         self.assertTrue(validate_path_element_ntfs(b"lpt0"))
+
+    def test_ntfs_element_accepts_bare_drive_letter(self) -> None:
+        # The drive-letter check lives in validate_path against the whole
+        # path, matching where C git's verify_path applies it. Individual
+        # elements may still contain a colon (see issue #2205).
+        self.assertTrue(validate_path_element_ntfs(b"C:"))
+        self.assertTrue(validate_path_element_ntfs(b"C:foo"))
+
+
+class TestHasDosDrivePrefix(TestCase):
+    def test_bare_drive_letter(self) -> None:
+        for name in (b"C:", b"c:", b"D:", b"Z:", b"a:"):
+            self.assertTrue(_has_dos_drive_prefix(name), repr(name))
+
+    def test_drive_letter_with_tail(self) -> None:
+        self.assertTrue(_has_dos_drive_prefix(b"C:foo"))
+        self.assertTrue(_has_dos_drive_prefix(b"C:/foo"))
+        self.assertTrue(_has_dos_drive_prefix(b"C:\\foo"))
+
+    def test_non_alphabetic_drive(self) -> None:
+        # subst allows any ASCII byte as a drive letter.
+        self.assertTrue(_has_dos_drive_prefix(b"1:"))
+        self.assertTrue(_has_dos_drive_prefix(b"!:"))
+
+    def test_high_bit_first_byte_not_treated_as_ascii(self) -> None:
+        # C git also handles subst-created Unicode drives; not emulated.
+        self.assertFalse(_has_dos_drive_prefix(b"\xc3\xa9:"))
+
+    def test_no_colon(self) -> None:
+        self.assertFalse(_has_dos_drive_prefix(b"C"))
+        self.assertFalse(_has_dos_drive_prefix(b"CD"))
+        self.assertFalse(_has_dos_drive_prefix(b""))
+
+    def test_colon_not_at_position_one(self) -> None:
+        self.assertFalse(_has_dos_drive_prefix(b":foo"))
+        self.assertFalse(_has_dos_drive_prefix(b"ab:cd"))
+
+
+class TestValidatePath(TestCase):
+    @skipIf(os.name != "nt", "drive prefix is only rejected on Windows")
+    def test_rejects_drive_letter_prefix_on_windows(self) -> None:
+        self.assertFalse(validate_path(b"C:/Users/victim/evil.txt"))
+        self.assertFalse(validate_path(b"C:"))
+        self.assertFalse(validate_path(b"c:evil"))
+
+    @skipIf(os.name != "nt", "drive prefix is only rejected on Windows")
+    def test_rejects_drive_letter_prefix_regardless_of_validator(self) -> None:
+        # Not gated on core.protectNTFS, matching C git.
+        for v in (
+            validate_path_element_default,
+            validate_path_element_hfs,
+            validate_path_element_ntfs,
+        ):
+            self.assertFalse(
+                validate_path(b"C:/x", v),
+                f"validator {v.__name__} should reject drive-prefix path",
+            )
+
+    @skipIf(os.name == "nt", "on POSIX C:x is just an unusual filename")
+    def test_accepts_drive_letter_prefix_on_posix(self) -> None:
+        # POSIX' os.path.join does not absolutize on a drive-letter prefix.
+        self.assertTrue(validate_path(b"C:/Users/victim/evil.txt"))
+        self.assertTrue(validate_path(b"C:"))
+        self.assertTrue(validate_path(b"c:evil"))
+
+    def test_accepts_colon_mid_path(self) -> None:
+        # See issue #2205.
+        self.assertTrue(
+            validate_path(b"foo/C:bar", validate_path_element_ntfs),
+        )
+        self.assertTrue(
+            validate_path(b"with:colon.txt", validate_path_element_ntfs),
+        )
 
 
 class TestDecodeUTF8WithFallback(TestCase):


### PR DESCRIPTION
A tree entry named `C:` (or any ASCII-byte-then-colon spelling) would let `os.path.join(root, b"C:...")` on Windows discard the work-tree root and write to the absolute drive path, giving a malicious repository an arbitrary file write outside the work tree.