### PR TITLE
verify a bitmap's pack checksum in Pack.bitmap

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -35,6 +35,15 @@
    different sides of a shared directory merge cleanly instead of being
    reported as a directory-level conflict. (Jelmer Vernooĳ, #2295)
 
+ * HARDEN: Verify that a ``.bitmap`` index matches the pack it is loaded for.
+   The bitmap header records the checksum of its pack, but ``Pack.bitmap``
+   never checked it, so a stale or swapped-in bitmap (built for a different
+   object set) was used against this pack's index and silently produced a
+   wrong reachable-object set during fetch negotiation. ``Pack.bitmap`` now
+   compares the recorded checksum and ignores a mismatched bitmap, falling
+   back to graph traversal, matching git's ``load_bitmap_header``.
+   (netliomax25-code)
+
  * HARDEN: Parse commit-message trailers in linear time. ``parse_trailers``
    located the trailer block by re-slicing and re-stripping the tail of the
    message for every blank line, which is cubic on a message made mostly of

--- a/dulwich/bitmap.py
+++ b/dulwich/bitmap.py
@@ -62,6 +62,7 @@ from collections.abc import Callable, Iterable, Iterator
 from io import BytesIO
 from typing import IO, TYPE_CHECKING
 
+from .errors import ChecksumMismatch
 from .file import GitFile
 from .objects import (
     Blob,
@@ -522,36 +523,48 @@ class PackBitmap:
 def read_bitmap(
     filename: str | os.PathLike[str],
     pack_index: "PackIndex | None" = None,
+    pack_checksum: bytes | None = None,
 ) -> PackBitmap:
     """Read a bitmap index file.
 
     Args:
         filename: Path to the .bitmap file
         pack_index: Optional PackIndex to resolve object positions to SHAs
+        pack_checksum: Optional checksum of the pack this bitmap belongs to.
+            When given, the checksum stored in the bitmap header must match it.
 
     Returns:
         Loaded PackBitmap
 
     Raises:
         ValueError: If file format is invalid
-        ChecksumMismatch: If checksum verification fails
+        ChecksumMismatch: If pack_checksum is given and does not match the
+            checksum recorded in the bitmap header
     """
     with GitFile(filename, "rb") as f:
-        return read_bitmap_file(f, pack_index=pack_index)
+        return read_bitmap_file(f, pack_index=pack_index, pack_checksum=pack_checksum)
 
 
-def read_bitmap_file(f: IO[bytes], pack_index: "PackIndex | None" = None) -> PackBitmap:
+def read_bitmap_file(
+    f: IO[bytes],
+    pack_index: "PackIndex | None" = None,
+    pack_checksum: bytes | None = None,
+) -> PackBitmap:
     """Read bitmap data from a file object.
 
     Args:
         f: File object to read from
         pack_index: Optional PackIndex to resolve object positions to SHAs
+        pack_checksum: Optional checksum of the pack this bitmap belongs to.
+            When given, the checksum stored in the bitmap header must match it.
 
     Returns:
         Loaded PackBitmap
 
     Raises:
         ValueError: If file format is invalid
+        ChecksumMismatch: If pack_checksum is given and does not match the
+            checksum recorded in the bitmap header
     """
     # Read header
     signature = f.read(4)
@@ -579,12 +592,14 @@ def read_bitmap_file(f: IO[bytes], pack_index: "PackIndex | None" = None) -> Pac
     entry_count = struct.unpack(">I", entry_count_bytes)[0]
 
     # Read pack checksum
-    pack_checksum = f.read(20)
-    if len(pack_checksum) < 20:
+    stored_pack_checksum = f.read(20)
+    if len(stored_pack_checksum) < 20:
         raise ValueError("Missing pack checksum")
+    if pack_checksum is not None and stored_pack_checksum != pack_checksum:
+        raise ChecksumMismatch(pack_checksum, stored_pack_checksum)
 
     bitmap = PackBitmap(version=version, flags=flags)
-    bitmap.pack_checksum = pack_checksum
+    bitmap.pack_checksum = stored_pack_checksum
 
     # Read type bitmaps (EWAH bitmaps are self-describing)
     for i, type_bitmap in enumerate(

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -108,6 +108,7 @@ try:
 except ModuleNotFoundError:
     from difflib import SequenceMatcher
 
+import logging
 import os
 import struct
 import sys
@@ -156,6 +157,8 @@ if TYPE_CHECKING:
     from .commit_graph import CommitGraph
     from .object_store import BaseObjectStore
     from .refs import Ref
+
+logger = logging.getLogger(__name__)
 
 # Some platforms (e.g. plan9) don't support mmap properly
 has_mmap = sys.platform != "Plan9"
@@ -4198,7 +4201,8 @@ class Pack:
         """The bitmap being used, if available.
 
         Returns:
-            PackBitmap instance or None if no bitmap exists
+            PackBitmap instance, or None if no bitmap exists or the bitmap
+            was built for a different pack
 
         Raises:
             ValueError: If bitmap file is invalid or corrupt
@@ -4206,7 +4210,23 @@ class Pack:
         if self._bitmap is None:
             from .bitmap import read_bitmap
 
-            self._bitmap = read_bitmap(self._bitmap_path, pack_index=self.index)
+            try:
+                self._bitmap = read_bitmap(
+                    self._bitmap_path,
+                    pack_index=self.index,
+                    pack_checksum=self.get_stored_checksum(),
+                )
+            except ChecksumMismatch:
+                # The bitmap records the checksum of the pack it was built for.
+                # A mismatch means it is stale or was swapped in from another
+                # pack, so its positions no longer describe this pack's objects.
+                # Ignore it and let callers fall back to graph traversal, the
+                # same as git.
+                logger.warning(
+                    "Ignoring bitmap %s: checksum does not match pack",
+                    self._bitmap_path,
+                )
+                return None
         return self._bitmap
 
     def ensure_bitmap(

--- a/tests/test_bitmap.py
+++ b/tests/test_bitmap.py
@@ -45,6 +45,7 @@ from dulwich.bitmap import (
     write_bitmap_file,
 )
 from dulwich.config import ConfigFile
+from dulwich.errors import ChecksumMismatch
 from dulwich.object_store import (
     BitmapReachability,
     DiskObjectStore,
@@ -488,6 +489,28 @@ class BitmapFileTests(unittest.TestCase):
         self.assertIn(1, bitmap2.tree_bitmap)
         self.assertIn(2, bitmap2.blob_bitmap)
         self.assertIn(3, bitmap2.tag_bitmap)
+
+    def test_pack_checksum_match(self):
+        """A matching pack_checksum loads the bitmap normally."""
+        bitmap = PackBitmap()
+        bitmap.pack_checksum = b"\xaa" * 20
+        f = BytesIO()
+        write_bitmap_file(f, bitmap)
+
+        f.seek(0)
+        bitmap2 = read_bitmap_file(f, pack_checksum=b"\xaa" * 20)
+        self.assertEqual(b"\xaa" * 20, bitmap2.pack_checksum)
+
+    def test_pack_checksum_mismatch_rejected(self):
+        """A bitmap whose header checksum names another pack is rejected."""
+        bitmap = PackBitmap()
+        bitmap.pack_checksum = b"\xaa" * 20
+        f = BytesIO()
+        write_bitmap_file(f, bitmap)
+
+        f.seek(0)
+        with self.assertRaises(ChecksumMismatch):
+            read_bitmap_file(f, pack_checksum=b"\xbb" * 20)
 
     def test_invalid_signature(self):
         """Test reading file with invalid signature."""
@@ -1255,6 +1278,38 @@ class PackEnsureBitmapTests(unittest.TestCase):
         refs = {b"refs/heads/master": self.commit.id}
         bitmap = self.pack.ensure_bitmap(self.store, refs, commit_interval=50)
         self.assertIsNotNone(bitmap)
+
+    def test_bitmap_with_wrong_pack_checksum_is_ignored(self):
+        """Pack.bitmap ignores a .bitmap built for a different pack."""
+        refs = {b"refs/heads/master": self.commit.id}
+        self.pack.ensure_bitmap(self.store, refs, commit_interval=1)
+
+        # Rewrite the on-disk bitmap so its recorded pack checksum names a
+        # different pack, as a stale or swapped-in bitmap would.
+        bitmap_path = self.pack._bitmap_path
+        loaded = read_bitmap(bitmap_path)
+        loaded.pack_checksum = b"\x00" * 20
+        write_bitmap(bitmap_path, loaded)
+        self.store.close()
+
+        reopened = DiskObjectStore(self.temp_dir)
+        self.addCleanup(reopened.close)
+        pack = reopened.packs[0]
+        self.assertNotEqual(b"\x00" * 20, pack.get_stored_checksum())
+        self.assertIsNone(pack.bitmap)
+
+    def test_bitmap_with_matching_pack_checksum_loads(self):
+        """Pack.bitmap loads a bitmap whose checksum matches the pack."""
+        refs = {b"refs/heads/master": self.commit.id}
+        self.pack.ensure_bitmap(self.store, refs, commit_interval=1)
+        self.store.close()
+
+        reopened = DiskObjectStore(self.temp_dir)
+        self.addCleanup(reopened.close)
+        pack = reopened.packs[0]
+        bitmap = pack.bitmap
+        self.assertIsNotNone(bitmap)
+        self.assertEqual(pack.get_stored_checksum(), bitmap.pack_checksum)
 
 
 class GeneratePackBitmapsTests(unittest.TestCase):


### PR DESCRIPTION
1. The bitmap header records the checksum of the pack it was built for, but `Pack.bitmap` read the `.bitmap` and used it against this pack's index without ever comparing that checksum. `read_bitmap`/`read_bitmap_file` stored the recorded value on `pack_checksum` and the docstring listed a `ChecksumMismatch` that was never raised.
2. A `.bitmap` is repository metadata that can be stale (left after a repack) or come from an untrusted repo. A bitmap built for a different object set was accepted, so its positions were resolved against the wrong index and `BitmapReachability` returned an incorrect reachable-object set during fetch negotiation rather than failing.
3. `read_bitmap`/`read_bitmap_file` now take an optional `pack_checksum` and raise `ChecksumMismatch` when the recorded value differs. `Pack.bitmap` passes `self.get_stored_checksum()` and, on mismatch, logs a warning and returns `None`, so callers fall back to graph traversal. This mirrors git's `load_bitmap_header`, which ignores a bitmap whose checksum does not match its pack.

Validation: with a pack whose real bitmap I rewrote to record a different pack checksum, `Pack.bitmap` returned that bitmap before the change and returns `None` after. Added regression tests in `tests/test_bitmap.py`; the bitmap, pack, and object-store suites plus `mypy` and `ruff` pass.
