### PR TITLE
bitmap: bound EWAH running length when decoding

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.9	UNRELEASED
 
+ * Bound the running length when decoding EWAH bitmaps, so a corrupt or
+   malformed ``.bitmap`` index raises ``ValueError`` instead of hanging in
+   an unbounded loop that exhausts memory. (Jelmer Vernooĳ)
+
  * SECURITY: On Windows, reject checkout paths whose leading component
    is a DOS drive-letter prefix like `C:`. `os.path.join(root, "C:...")`
    discards `root` and writes to the absolute drive path, so a tree entry

--- a/dulwich/bitmap.py
+++ b/dulwich/bitmap.py
@@ -201,6 +201,13 @@ class EWAHBitmap:
         self.bit_count = bit_count
         current_bit = 0
 
+        # The bitmap describes bit_count bits, stored as ceil(bit_count / 64)
+        # 64-bit words. Decoding must never emit more bits than that. A corrupt
+        # or malicious RLW can declare a huge running_len, which would otherwise
+        # trigger an unbounded loop and memory allocation, so bound every
+        # section against this limit.
+        max_bits = ((bit_count + 63) // 64) * 64
+
         # Read all words first
         words = []
         for _ in range(word_count):
@@ -223,16 +230,27 @@ class EWAHBitmap:
 
             # Process running bits
             if running_len > 0:
+                run_bits = running_len * 64
+                if current_bit + run_bits > max_bits:
+                    raise ValueError(
+                        f"EWAH running length {running_len} exceeds declared "
+                        f"bit count {bit_count}"
+                    )
                 if running_bit == 1:
                     # Add all bits in the repeated section
-                    for i in range(running_len * 64):
+                    for i in range(run_bits):
                         self.bits.add(current_bit + i)
-                current_bit += running_len * 64
+                current_bit += run_bits
 
             # Process literal words
             for _ in range(literal_words):
                 if idx >= len(words):
                     break
+
+                if current_bit + 64 > max_bits:
+                    raise ValueError(
+                        f"EWAH literal words exceed declared bit count {bit_count}"
+                    )
 
                 literal = words[idx]
                 idx += 1

--- a/fuzzing/fuzz-targets/fuzz_bitmap.py
+++ b/fuzzing/fuzz-targets/fuzz_bitmap.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+import sys
+from io import BytesIO
+
+import atheris
+
+with atheris.instrument_imports():
+    from dulwich.bitmap import EWAHBitmap, read_bitmap_file
+
+
+def TestOneInput(data) -> int | None:
+    # Exercise the standalone EWAH decoder as well as the full bitmap file
+    # reader, both of which parse untrusted input.
+    try:
+        EWAHBitmap(data)
+    except ValueError:
+        pass
+
+    try:
+        read_bitmap_file(BytesIO(data))
+    except ValueError:
+        pass
+
+
+def main() -> None:
+    atheris.Setup(sys.argv, TestOneInput)
+    atheris.Fuzz()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -23,6 +23,7 @@
 
 import os
 import shutil
+import struct
 import tempfile
 import time
 import unittest
@@ -730,6 +731,70 @@ class BitmapErrorHandlingTests(unittest.TestCase):
 
         # Should raise ValueError about missing data
         self.assertIsInstance(ctx.exception, ValueError)
+
+    def test_decode_oversized_running_length(self):
+        """Reject an RLW whose running length exceeds the declared bit count.
+
+        A malicious bitmap can declare a tiny bit_count but a huge
+        running_len, which would otherwise trigger an unbounded loop and
+        memory allocation (a decompression bomb).
+        """
+        # bit_count=1024 (16 words), word_count=1, then a single RLW with
+        # running_bit=1 and running_len=0x10000000.
+        rlw = (1 << 1) | 1 | (0x10000000 << 1)
+        data = struct.pack(">II", 1024, 1)
+        data += struct.pack(">Q", rlw)
+        data += struct.pack(">I", 0)  # RLW position
+
+        with self.assertRaises(ValueError) as ctx:
+            EWAHBitmap(data)
+        self.assertIn("running length", str(ctx.exception).lower())
+
+    def test_decode_oversized_literal_words(self):
+        """Reject more literal words than the declared bit count allows."""
+        # bit_count=64 (one word) but the RLW claims two literal words.
+        rlw = 2 << 33
+        data = struct.pack(">II", 64, 3)
+        data += struct.pack(">Q", rlw)
+        data += struct.pack(">Q", 0xFFFFFFFFFFFFFFFF)
+        data += struct.pack(">Q", 0xFFFFFFFFFFFFFFFF)
+        data += struct.pack(">I", 0)  # RLW position
+
+        with self.assertRaises(ValueError) as ctx:
+            EWAHBitmap(data)
+        self.assertIn("literal words", str(ctx.exception).lower())
+
+    def test_decode_running_length_at_limit(self):
+        """A run that fills exactly the declared bit count is accepted."""
+        # bit_count=128 (two words), one RLW with running_bit=1 and
+        # running_len=2 fills the whole bitmap.
+        rlw = (2 << 1) | 1
+        data = struct.pack(">II", 128, 1)
+        data += struct.pack(">Q", rlw)
+        data += struct.pack(">I", 0)  # RLW position
+
+        decoded = EWAHBitmap(data)
+        self.assertEqual(128, len(decoded))
+        self.assertIn(0, decoded)
+        self.assertIn(127, decoded)
+
+    def test_read_bitmap_file_oversized_running_length(self):
+        """A corrupt type bitmap with an oversized run is rejected on read."""
+        data = BITMAP_SIGNATURE
+        data += BITMAP_VERSION.to_bytes(2, "big")
+        data += b"\x00\x00"  # Flags
+        data += b"\x00\x00\x00\x00"  # Entry count
+        data += b"\x00" * 20  # Pack checksum
+
+        # First type bitmap: bit_count=1024, one RLW with a huge running_len.
+        rlw = (1 << 1) | 1 | (0x10000000 << 1)
+        data += struct.pack(">II", 1024, 1)
+        data += struct.pack(">Q", rlw)
+        data += struct.pack(">I", 0)
+
+        with self.assertRaises(ValueError) as ctx:
+            read_bitmap_file(BytesIO(data))
+        self.assertIn("running length", str(ctx.exception).lower())
 
     def test_empty_bitmap_file(self):
         """Test reading completely empty file."""


### PR DESCRIPTION
A corrupt or truncated .bitmap index could declare a tiny bit_count but a huge running_len in an RLW, driving _decode into an unbounded loop that inserts billions of integers into a set. Reject any run or literal that would extend past the declared bit count and raise ValueError instead.

Bitmap files are read from local disk (never over the wire), so this is robustness against a bad local file rather than a remotely-reachable issue.

Reported by Luke Banto