### PR TITLE
bound inflated size of dumb HTTP loose objects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,15 @@
 1.2.13	UNRELEASED
 
+ * SECURITY: Stream loose objects fetched over dumb HTTP.
+   ``DumbHTTPObjectStore._fetch_loose_object`` inflated the server's response
+   with a single unbounded ``zlib.decompress``, so a malicious or
+   man-in-the-middle dumb server could expand a small response into gigabytes
+   of memory during clone/fetch. The response is now inflated incrementally
+   through a bounded buffer, spooling large objects to a temporary file, and
+   the result is only returned once it hashes to the requested object ID,
+   matching how C git's dumb-http walker fetches loose objects.
+   (netliomax25-code, #2315)
+
  * Extend the ``verify_leading_dirs`` symlink guard to
    ``update_working_tree`` (used by ``pull``, ``merge`` and ``checkout``).
    The 1.2.12 fix only covered ``build_index_from_tree``, so a tree pairing a

--- a/dulwich/dumb.py
+++ b/dulwich/dumb.py
@@ -45,7 +45,6 @@ from .errors import NotGitRepository, ObjectFormatException
 from .object_store import BaseObjectStore
 from .objects import (
     ZERO_SHA,
-    Blob,
     Commit,
     ObjectID,
     RawObjectID,
@@ -53,6 +52,7 @@ from .objects import (
     Tag,
     Tree,
     hex_to_sha,
+    object_class,
     sha_to_hex,
 )
 from .pack import Pack, PackData, PackIndex, UnpackedObject, load_pack_index_file
@@ -60,6 +60,38 @@ from .protocol import split_peeled_refs
 from .refs import Ref, read_info_refs
 
 logger = logging.getLogger(__name__)
+
+# Inflated loose objects larger than this spill to disk while streaming.
+_LOOSE_OBJECT_SPOOL_SIZE = 1024 * 1024
+
+
+def _inflate_chunks(
+    read: Callable[..., bytes], read_size: int = 4096, max_length: int = 65536
+) -> Iterator[bytes]:
+    """Incrementally inflate a zlib stream read in chunks.
+
+    Yields decompressed chunks of at most max_length bytes, so memory use
+    stays bounded regardless of the stream's compression ratio.
+
+    Raises:
+      zlib.error: If the stream is corrupt or truncated.
+    """
+    decompressor = zlib.decompressobj()
+    while not decompressor.eof:
+        chunk = read(read_size)
+        if not chunk:
+            break
+        buf = decompressor.decompress(chunk, max_length)
+        while buf:
+            yield buf
+            if not decompressor.unconsumed_tail:
+                break
+            buf = decompressor.decompress(decompressor.unconsumed_tail, max_length)
+    tail = decompressor.flush()
+    if tail:
+        yield tail
+    if not decompressor.eof:
+        raise zlib.error("incomplete or truncated zlib stream")
 
 
 class DumbHTTPObjectStore(BaseObjectStore):
@@ -125,6 +157,12 @@ class DumbHTTPObjectStore(BaseObjectStore):
     def _fetch_loose_object(self, sha: bytes) -> tuple[int, bytes]:
         """Fetch a loose object by SHA.
 
+        The response is inflated incrementally through a bounded buffer and
+        spooled to a temporary file, hashing as it goes, so a malicious dumb
+        server cannot expand a small response into an unbounded amount of
+        memory. The content is only loaded once the stream has hashed to the
+        requested object ID, like C git's dumb-http walker.
+
         Args:
           sha: SHA1 of the object (hex string as bytes)
 
@@ -133,48 +171,67 @@ class DumbHTTPObjectStore(BaseObjectStore):
 
         Raises:
           KeyError: If object not found
+          ObjectFormatException: If the response is not a valid loose object
+            or does not hash to the requested object ID
         """
         hex_sha = sha.decode("ascii")
-        path = f"objects/{hex_sha[:2]}/{hex_sha[2:]}"
-
+        url = urljoin(self.base_url, f"objects/{hex_sha[:2]}/{hex_sha[2:]}")
+        resp, read = self._http_request(url, {})
         try:
-            compressed = self._fetch_url(path)
+            if resp.status != 200:
+                raise KeyError(sha)
+
+            hasher = self.object_format.new_hash()
+            obj_class: type[ShaFile] | None = None
+            obj_size = 0
+            content_size = 0
+            header = b""
+            with tempfile.SpooledTemporaryFile(
+                max_size=_LOOSE_OBJECT_SPOOL_SIZE, prefix="dulwich-dumb-"
+            ) as content_file:
+                for buf in _inflate_chunks(read):
+                    hasher.update(buf)
+                    if obj_class is None:
+                        header += buf
+                        header_end = header.find(b"\x00")
+                        if header_end == -1:
+                            # "<type> <size>\0" is at most a few dozen bytes;
+                            # anything longer is not a loose object header.
+                            if len(header) > 64:
+                                raise ObjectFormatException("Invalid object header")
+                            continue
+                        header, buf = header[:header_end], header[header_end + 1 :]
+                        parts = header.split(b" ", 1)
+                        if len(parts) != 2:
+                            raise ObjectFormatException("Invalid object header")
+                        obj_class = object_class(parts[0])
+                        if obj_class is None:
+                            raise ObjectFormatException(
+                                f"Unknown object type: {parts[0]!r}"
+                            )
+                        try:
+                            obj_size = int(parts[1])
+                        except ValueError:
+                            raise ObjectFormatException("Invalid object header")
+                    content_file.write(buf)
+                    content_size += len(buf)
+
+                if obj_class is None:
+                    raise ObjectFormatException("Invalid object header")
+                if content_size != obj_size:
+                    raise ObjectFormatException("Object size mismatch")
+                actual_sha = hasher.hexdigest().encode("ascii")
+                if actual_sha != sha:
+                    raise ObjectFormatException(
+                        f"Fetched object has sha {actual_sha.decode('ascii')}, "
+                        f"expected {hex_sha}"
+                    )
+                content_file.seek(0)
+                return obj_class.type_num, content_file.read()
         except OSError:
             raise KeyError(sha)
-
-        # Decompress and parse the object
-        decompressed = zlib.decompress(compressed)
-
-        # Parse header
-        header_end = decompressed.find(b"\x00")
-        if header_end == -1:
-            raise ObjectFormatException("Invalid object header")
-
-        header = decompressed[:header_end]
-        content = decompressed[header_end + 1 :]
-
-        parts = header.split(b" ", 1)
-        if len(parts) != 2:
-            raise ObjectFormatException("Invalid object header")
-
-        obj_type = parts[0]
-        obj_size = int(parts[1])
-
-        if len(content) != obj_size:
-            raise ObjectFormatException("Object size mismatch")
-
-        # Convert type name to type number
-        type_map = {
-            b"blob": Blob.type_num,
-            b"tree": Tree.type_num,
-            b"commit": Commit.type_num,
-            b"tag": Tag.type_num,
-        }
-
-        if obj_type not in type_map:
-            raise ObjectFormatException(f"Unknown object type: {obj_type!r}")
-
-        return type_map[obj_type], content
+        finally:
+            resp.close()
 
     def _load_packs(self) -> None:
         """Load the list of available packs from the remote."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2180,20 +2180,19 @@ class HttpGitClientTests(TestCase):
     def test_fetch_pack_dumb_http(self) -> None:
         from urllib3.response import HTTPResponse
 
-        # Mock responses for dumb HTTP
-        info_refs_content = (
-            b"0123456789abcdef0123456789abcdef01234567\trefs/heads/master\n"
-        )
-        head_content = b"ref: refs/heads/master"
-
-        # Create a blob object for testing
+        # Create a blob object for testing; the advertised ref must use the
+        # blob's real sha, since fetched loose objects are verified against
+        # the requested object id.
         blob_content = b"Hello, dumb HTTP!"
-        blob_sha = b"0123456789abcdef0123456789abcdef01234567"
-        blob_hex = blob_sha.decode("ascii")
         blob_obj_data = (
             b"blob " + str(len(blob_content)).encode() + b"\x00" + blob_content
         )
+        blob_hex = hashlib.sha1(blob_obj_data).hexdigest()
         blob_compressed = zlib.compress(blob_obj_data)
+
+        # Mock responses for dumb HTTP
+        info_refs_content = blob_hex.encode("ascii") + b"\trefs/heads/master\n"
+        head_content = b"ref: refs/heads/master"
 
         responses = {
             "/HEAD": {

--- a/tests/test_dumb.py
+++ b/tests/test_dumb.py
@@ -27,7 +27,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from dulwich.dumb import DumbHTTPObjectStore, DumbRemoteHTTPRepo
-from dulwich.errors import NotGitRepository
+from dulwich.errors import NotGitRepository, ObjectFormatException
 from dulwich.objects import ZERO_SHA, Blob, Commit, ShaFile, Tag, Tree, sha_to_hex
 
 
@@ -130,6 +130,44 @@ class DumbHTTPObjectStoreTests(TestCase):
         self._add_response(path, b"invalid data")
 
         self.assertRaises(Exception, self.store._fetch_loose_object, sha)
+
+    def test_fetch_loose_object_rejects_sha_mismatch(self) -> None:
+        # A malicious dumb server can substitute a different (e.g. much
+        # larger) object for the one requested; the mismatch must be detected
+        # before the content is handed to the caller.
+        requested = Blob()
+        requested.data = b"expected content"
+        substituted = Blob()
+        substituted.data = b"A" * 4096
+        hex_sha = requested.id
+        path = f"objects/{hex_sha[:2].decode('ascii')}/{hex_sha[2:].decode('ascii')}"
+        self._add_response(path, self._make_object(substituted))
+
+        self.assertRaises(
+            ObjectFormatException, self.store._fetch_loose_object, requested.id
+        )
+
+    def test_fetch_loose_object_truncated(self) -> None:
+        blob = Blob()
+        blob.data = b"Hello, world!"
+        hex_sha = blob.id
+        path = f"objects/{hex_sha[:2].decode('ascii')}/{hex_sha[2:].decode('ascii')}"
+        self._add_response(path, self._make_object(blob)[:-4])
+
+        self.assertRaises(zlib.error, self.store._fetch_loose_object, blob.id)
+
+    def test_fetch_loose_object_spills_large_object_to_disk(self) -> None:
+        # Objects above the spool threshold are inflated to a temporary file
+        # while being hashed, rather than buffered in memory up front.
+        blob = Blob()
+        blob.data = b"x" * (2 * 1024 * 1024)
+        hex_sha = blob.id
+        path = f"objects/{hex_sha[:2].decode('ascii')}/{hex_sha[2:].decode('ascii')}"
+        self._add_response(path, self._make_object(blob))
+
+        type_num, content = self.store._fetch_loose_object(blob.id)
+        self.assertEqual(Blob.type_num, type_num)
+        self.assertEqual(blob.data, content)
 
     def test_load_packs_empty(self) -> None:
         # No packs file


### PR DESCRIPTION
DumbHTTPObjectStore._fetch_loose_object inflated a dumb HTTP server's loose-object response with a single unbounded zlib.decompress, so a hostile or intercepted server could expand a small reply into gigabytes of memory during clone or fetch. Following review, the response is now streamed the way C git's dumb-http walker handles fetched loose objects: inflated incrementally through a bounded buffer, spooled to a temporary file past 1 MiB, and hashed as it goes, with the content only returned once the stream hashes to the requested object id. No size limit is involved, matching C git. Added regression tests for the sha-mismatch, truncated and larger-than-spool cases.