### PR TITLE
apply protectHFS and protectNTFS together in path validator

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 1.2.11	UNRELEASED
 
+ * SECURITY: Apply ``core.protectHFS`` and ``core.protectNTFS`` together when
+   selecting the checkout path-element validator. ``get_path_element_validator``
+   returned only the NTFS validator whenever ``protectNTFS`` was on (the default
+   everywhere), so on macOS the HFS check never ran and an HFS+ spelling of
+   ``.git`` using ignorable code points (e.g. ``.gi<U+200C>t``) passed
+   validation and could poison ``.git`` on checkout. Both protections now apply
+   when both are enabled, matching git's ``verify_path``.
+
  * SECURITY: Canonicalize the file mode of regular files written into a
    ``git archive`` tarball. ``tar_stream`` copied the tree-supplied mode
    verbatim, so a crafted tree entry (e.g. mode ``0o104755``) carried

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -2161,7 +2161,9 @@ def get_path_element_validator(config: "Config") -> Callable[[bytes], bool]:
     ``core.protectNTFS`` defaults to true on every platform (matching Git's
     ``PROTECT_NTFS_DEFAULT=1``) because a repository authored on POSIX can
     still be cloned on Windows later; ``core.protectHFS`` defaults to true on
-    macOS. With both disabled this falls back to the default validator, which
+    macOS. Both protections are independent and apply together, so on macOS
+    (where both default on) a path element must satisfy the NTFS and HFS+
+    checks. With both disabled this falls back to the default validator, which
     only refuses ``.git``, ``.`` and ``..``.
 
     Args:
@@ -2171,12 +2173,20 @@ def get_path_element_validator(config: "Config") -> Callable[[bytes], bool]:
         Function that validates a single path element for the configured
         filesystem protections.
     """
+    validators: list[Callable[[bytes], bool]] = []
     if config.get_boolean(b"core", b"protectNTFS", True):
-        return validate_path_element_ntfs
-    elif config.get_boolean(b"core", b"protectHFS", sys.platform == "darwin"):
-        return validate_path_element_hfs
-    else:
+        validators.append(validate_path_element_ntfs)
+    if config.get_boolean(b"core", b"protectHFS", sys.platform == "darwin"):
+        validators.append(validate_path_element_hfs)
+    if not validators:
         return validate_path_element_default
+    if len(validators) == 1:
+        return validators[0]
+
+    def validate_all(element: bytes) -> bool:
+        return all(validator(element) for validator in validators)
+
+    return validate_all
 
 
 def validate_path(

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -367,12 +367,10 @@ from ..index import (
     _fs_to_tree_path,
     blob_from_path_and_stat,
     build_file_from_blob,
+    get_path_element_validator,
     get_unstaged_changes,
     symlink,
     update_working_tree,
-    validate_path_element_default,
-    validate_path_element_hfs,
-    validate_path_element_ntfs,
 )
 from ..object_store import BaseObjectStore, tree_lookup_path
 from ..objects import (
@@ -5498,15 +5496,10 @@ def _get_worktree_update_config(
     config = repo.get_config()
     honor_filemode = config.get_boolean(b"core", b"filemode", os.name != "nt")
 
-    # core.protectNTFS defaults to True on all platforms (matching
-    # Git's PROTECT_NTFS_DEFAULT=1) because a repo authored on
-    # POSIX can still be cloned on Windows later.
-    if config.get_boolean(b"core", b"protectNTFS", True):
-        validate_path_element = validate_path_element_ntfs
-    elif config.get_boolean(b"core", b"protectHFS", sys.platform == "darwin"):
-        validate_path_element = validate_path_element_hfs
-    else:
-        validate_path_element = validate_path_element_default
+    # core.protectNTFS defaults to True on all platforms (matching Git's
+    # PROTECT_NTFS_DEFAULT=1) and protectHFS defaults to True on macOS; both
+    # apply together, so defer to the shared selector rather than picking one.
+    validate_path_element = get_path_element_validator(config)
 
     if config.get_boolean(b"core", b"symlinks", True):
 

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -67,6 +67,7 @@ from dulwich.index import (
     cleanup_mode,
     commit_tree,
     detect_case_only_renames,
+    get_path_element_validator,
     get_unstaged_changes,
     index_entry_from_directory,
     index_entry_from_path,
@@ -1826,6 +1827,47 @@ class TestValidatePath(TestCase):
         self.assertTrue(
             validate_path(b"with:colon.txt", validate_path_element_ntfs),
         )
+
+
+class TestGetPathElementValidator(TestCase):
+    # ``.gi`` + U+200C ZERO WIDTH NON-JOINER + ``t``. HFS+ drops the
+    # ignorable code point, so this file lands as ``.git`` on macOS.
+    HFS_DOTGIT = b".gi\xe2\x80\x8ct"
+
+    def test_ntfs_only_leaves_hfs_spelling(self) -> None:
+        config = ConfigDict()
+        config.set((b"core",), b"protectNTFS", b"true")
+        config.set((b"core",), b"protectHFS", b"false")
+        validator = get_path_element_validator(config)
+        # The NTFS check does not strip HFS+ ignorable characters, matching
+        # git without core.protectHFS.
+        self.assertTrue(validator(self.HFS_DOTGIT))
+
+    def test_both_enabled_rejects_hfs_spelling(self) -> None:
+        config = ConfigDict()
+        config.set((b"core",), b"protectNTFS", b"true")
+        config.set((b"core",), b"protectHFS", b"true")
+        validator = get_path_element_validator(config)
+        # protectNTFS and protectHFS apply together; the HFS spelling of
+        # ``.git`` must still be rejected when NTFS protection is also on.
+        self.assertFalse(validator(self.HFS_DOTGIT))
+        self.assertFalse(validator(b".git"))
+        self.assertTrue(validator(b"README.md"))
+
+    def test_hfs_only_rejects_hfs_spelling(self) -> None:
+        config = ConfigDict()
+        config.set((b"core",), b"protectNTFS", b"false")
+        config.set((b"core",), b"protectHFS", b"true")
+        validator = get_path_element_validator(config)
+        self.assertFalse(validator(self.HFS_DOTGIT))
+
+    def test_both_disabled_uses_default(self) -> None:
+        config = ConfigDict()
+        config.set((b"core",), b"protectNTFS", b"false")
+        config.set((b"core",), b"protectHFS", b"false")
+        validator = get_path_element_validator(config)
+        self.assertIs(validator, validate_path_element_default)
+        self.assertTrue(validator(self.HFS_DOTGIT))
 
 
 class TestDecodeUTF8WithFallback(TestCase):


### PR DESCRIPTION
1. `get_path_element_validator` picks the checkout validator with `if protectNTFS / elif protectHFS`, so when protectNTFS is on (its default everywhere) the HFS check never runs. git applies `is_ntfs_dotgit` and `is_hfs_dotgit` independently.
2. On macOS (protectHFS default on) an HFS+ spelling of `.git` built from ignorable code points, e.g. `.gi‌t`, passes the NTFS validator, which does not strip HFS-ignorable characters. Checking out an untrusted tree writes it, and the filesystem collapses it back to `.git`.
3. The same inline `if/elif` selector is duplicated in porcelain `_get_worktree_update_config`.

Return a validator that requires every enabled protection to pass, so NTFS and HFS both apply when both are on, and route the porcelain helper through the shared selector. Behavior is unchanged when only one protection is active. Verified the HFS spelling is now rejected under the macOS defaults and still accepted when protectHFS is off; added regression tests and a NEWS entry.