### PR TITLE
raise ApplyDeltaError on truncated deltas in copy and insert ops

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -3848,6 +3848,17 @@ def apply_delta(
                 break
         return size, index
 
+    def read_byte(delta: bytes) -> int:
+        nonlocal index
+        # Bound-check explicitly: ``delta[index:index+1]`` silently returns
+        # b"" past the end, which would crash with TypeError in ``ord`` and
+        # leave the caller unable to distinguish a truncated delta from a
+        # programming bug.
+        if index >= delta_length:
+            raise ApplyDeltaError("delta truncated in copy op")
+        index += 1
+        return ord(delta[index - 1 : index])
+
     src_size, index = get_delta_header_size(delta, index)
     dest_size, index = get_delta_header_size(delta, index)
     if src_size != len(src_buf):
@@ -3861,15 +3872,13 @@ def apply_delta(
             cp_off = 0
             for i in range(4):
                 if cmd & (1 << i):
-                    x = ord(delta[index : index + 1])
-                    index += 1
+                    x = read_byte(delta)
                     cp_off |= x << (i * 8)
             cp_size = 0
             # Version 3 packs can contain copy sizes larger than 64K.
             for i in range(3):
                 if cmd & (1 << (4 + i)):
-                    x = ord(delta[index : index + 1])
-                    index += 1
+                    x = read_byte(delta)
                     cp_size |= x << (i * 8)
             if cp_size == 0:
                 cp_size = 0x10000
@@ -3881,6 +3890,8 @@ def apply_delta(
                 break
             out.append(src_buf[cp_off : cp_off + cp_size])
         elif cmd != 0:
+            if index + cmd > delta_length:
+                raise ApplyDeltaError("delta truncated in insert op")
             out.append(delta[index : index + cmd])
             index += cmd
         else:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -283,6 +283,15 @@ class TestPackDeltas(TestCase):
         self.assertRaises(ApplyDeltaError, apply_delta, b"", b"\x80")
         self.assertRaises(ApplyDeltaError, apply_delta, b"", b"")
 
+    def test_apply_delta_truncated_copy_op(self) -> None:
+        # A copy op declares offset and size bytes via its command byte's
+        # low nibble but the delta ends before those bytes are present. Used
+        # to crash with a generic TypeError from ``ord(b"")`` in the copy-op
+        # parsing loop; now raises ApplyDeltaError.
+        # \x00 src_size=0, \x00 dest_size=0, \x81 copy op that expects one
+        # offset byte which is missing.
+        self.assertRaises(ApplyDeltaError, apply_delta, b"", b"\x00\x00\x81")
+
     def test_create_delta_insert_only(self) -> None:
         """Test create_delta when only insertions are required."""
         base = b""


### PR DESCRIPTION
A delta whose copy-op command byte declared offset/size bytes past the end of the delta buffer used to crash with ``TypeError: ord() expected a character, but string of length 0 found`` from ``ord(b"")``. Truncated insert ops similarly ran past the end and only surfaced as the fallthrough "delta not empty" check. Bound-check both cases explicitly so the caller gets a typed ``ApplyDeltaError`` with a message that names the actual failure. Reproduced by the ``test_apply_delta_only_raises_apply_delta_error`` property test with ``base=b"", delta=b"\x00\x00\x81"``.