### PR TITLE
fix cubic trailer block search in parse_trailers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@
    different sides of a shared directory merge cleanly instead of being
    reported as a directory-level conflict. (Jelmer Vernooĳ, #2295)
 
+ * HARDEN: Parse commit-message trailers in linear time. ``parse_trailers``
+   located the trailer block by re-slicing and re-stripping the tail of the
+   message for every blank line, which is cubic on a message made mostly of
+   blank lines. Trailers are scanned during subtree operations, which walk
+   every reachable commit, so a crafted commit message could tie up CPU for
+   minutes to hours (a 3 KB all-blank message took roughly 36s before the fix
+   and is now immediate). (netliomax25-code)
+
  * SECURITY: Apply ``core.protectHFS`` and ``core.protectNTFS`` together when
    selecting the checkout path-element validator. ``get_path_element_validator``
    returned only the NTFS validator whenever ``protectNTFS`` was on (the default

--- a/dulwich/trailers.py
+++ b/dulwich/trailers.py
@@ -141,34 +141,32 @@ def parse_trailers(
     # Determine the search range
     search_end = cutoff_line if cutoff_line is not None else len(lines)
 
-    # Search backwards for the trailer block
-    # A trailer block must be preceded by a blank line and extend to the end
-    for i in range(search_end - 1, -1, -1):
-        line = lines[i].rstrip()
+    # Find the trailer block by scanning backward from the last non-blank line.
+    # A trailer block is a run of trailer/continuation/blank lines that contains
+    # at least one trailer and is preceded by a blank line. Because the block
+    # only grows as the scan moves up, a non-blank line that is neither a
+    # continuation nor a trailer invalidates every larger block, so the scan can
+    # stop at it. Doing this in one pass keeps parsing linear in the message
+    # size; the previous version re-sliced and re-checked the tail for every
+    # blank line, which is cubic on a message made mostly of blank lines.
+    content_end = search_end
+    while content_end > 0 and not lines[content_end - 1].strip():
+        content_end -= 1
 
-        # Check if this is a blank line
-        if not line:
-            # Check if the lines after this blank line are trailers
-            potential_trailers = lines[i + 1 : search_end]
-
-            # Remove trailing blank lines from potential trailers
-            while potential_trailers and not potential_trailers[-1].strip():
-                potential_trailers = potential_trailers[:-1]
-
-            # Check if these lines form a trailer block and extend to search_end
-            if potential_trailers and _is_trailer_block(potential_trailers, separators):
-                # Verify these trailers extend to the end (search_end)
-                # by checking there are no non-blank lines after them
-                last_trailer_index = i + 1 + len(potential_trailers)
-                has_content_after = False
-                for j in range(last_trailer_index, search_end):
-                    if lines[j].strip():
-                        has_content_after = True
-                        break
-
-                if not has_content_after:
-                    trailer_start = i + 1
-                    break
+    has_trailer = False
+    for k in range(content_end - 1, 0, -1):
+        line = lines[k].rstrip()
+        if line and not line[0].isspace():
+            # A non-blank, non-continuation line must be a trailer, otherwise no
+            # block reaching this line (or starting above it) can be valid.
+            if not _is_trailer_line(line, separators):
+                break
+            has_trailer = True
+        # Blank and continuation lines are allowed inside the block. Stop at the
+        # first preceding blank line once a trailer has been seen.
+        if has_trailer and not lines[k - 1].strip():
+            trailer_start = k
+            break
 
     if trailer_start is None:
         # No trailer block found
@@ -193,66 +191,26 @@ def parse_trailers(
     return (message_without_trailers.encode("utf-8"), trailers)
 
 
-def _is_trailer_block(lines: list[str], separators: str) -> bool:
-    """Check if a group of lines forms a valid trailer block.
+def _is_trailer_line(line: str, separators: str) -> bool:
+    """Check if a single line is a trailer line.
 
-    A trailer block must be composed entirely of trailer lines (with possible
-    blank lines and continuation lines). A single non-trailer line invalidates
-    the entire block.
+    A trailer line contains one of the separator characters and the token
+    before the first separator is non-empty and free of whitespace.
 
     Args:
-        lines: The lines to check
+        line: The line to check (trailing whitespace already removed)
         separators: Valid separator characters
 
     Returns:
-        True if the lines form a valid trailer block
+        True if the line is a trailer line
     """
-    if not lines:
-        return False
-
-    # Remove empty lines at the end
-    while lines and not lines[-1].strip():
-        lines = lines[:-1]
-
-    if not lines:
-        return False
-
-    has_any_trailer = False
-
-    i = 0
-    while i < len(lines):
-        line = lines[i].rstrip()
-
-        if not line:
-            # Empty lines are allowed within the trailer block
-            i += 1
-            continue
-
-        # Check if this line is a continuation (starts with whitespace)
-        if line and line[0].isspace():
-            # This is a continuation of the previous line
-            i += 1
-            continue
-
-        # Check if this is a trailer line
-        is_trailer = False
-        for sep in separators:
-            if sep in line:
-                key_part = line.split(sep, 1)[0]
-                # Key must not contain whitespace
-                if key_part and not any(c.isspace() for c in key_part):
-                    is_trailer = True
-                    has_any_trailer = True
-                    break
-
-        # If this is not a trailer line, the block is invalid
-        if not is_trailer:
-            return False
-
-        i += 1
-
-    # Must have at least one trailer
-    return has_any_trailer
+    for sep in separators:
+        if sep in line:
+            key_part = line.split(sep, 1)[0]
+            # Key must not contain whitespace
+            if key_part and not any(c.isspace() for c in key_part):
+                return True
+    return False
 
 
 def _parse_trailer_lines(lines: list[str], separators: str) -> list[Trailer]:

--- a/tests/test_trailers.py
+++ b/tests/test_trailers.py
@@ -123,6 +123,35 @@ class TestParseTrailers(unittest.TestCase):
         self.assertEqual(body, b"")
         self.assertEqual(trailers, [])
 
+    def test_many_blank_lines(self) -> None:
+        """A message of only blank lines has no trailers and parses in linear time.
+
+        A commit message comes from an untrusted remote and is scanned for
+        trailers during subtree operations (a walk over every reachable commit).
+        The previous backward search re-sliced and re-stripped the tail for each
+        blank line, which is cubic; this many-blank-line input would take minutes
+        to hours before the fix and completes immediately after it.
+        """
+        message = b"\n" * 200000
+        body, trailers = parse_trailers(message)
+        self.assertEqual(body, message)
+        self.assertEqual(trailers, [])
+
+    def test_many_blank_lines_then_non_trailer(self) -> None:
+        """Blank lines followed by a non-trailer line still parse in linear time."""
+        message = b"\n" * 200000 + b"not a trailer line\n"
+        body, trailers = parse_trailers(message)
+        self.assertEqual(body, message)
+        self.assertEqual(trailers, [])
+
+    def test_trailer_after_many_blank_lines(self) -> None:
+        """A real trailer is still found after a long run of blank lines."""
+        message = b"Subject\n" + b"\n" * 100000 + b"Signed-off-by: Alice\n"
+        _body, trailers = parse_trailers(message)
+        self.assertEqual(len(trailers), 1)
+        self.assertEqual(trailers[0].key, "Signed-off-by")
+        self.assertEqual(trailers[0].value, "Alice")
+
 
 class TestFormatTrailers(unittest.TestCase):
     """Tests for format_trailers function."""


### PR DESCRIPTION
1. parse_trailers looked for the trailer block by trying every blank line and, for each one, re-slicing the tail of the message and stripping its trailing blank lines one element at a time, then re-scanning the slice. On a message that is mostly blank lines this is O(n^3) (a variant ending in a non-trailer line is O(n^2)).
2. commit messages come from cloned/fetched history and are scanned for trailers while walking every reachable commit during subtree operations (find_subtree_splits -> parse_subtree_metadata), and also via interpret_trailers and the public parse_trailers, so a crafted all-blank message can tie up CPU for a long time (a 3 KB all-blank message took about 36s; an 80 KB message now takes about 0.03s).
3. replaced the backward search with one upward pass from the last non-blank line, stopping at the first line that is not blank/continuation/trailer, or at the first preceding blank line once a trailer has been seen.

Output is unchanged: I compared against the previous implementation over 362k messages (exhaustive up to 4 lines, plus random ones) with no differences, and the existing tests still pass. Added regression tests for the blank-line inputs.