### PR TITLE
repo: respect GIT_COMMON_DIR environment variable (fixes #1860)

### DIFF
--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1483,7 +1483,23 @@ class Repo(BaseRepo):
                 self._controldir = hidden_path
         else:
             self._controldir = root
-        commondir = self.get_named_file(COMMONDIR)
+        # GIT_COMMON_DIR env var takes precedence over the commondir file
+        # (matches git's setup.c: read_repo_path() honours GIT_COMMON_DIR
+        # before falling back to the `commondir` file in the gitdir).
+        # Closes https://github.com/jelmer/dulwich/issues/1860
+        git_common_dir = os.environ.get("GIT_COMMON_DIR")
+        if git_common_dir:
+            self._commondir = git_common_dir
+        else:
+            commondir = self.get_named_file(COMMONDIR)
+            if commondir is not None:
+                with commondir:
+                    self._commondir = os.path.join(
+                        self.controldir(),
+                        os.fsdecode(commondir.read().rstrip(b"\r\n")),
+                    )
+            else:
+                self._commondir = self._controldir
         if commondir is not None:
             with commondir:
                 self._commondir = os.path.join(


### PR DESCRIPTION
## What this fixes

Closes #1860.

When a user sets `GIT_COMMON_DIR` in their environment (typical for worktree setups and custom git layouts), Dulwich should use that path as `commondir()` instead of inferring it from the `commondir` file inside the gitdir.

## Changes (`dulwich/repo.py`)

- In `Repo.__init__`, before reading the `commondir` file, check `os.environ.get("GIT_COMMON_DIR")`. If set, use it as the common directory.
- The existing `commondir` file fallback is preserved when the env var is not set.

## Behavior

- Unset (current default): `commondir()` works exactly as before — reads `commondir` file or falls back to `controldir`.
- Set to a path: `commondir()` returns that path directly, matching git's own `setup.c` behavior.

## Diff

```
 dulwich/repo.py | 18 +++++++++++++++++-
 1 file changed, 17 insertions(+), 1 deletion(-)
```

## Test plan

```python
import os
os.environ['GIT_COMMON_DIR'] = '/tmp/parent/.git'
from dulwich.repo import Repo
r = Repo('/path/to/worktree')
assert r.commondir() == '/tmp/parent/.git'
```

I don't see an existing test for `commondir()` against the env var in `dulwich/tests/test_repository.py`; happy to add one in a follow-up commit on this PR if you'd like.