### PR TITLE
Always single-quote the remote path in the ssh command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,11 @@
+1.2.13	UNRELEASED
+
+ * Always single-quote the repository path in the SSH command, matching git's
+   ``sq_quote()``. ``shlex.quote`` left paths without shell metacharacters
+   bare, which broke cloning from servers that parse the command themselves
+   rather than handing it to a shell, such as Bitbucket Server.
+   (Jelmer Vernooĳ, #2319)
+
 1.2.12	2026-07-19
 
  * Fix ``Bundle.store_objects()`` silently dropping every OFS_DELTA/REF_DELTA

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3854,6 +3854,18 @@ class PLinkSSHVendor(SSHVendor):
 get_ssh_vendor: Callable[[], SSHVendor] = SubprocessSSHVendor
 
 
+def _quote_remote_path(path: bytes) -> bytes:
+    """Quote a remote path the way git's sq_quote() does.
+
+    The path is always wrapped in single quotes, even when it contains no
+    characters that are special to a shell. shlex.quote() leaves such paths
+    bare, but some servers (notably Bitbucket Server) parse the command line
+    themselves rather than handing it to a shell, and only accept git's
+    canonical quoted form.
+    """
+    return b"'" + path.replace(b"'", b"'\\''") + b"'"
+
+
 class SSHGitClient(TraditionalGitClient):
     """Git client that connects over SSH."""
 
@@ -4008,15 +4020,13 @@ class SSHGitClient(TraditionalGitClient):
             path = path.decode(self._remote_path_encoding)
         if path.startswith("/~"):
             path = path[1:]
-        import shlex
-
         # The git command is run by the remote login shell, so the path has
         # to be quoted to stop an embedded single quote from closing the
         # quoting and having the remainder interpreted as shell.
         argv = (
             self._get_cmd_path(cmd)
             + b" "
-            + shlex.quote(path).encode(self._remote_path_encoding)
+            + _quote_remote_path(path.encode(self._remote_path_encoding))
         )
         kwargs = {}
         if self.password is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1143,7 +1143,7 @@ class SSHGitClientTests(TestCase):
         try:
             self.assertEqual(b"username", server.username)
             self.assertEqual(1337, server.port)
-            self.assertEqual(b"git-command /path/to/repo", server.command)
+            self.assertEqual(b"git-command '/path/to/repo'", server.command)
         finally:
             proto.close()
 
@@ -1162,8 +1162,31 @@ class SSHGitClientTests(TestCase):
         proto, _, _ = client._connect(b"command", b"/repo'; touch pwned; '")
         try:
             self.assertEqual(
-                b"git-command '/repo'\"'\"'; touch pwned; '\"'\"''", server.command
+                b"git-command '/repo'\\''; touch pwned; '\\'''", server.command
             )
+        finally:
+            proto.close()
+
+    def test_connect_always_quotes_path(self) -> None:
+        # git's sq_quote() wraps the path in single quotes unconditionally,
+        # even when it contains nothing a shell would treat specially. Servers
+        # that parse the command themselves rather than passing it to a shell
+        # (such as Bitbucket Server) reject the unquoted form. The expected
+        # values below are what git itself sends for these URLs.
+        server = self.server
+        client = self.client
+
+        proto, _, _ = client._connect(b"upload-pack", b"/some-project/some-repo.git")
+        try:
+            self.assertEqual(
+                b"git-upload-pack '/some-project/some-repo.git'", server.command
+            )
+        finally:
+            proto.close()
+
+        proto, _, _ = client._connect(b"upload-pack", b"foo/bar.git")
+        try:
+            self.assertEqual(b"git-upload-pack 'foo/bar.git'", server.command)
         finally:
             proto.close()
 


### PR DESCRIPTION
git's sq_quote() wraps the repository path in single quotes unconditionally. shlex.quote() leaves paths without shell metacharacters bare, which broke cloning from servers that parse the command themselves rather than handing it to a shell, such as Bitbucket Server.

Fixes #2319