### PR TITLE
validate object ids in receive-pack ref commands

### DIFF
--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -1744,7 +1744,16 @@ class ReceivePackHandler(PackHandler):
 
         # client will now send us a list of (oldsha, newsha, ref)
         while ref_line:
-            (oldsha, newsha, ref_name) = ref_line.split()
+            fields = ref_line.rstrip(b"\n").split(b" ")
+            if (
+                len(fields) != 3
+                or not valid_hexsha(fields[0])
+                or not valid_hexsha(fields[1])
+            ):
+                raise GitProtocolError(
+                    f"Invalid ref update line from client: {ref_line!r}"
+                )
+            oldsha, newsha, ref_name = fields
             client_refs.append((ObjectID(oldsha), ObjectID(newsha), Ref(ref_name)))
             ref_line = self.proto.read_pkt_line()
 

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -1744,16 +1744,16 @@ class ReceivePackHandler(PackHandler):
 
         # client will now send us a list of (oldsha, newsha, ref)
         while ref_line:
-            fields = ref_line.rstrip(b"\n").split(b" ")
-            if (
-                len(fields) != 3
-                or not valid_hexsha(fields[0])
-                or not valid_hexsha(fields[1])
-            ):
+            try:
+                (oldsha, newsha, ref_name) = ref_line.rstrip(b"\n").split(b" ")
+            except ValueError:
                 raise GitProtocolError(
                     f"Invalid ref update line from client: {ref_line!r}"
                 )
-            oldsha, newsha, ref_name = fields
+            if not valid_hexsha(oldsha) or not valid_hexsha(newsha):
+                raise GitProtocolError(
+                    f"Invalid ref update line from client: {ref_line!r}"
+                )
             client_refs.append((ObjectID(oldsha), ObjectID(newsha), Ref(ref_name)))
             ref_line = self.proto.read_pkt_line()
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -388,6 +388,35 @@ class ReceivePackHandlerTestCase(TestCase):
         self.assertEqual(status[1][0], b"refs/heads/fake-branch")
         self.assertEqual(status[1][1], b"ok")
 
+    def test_handle_invalid_ref_line(self) -> None:
+        """A ref-update line without three fields is rejected, not crashed on."""
+        self._handler.proto.set_output(
+            [ONE + b" " + TWO + b" refs/heads/master extra", None]
+        )
+        self.assertRaises(GitProtocolError, self._handler.handle)
+
+    def test_handle_invalid_object_id(self) -> None:
+        """A ref-update line with a non-hex object id is rejected."""
+        self._handler.proto.set_output(
+            [b"nothexsha " + TWO + b" refs/heads/master", None]
+        )
+        self.assertRaises(GitProtocolError, self._handler.handle)
+
+    def test_handle_valid_ref_line(self) -> None:
+        """A well-formed ref-update line is still parsed and applied."""
+        self._repo.refs._update({b"refs/heads/todelete": ONE})
+        self._handler.proto.set_output(
+            [
+                ONE
+                + b" "
+                + ZERO_SHA
+                + b" refs/heads/todelete\x00delete-refs report-status",
+                None,
+            ]
+        )
+        self._handler.handle()
+        self.assertNotIn(b"refs/heads/todelete", self._repo.refs.allkeys())
+
     def test_pre_receive_hook_success(self) -> None:
         """Test that pre-receive hook is called and can succeed."""
 


### PR DESCRIPTION
1. ReceivePackHandler.handle splits each client ref-update line with ref_line.split() and wraps the fields in ObjectID()/Ref() without validating them, while the sibling upload-pack parser _split_proto_line checks valid_hexsha and git's receive-pack validates each id with parse_oid_hex.
2. A line that does not split into three fields raises an uncaught ValueError that aborts the handler, and a non-hex old/new value is accepted into client_refs and passed to the pre/post-receive and update hooks and to set_if_equals.
3. Check the field count and both object ids with valid_hexsha, raising GitProtocolError on malformed input, matching the sibling parser.

Added receive-pack handler tests in tests/test_server.py for the malformed-line, non-hex-id, and valid-delete cases.
