### PR TITLE
canonicalize file mode in git archive tar entries

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+1.2.11	UNRELEASED
+
+ * SECURITY: Canonicalize the file mode of regular files written into a
+   ``git archive`` tarball. ``tar_stream`` copied the tree-supplied mode
+   verbatim, so a crafted tree entry (e.g. mode ``0o104755``) carried
+   setuid/setgid/sticky bits into the archive and an extracted file could
+   land setuid. Modes are now run through ``cleanup_mode`` like checkout,
+   matching git's archive writer.
+
 1.2.10	2026-07-07
 
  * Fix regression in 1.2.9 where loose objects whose content inflates to

--- a/dulwich/archive.py
+++ b/dulwich/archive.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from .object_store import BaseObjectStore
     from .objects import TreeEntry
 
+from .index import cleanup_mode
 from .objects import Blob, Tree
 
 
@@ -204,7 +205,14 @@ def tar_stream(
             info.name = entry_abspath.decode("utf-8", "surrogateescape")
             info.size = blob.raw_length()
             assert entry.mode is not None
-            info.mode = entry.mode
+            # Canonicalize the tree-supplied mode the same way git's archive
+            # writer does before emitting a permission field. A crafted tree
+            # entry can carry setuid/setgid/sticky or other non-canonical bits
+            # (e.g. 0o104755), which tarfile would otherwise copy verbatim into
+            # the archive so an extracted file lands setuid. cleanup_mode maps a
+            # regular file to 0o644/0o755 (matching checkout), and masking to the
+            # permission bits drops the special bits.
+            info.mode = cleanup_mode(entry.mode) & 0o777
             info.mtime = mtime
 
             tar.addfile(info, data)

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -188,6 +188,33 @@ class ArchiveTests(TestCase):
         with self.assertRaises(UnsafeArchivePathError):
             b"".join(tar_stream(store, outer, mtime=0))
 
+    def test_mode_canonicalized(self) -> None:
+        """setuid/setgid/sticky and other non-canonical mode bits are dropped.
+
+        A crafted tree can hold a regular-file mode such as 0o104755. git's
+        archive writer canonicalizes these before emitting the tar permission
+        field, so an extracted file never ends up setuid.
+        """
+        store = MemoryObjectStore()
+        b1 = Blob.from_string(b"payload")
+        store.add_object(b1)
+        t = Tree()
+        t.add(b"suid_exec", 0o104755, b1.id)
+        t.add(b"sgid_sticky", 0o106644, b1.id)
+        t.add(b"plain", 0o100644, b1.id)
+        t.add(b"exec", 0o100755, b1.id)
+        store.add_object(t)
+        stream = b"".join(tar_stream(store, t, mtime=0))
+        tf = tarfile.TarFile(fileobj=BytesIO(stream))
+        self.addCleanup(tf.close)
+        modes = {m.name: m.mode for m in tf.getmembers()}
+        self.assertEqual(0o755, modes["suid_exec"])
+        self.assertEqual(0o644, modes["sgid_sticky"])
+        self.assertEqual(0o644, modes["plain"])
+        self.assertEqual(0o755, modes["exec"])
+        for mode in modes.values():
+            self.assertEqual(0, mode & 0o7000)
+
     def test_tar_stream_with_submodule(self) -> None:
         """Test tar_stream handles missing objects (submodules) gracefully."""
         store = MemoryObjectStore()


### PR DESCRIPTION
Repro: build an archive of a tree whose regular-file entry carries a mode like `0o104755` (setuid) or `0o106644` (setgid + sticky), via `porcelain.archive`, the `dulwich archive` CLI, or the `git archive` upload-archive server. The resulting tar entry keeps those bits, so extraction produces a setuid/setgid file.

Cause: `tar_stream` copied the tree-supplied mode straight into the tar header (`info.mode = entry.mode`). `tarfile` masks with `0o7777`, so setuid/setgid/sticky and other non-canonical bits survive. git's archive writer canonicalizes every regular-file mode from the executable bit and never emits those special bits.

Fix: run the mode through `cleanup_mode` (the same create_ce_mode canonicalization dulwich already applies on checkout) and mask to the permission bits before `addfile`, yielding `0o644`/`0o755`. The tree is attacker-controlled when it comes from a cloned or fetched commit, so the canonicalization belongs in the archive writer rather than the caller.
