### PR TITLE
detect delta cycles in resolve_object

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,13 @@
    land setuid. Modes are now run through ``cleanup_mode`` like checkout,
    matching git's archive writer.
 
+ * Detect delta cycles when resolving an object from a pack. The random-access
+   ``Pack.resolve_object`` walk only rejected a single self-referencing delta,
+   so a crafted pack with two or more REF_DELTA objects that name each other
+   sent ``get_raw`` into an unbounded loop that grew memory without bound. Such
+   chains now raise ``UnresolvedDeltas``, matching git's delta-cycle rejection
+   and the streaming resolver.
+
 1.2.10	2026-07-07
 
  * Fix regression in 1.2.9 where loose objects whose content inflates to

--- a/NEWS
+++ b/NEWS
@@ -15,12 +15,9 @@
    land setuid. Modes are now run through ``cleanup_mode`` like checkout,
    matching git's archive writer.
 
- * Detect delta cycles when resolving an object from a pack. The random-access
-   ``Pack.resolve_object`` walk only rejected a single self-referencing delta,
-   so a crafted pack with two or more REF_DELTA objects that name each other
-   sent ``get_raw`` into an unbounded loop that grew memory without bound. Such
-   chains now raise ``UnresolvedDeltas``, matching git's delta-cycle rejection
-   and the streaming resolver.
+ * Detect delta cycles in ``Pack.resolve_object``: a crafted pack with
+   REF_DELTA objects that name each other sent ``get_raw`` into an
+   unbounded loop. Such chains now raise ``DeltaCycle``.
 
 1.2.10	2026-07-07
 

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -4510,6 +4510,9 @@ class Pack:
         base_type = type
         base_obj = obj
         delta_stack = []
+        # Offsets of REF_DELTA bases already followed on this chain, used to
+        # detect delta cycles.
+        seen_ref_offsets: set[int] = {offset}
         while base_type in DELTA_TYPES:
             prev_offset = base_offset
             if get_ref is None:
@@ -4539,6 +4542,16 @@ class Pack:
                 base_offset = base_offset_temp
                 if base_offset == prev_offset:  # object is based on itself
                     raise UnresolvedDeltas([basename])
+                # A REF_DELTA base already followed on this chain means the
+                # deltas form a cycle (e.g. two objects that delta against each
+                # other). Every cycle crosses at least one REF_DELTA edge, so
+                # tracking resolved REF base offsets is enough to break it.
+                # Without this the loop spins forever while delta_stack grows
+                # without bound; git rejects such packs.
+                if base_offset is not None:
+                    if base_offset in seen_ref_offsets:
+                        raise UnresolvedDeltas([basename])
+                    seen_ref_offsets.add(base_offset)
             else:
                 raise AssertionError(f"Unexpected delta type: {base_type}")
             delta_stack.append((prev_offset, base_type, delta))

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -261,6 +261,10 @@ class UnresolvedDeltas(Exception):
         self.shas = shas
 
 
+class DeltaCycle(UnresolvedDeltas):
+    """A pack's delta chain references itself and cannot be resolved."""
+
+
 class ObjectContainer(Protocol):
     """Protocol for objects that can contain git objects."""
 
@@ -4510,8 +4514,6 @@ class Pack:
         base_type = type
         base_obj = obj
         delta_stack = []
-        # Offsets of REF_DELTA bases already followed on this chain, used to
-        # detect delta cycles.
         seen_ref_offsets: set[int] = {offset}
         while base_type in DELTA_TYPES:
             prev_offset = base_offset
@@ -4542,15 +4544,11 @@ class Pack:
                 base_offset = base_offset_temp
                 if base_offset == prev_offset:  # object is based on itself
                     raise UnresolvedDeltas([basename])
-                # A REF_DELTA base already followed on this chain means the
-                # deltas form a cycle (e.g. two objects that delta against each
-                # other). Every cycle crosses at least one REF_DELTA edge, so
-                # tracking resolved REF base offsets is enough to break it.
-                # Without this the loop spins forever while delta_stack grows
-                # without bound; git rejects such packs.
+                # A repeated REF_DELTA base offset means the chain cycles;
+                # without this check the loop would never terminate.
                 if base_offset is not None:
                     if base_offset in seen_ref_offsets:
-                        raise UnresolvedDeltas([basename])
+                        raise DeltaCycle([basename])
                     seen_ref_offsets.add(base_offset)
             else:
                 raise AssertionError(f"Unexpected delta type: {base_type}")

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -1008,6 +1008,43 @@ class TestThinPack(PackTests):
             )
 
 
+class ResolveObjectDeltaCycleTests(TestCase):
+    def test_get_raw_rejects_ref_delta_cycle(self) -> None:
+        # Two REF_DELTA objects that name each other form a delta cycle. Without
+        # cycle detection resolve_object walks the chain forever while
+        # delta_stack grows without bound. git rejects such packs; dulwich
+        # should raise UnresolvedDeltas instead of hanging.
+        sha_a = b"\xaa" * 20
+        sha_b = b"\xbb" * 20
+        delta = list(create_delta(b"x", b"x"))
+
+        buf = BytesIO()
+        write_pack_header(buf.write, 2)
+        offset_a = buf.tell()
+        write_pack_object(
+            buf.write, REF_DELTA, (sha_b, delta), object_format=DEFAULT_OBJECT_FORMAT
+        )
+        offset_b = buf.tell()
+        write_pack_object(
+            buf.write, REF_DELTA, (sha_a, delta), object_format=DEFAULT_OBJECT_FORMAT
+        )
+        body = buf.getvalue()
+        raw = body + sha1(body).digest()
+
+        data = PackData(
+            "test.pack", file=BytesIO(raw), object_format=DEFAULT_OBJECT_FORMAT
+        )
+        self.addCleanup(data.close)
+        index = MemoryPackIndex(
+            [(sha_a, offset_a, 0), (sha_b, offset_b, 0)],
+            DEFAULT_OBJECT_FORMAT,
+            pack_checksum=raw[-20:],
+        )
+        pack = Pack.from_objects(data, index)
+        self.addCleanup(pack.close)
+        self.assertRaises(UnresolvedDeltas, pack.get_raw, sha_a)
+
+
 class WritePackTests(TestCase):
     def test_write_pack_header(self) -> None:
         f = BytesIO()

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -43,6 +43,7 @@ from dulwich.pack import (
     OFS_DELTA,
     REF_DELTA,
     DeltaChainIterator,
+    DeltaCycle,
     MemoryPackIndex,
     Pack,
     PackData,
@@ -1010,10 +1011,8 @@ class TestThinPack(PackTests):
 
 class ResolveObjectDeltaCycleTests(TestCase):
     def test_get_raw_rejects_ref_delta_cycle(self) -> None:
-        # Two REF_DELTA objects that name each other form a delta cycle. Without
-        # cycle detection resolve_object walks the chain forever while
-        # delta_stack grows without bound. git rejects such packs; dulwich
-        # should raise UnresolvedDeltas instead of hanging.
+        # Two REF_DELTA objects that name each other form a delta cycle;
+        # resolve_object should raise DeltaCycle instead of looping forever.
         sha_a = b"\xaa" * 20
         sha_b = b"\xbb" * 20
         delta = list(create_delta(b"x", b"x"))
@@ -1042,7 +1041,7 @@ class ResolveObjectDeltaCycleTests(TestCase):
         )
         pack = Pack.from_objects(data, index)
         self.addCleanup(pack.close)
-        self.assertRaises(UnresolvedDeltas, pack.get_raw, sha_a)
+        self.assertRaises(DeltaCycle, pack.get_raw, sha_a)
 
 
 class WritePackTests(TestCase):


### PR DESCRIPTION
1. `Pack.resolve_object` walks a pack object's delta chain, but the only cycle guard rejects a single self-referencing REF_DELTA (`base_offset == prev_offset`), so a pack holding two or more REF_DELTA objects that name each other is not caught.
2. `get_raw` drives that walk, so reading such an object never returns: each iteration re-inflates a delta and appends to `delta_stack`, so memory grows without bound. A pack file is untrusted input (a cloned or downloaded repository, a submodule, a pack read from disk). `git index-pack` and dulwich's own streaming `DeltaChainIterator` both reject delta cycles; only this random-access path did not.
3. Track the REF_DELTA base offsets already followed on the chain and raise `UnresolvedDeltas` when one repeats. Every cycle crosses at least one REF_DELTA edge (OFS_DELTA offsets strictly decrease), so this is enough to break any cycle, and valid chains visit distinct offsets so their result is unchanged.

Verified with a two-object REF_DELTA cycle: before the change `get_raw` hangs; after it raises `UnresolvedDeltas`. Added a regression test covering that pack.