### PR TITLE
Fix bare except clauses in index.py, test_filters.py, and test_object_store.py

### DIFF
--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -1224,7 +1224,7 @@ class Index:
                     extensions=meaningful_extensions,
                 )
                 sha1_writer.close()
-        except:
+        except Exception:
             f.close()
             raise
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -515,7 +515,7 @@ while True:
                 os.chmod(path, 0o755)
 
             return path
-        except:
+        except Exception:
             if os.path.exists(path):
                 os.unlink(path)
             raise
@@ -940,7 +940,7 @@ while True:
                 os.chmod(path, 0o755)
 
             return path
-        except:
+        except Exception:
             if os.path.exists(path):
                 os.unlink(path)
             raise

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -535,7 +535,7 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
             ]
             build_pack(f, objects_spec, store=store)
             commit()
-        except:
+        except Exception:
             abort()
             raise
 
@@ -566,7 +566,7 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
             objects_spec2 = [(b3.type_num, b3.as_raw_string())]
             build_pack(f2, objects_spec2, store=store2)
             commit2()
-        except:
+        except Exception:
             abort2()
             raise
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` in three files:

- `dulwich/index.py`: bare `except:` in file-write error handler
- - `tests/test_filters.py`: two bare `except:` clauses in filter path helpers
- - `tests/test_object_store.py`: two bare `except:` clauses in transaction test helpers
Bare `except:` catches `BaseException` (including `SystemExit` and `KeyboardInterrupt`), which can mask serious errors and interfere with interpreter shutdown. Using `except Exception:` is the correct fix.