### PR TITLE
sanitize message newlines in format_reflog_line

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -15,6 +15,15 @@
    land setuid. Modes are now run through ``cleanup_mode`` like checkout,
    matching git's archive writer.
 
+ * SECURITY: Collapse embedded whitespace in reflog messages when writing a
+   reflog line. ``format_reflog_line`` wrote the message verbatim, and
+   ``do_commit`` logs ``commit: <full message>``, so any commit whose message
+   spans multiple lines produced a multi-line reflog that ``read_reflog``
+   could not parse; a crafted message (e.g. from a rebased or cherry-picked
+   untrusted commit) could inject additional, forged reflog entries with
+   attacker-chosen SHAs. Newlines are now collapsed to spaces, matching git's
+   ``copy_reflog_msg``.
+
 1.2.10	2026-07-07
 
  * Fix regression in 1.2.9 where loose objects whose content inflates to

--- a/NEWS
+++ b/NEWS
@@ -7,22 +7,23 @@
    ``.git`` using ignorable code points (e.g. ``.gi<U+200C>t``) passed
    validation and could poison ``.git`` on checkout. Both protections now apply
    when both are enabled, matching git's ``verify_path``.
+   (netliomax25-code)
 
- * SECURITY: Canonicalize the file mode of regular files written into a
+ * HARDEN: Canonicalize the file mode of regular files written into a
    ``git archive`` tarball. ``tar_stream`` copied the tree-supplied mode
    verbatim, so a crafted tree entry (e.g. mode ``0o104755``) carried
    setuid/setgid/sticky bits into the archive and an extracted file could
    land setuid. Modes are now run through ``cleanup_mode`` like checkout,
-   matching git's archive writer.
+   matching git's archive writer. (netliomax25-code)
 
- * SECURITY: Collapse embedded whitespace in reflog messages when writing a
+ * HARDEN: Collapse embedded whitespace in reflog messages when writing a
    reflog line. ``format_reflog_line`` wrote the message verbatim, and
    ``do_commit`` logs ``commit: <full message>``, so any commit whose message
    spans multiple lines produced a multi-line reflog that ``read_reflog``
    could not parse; a crafted message (e.g. from a rebased or cherry-picked
    untrusted commit) could inject additional, forged reflog entries with
    attacker-chosen SHAs. Newlines are now collapsed to spaces, matching git's
-   ``copy_reflog_msg``.
+   ``copy_reflog_msg``. (netliomax25-code, #2300)
 
 1.2.10	2026-07-07
 

--- a/dulwich/reflog.py
+++ b/dulwich/reflog.py
@@ -105,6 +105,11 @@ def format_reflog_line(
     """
     if old_sha is None:
         old_sha = ZERO_SHA
+    # A reflog entry is a single line and the message is the last, tab-separated
+    # field. Collapse embedded whitespace (in particular newlines) to single
+    # spaces so a multi-line or crafted message cannot split into extra physical
+    # lines and forge additional reflog entries. Matches Git's copy_reflog_msg.
+    message = b" ".join(message.split())
     return (
         old_sha
         + b" "
@@ -169,7 +174,7 @@ def drop_reflog_entry(f: BinaryIO, index: int, rewrite: bool = False) -> None:
     log = []
     offset = f.tell()
     for line in f:
-        log.append((offset, parse_reflog_line(line)))
+        log.append((offset, parse_reflog_line(line.rstrip(b"\n"))))
         offset = f.tell()
 
     inverse_index = len(log) - index - 1
@@ -209,6 +214,7 @@ def drop_reflog_entry(f: BinaryIO, index: int, rewrite: bool = False) -> None:
                 entry.timezone,
                 entry.message,
             )
+            + b"\n"
         )
     f.truncate()
 
@@ -240,7 +246,7 @@ def expire_reflog(
     entries = []
     offset = f.tell()
     for line in f:
-        entries.append((offset, parse_reflog_line(line)))
+        entries.append((offset, parse_reflog_line(line.rstrip(b"\n"))))
         offset = f.tell()
 
     # Filter entries that should be kept
@@ -285,6 +291,7 @@ def expire_reflog(
                     entry.timezone,
                     entry.message,
                 )
+                + b"\n"
             )
         f.truncate()
 

--- a/tests/test_reflog.py
+++ b/tests/test_reflog.py
@@ -136,6 +136,29 @@ class ReflogLineTests(TestCase):
             parse_reflog_line(reflog_line),
         )
 
+    def test_format_message_newline(self) -> None:
+        # A message with an embedded newline (e.g. a commit body, or a crafted
+        # message from a rebased/cherry-picked untrusted commit) must not split
+        # into extra physical lines and forge additional reflog entries.
+        line = format_reflog_line(
+            None,
+            b"49030649db3dfec5a9bc03e5dde4255a14499f16",
+            b"Jelmer Vernooij <jelmer@jelmer.uk>",
+            1446552482,
+            0,
+            b"commit: subject\n\n"
+            b"0000000000000000000000000000000000000000 "
+            b"1111111111111111111111111111111111111111 "
+            b"Attacker <evil@example.com> 1700000000 +0000\tforged",
+        )
+        self.assertNotIn(b"\n", line)
+        entries = list(read_reflog(BytesIO(line + b"\n")))
+        self.assertEqual(1, len(entries))
+        self.assertEqual(b"Jelmer Vernooij <jelmer@jelmer.uk>", entries[0].committer)
+        self.assertEqual(
+            b"49030649db3dfec5a9bc03e5dde4255a14499f16", entries[0].new_sha
+        )
+
 
 _TEST_REFLOG = (
     b"0000000000000000000000000000000000000000 "


### PR DESCRIPTION
1. `format_reflog_line` writes the message verbatim as the final tab-separated field, and `do_commit` records `commit: <full commit message>`, so a commit whose message spans multiple lines produces a multi-line reflog that `read_reflog` then fails to parse.
2. Because the trailing text is read back as its own physical line, a crafted message (for example from a rebased or cherry-picked untrusted commit) can embed a full reflog line after a newline and forge extra entries with attacker-chosen old/new SHAs and committer; the committer field already goes through `check_user_identity`, the message did not.
3. Collapse embedded whitespace in the message to single spaces in `format_reflog_line`, matching git's `copy_reflog_msg`. `drop_reflog_entry` and `expire_reflog` relied on the trailing newline being part of the parsed message, so they now strip the terminator on read and re-append it on write.

Added a regression test that a message containing a newline serializes to a single line and reads back as one entry.
