### PR TITLE
Fix Bundle.store_objects() silently dropping delta objects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 1.2.12	UNRELEASED
 
+ * Fix ``Bundle.store_objects()`` silently dropping every OFS_DELTA/REF_DELTA
+   object in the bundle's pack instead of resolving it, leaving the target
+   object store missing most objects with no error raised. Delta resolution
+   now goes through ``PackInflater``, matching how packs are ingested
+   elsewhere in the object store code.
+   (theVinchi, #2312)
+
  * SECURITY: Refuse to write a checkout entry whose leading path resolves
    through a symlink. ``build_index_from_tree`` (used by ``reset_index`` and
    thus by ``clone``/``checkout``) materialized a tree in sorted order without

--- a/dulwich/bundle.py
+++ b/dulwich/bundle.py
@@ -49,8 +49,8 @@ else:
 if TYPE_CHECKING:
     from .object_format import ObjectFormat
 
-from .objects import ObjectID, ShaFile
-from .pack import PackData, UnpackedObject, write_pack_data
+from .objects import ObjectID
+from .pack import PackData, PackInflater, UnpackedObject, write_pack_data
 from .refs import Ref
 
 
@@ -157,18 +157,23 @@ class Bundle:
         """
         if self.pack_data is None:
             raise ValueError("pack_data is not loaded")
+        if not isinstance(self.pack_data, PackData):
+            # PackInflater resolves deltas by seeking into the pack's
+            # backing file, which only a real PackData has.
+            raise TypeError(
+                f"store_objects() requires file-backed pack data, got "
+                f"{type(self.pack_data).__name__}"
+            )
         count = 0
-        for unpacked in self.pack_data.iter_unpacked():
-            # Convert the unpacked object to a proper git object
-            if unpacked.decomp_chunks and unpacked.obj_type_num is not None:
-                git_obj = ShaFile.from_raw_chunks(
-                    unpacked.obj_type_num, unpacked.decomp_chunks
-                )
-                object_store.add_object(git_obj)
-                count += 1
+        # PackInflater resolves OFS_DELTA/REF_DELTA entries against the rest
+        # of this pack; iterating pack_data directly skips them; see
+        # https://github.com/jelmer/dulwich/issues/2312.
+        for git_obj in PackInflater.for_pack_data(self.pack_data):
+            object_store.add_object(git_obj)
+            count += 1
 
-                if progress and count % 100 == 0:
-                    progress(f"Stored {count} objects")
+            if progress and count % 100 == 0:
+                progress(f"Stored {count} objects")
 
         if progress:
             progress(f"Stored {count} objects total")

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -27,6 +27,7 @@ from io import BytesIO
 
 from dulwich.bundle import Bundle, create_bundle_from_repo, read_bundle, write_bundle
 from dulwich.object_format import DEFAULT_OBJECT_FORMAT
+from dulwich.object_store import MemoryObjectStore
 from dulwich.objects import Blob, Commit, Tree
 from dulwich.pack import PackData, write_pack_objects
 from dulwich.refs import Ref
@@ -540,3 +541,84 @@ class BundleTests(TestCase):
         # Verify the prerequisite was added correctly
         self.assertEqual(len(bundle.prerequisites), 1)
         self.assertEqual(bundle.prerequisites[0][0], prereq_hex)
+
+    def test_store_objects_resolves_deltas(self) -> None:
+        """store_objects() must resolve OFS_DELTA/REF_DELTA entries.
+
+        Regression test for https://github.com/jelmer/dulwich/issues/2312:
+        store_objects() used to skip any pack entry whose obj_type_num was
+        still None (i.e. not yet delta-resolved), silently dropping every
+        deltified object instead of raising or resolving it.
+        """
+        # Two revisions of a large, similar blob so write_pack_objects has
+        # a strong incentive to emit one of them as a delta.
+        data1 = (b"x" * 2000 + b"\n") * 50
+        data2 = data1 + b"tail line\n"
+
+        blob1 = Blob.from_string(data1)
+        blob2 = Blob.from_string(data2)
+
+        tree1 = Tree()
+        tree1.add(b"f.txt", 0o100644, blob1.id)
+        tree2 = Tree()
+        tree2.add(b"f.txt", 0o100644, blob2.id)
+
+        commit1 = Commit()
+        commit1.tree = tree1.id
+        commit1.message = b"one"
+        commit1.author = commit1.committer = b"Test User <test@example.com>"
+        commit1.commit_time = commit1.author_time = 1234567890
+        commit1.commit_timezone = commit1.author_timezone = 0
+
+        commit2 = Commit()
+        commit2.tree = tree2.id
+        commit2.parents = [commit1.id]
+        commit2.message = b"two"
+        commit2.author = commit2.committer = b"Test User <test@example.com>"
+        commit2.commit_time = commit2.author_time = 1234567891
+        commit2.commit_timezone = commit2.author_timezone = 0
+
+        objects = [
+            (blob1, None),
+            (tree1, None),
+            (commit1, None),
+            (blob2, None),
+            (tree2, None),
+            (commit2, None),
+        ]
+
+        b = BytesIO()
+        write_pack_objects(
+            b.write, objects, deltify=True, object_format=DEFAULT_OBJECT_FORMAT
+        )
+        b.seek(0)
+
+        # Sanity check the constructed pack actually contains a delta,
+        # otherwise this test wouldn't exercise the bug.
+        probe = PackData.from_file(
+            BytesIO(b.getvalue()), object_format=DEFAULT_OBJECT_FORMAT
+        )
+        try:
+            self.assertTrue(
+                any(u.obj_type_num is None for u in probe.iter_unpacked()),
+                "test pack does not contain a delta; test is not exercising the bug",
+            )
+        finally:
+            probe.close()
+
+        bundle = Bundle()
+        self.addCleanup(bundle.close)
+        bundle.version = 2
+        bundle.capabilities = {}
+        bundle.references = {b"refs/heads/master": commit2.id}
+        bundle.prerequisites = []
+        bundle.pack_data = PackData.from_file(b, object_format=DEFAULT_OBJECT_FORMAT)
+
+        store = MemoryObjectStore()
+        bundle.store_objects(store)
+
+        for obj in (blob1, tree1, commit1, blob2, tree2, commit2):
+            self.assertIn(
+                obj.id, store, f"{obj.__class__.__name__} {obj.id!r} missing from store"
+            )
+        self.assertEqual(6, len(list(store)))


### PR DESCRIPTION
Fixes #2312.

`Bundle.store_objects()` iterated `pack_data.iter_unpacked()` and skipped any entry whose `obj_type_num` was still `None` — i.e. every OFS_DELTA/REF_DELTA object — leaving the target object store missing most objects with no error raised. Since git deltifies by default, any realistic bundle hits this: on a full-history bundle of pallets/flask, 17,455 of 26,056 objects were dropped, including objects referenced by the tip commit's tree. Affected callers include `dulwich bundle unbundle` and the bundle-URI clone path.

### Change

- Resolve deltas through `PackInflater.for_pack_data()`, the same mechanism `MemoryObjectStore.add_pack()` already uses for pack ingestion.
- `PackInflater` resolves delta bases by seeking into the pack's backing file, so `store_objects()` now raises `TypeError` for non-file-backed `PackDataLike` implementations instead of producing an incomplete store. All in-tree callers obtain `pack_data` via `read_bundle()`, which always yields a file-backed `PackData`.
- Regression test constructs a delta-bearing pack in-process (`write_pack_objects(..., deltify=True)`, with a sanity check that a delta is actually present) and asserts all 6 objects reach the store; before the fix, only 3 arrived.
- NEWS entry added.

### Verification

- `tests/test_bundle.py`, `tests/test_pack.py`, `tests/test_object_store.py`, `tests/test_repository.py`: 427 passed, 4 skipped.
- End-to-end: `dulwich bundle unbundle` of a real `git bundle create` flask bundle now produces a repo whose tip tree fully resolves (236/236 blobs, matching `git ls-tree -r`).
- `ruff check` / `ruff format` clean; no new mypy errors in `dulwich/bundle.py`.
