### PR TITLE
Follow Git's wildmatch() for .gitignore/.gitattributes bracket expressions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -27,6 +27,12 @@
    link and overwrite ``.git/config`` on pull.
    (Jelmer Vernooĳ, reported by Hugh Lewis)
 
+ * Translate ``.gitignore``/``.gitattributes`` bracket expressions with Git's
+   ``wildmatch()`` semantics: ``[^...]`` negation, POSIX classes, backslash
+   escapes and malformed-class handling. ``ignore`` and ``attrs`` now share
+   one translator, the new public ``dulwich.wildmatch``.
+   (Vincent Gao, #2326)
+
  * Always single-quote the repository path in the SSH command, matching git's
    ``sq_quote()``. ``shlex.quote`` left paths without shell metacharacters
    bare, which broke cloning from servers that parse the command themselves

--- a/dulwich/attrs.py
+++ b/dulwich/attrs.py
@@ -26,6 +26,7 @@ __all__ = [
     "AttributeValue",
     "GitAttributes",
     "Pattern",
+    "compile_gitattributes_patterns",
     "match_path",
     "parse_git_attributes",
     "parse_gitattributes_file",
@@ -35,7 +36,7 @@ __all__ = [
 import logging
 import os
 import re
-from collections.abc import Generator, Iterator, Mapping, Sequence
+from collections.abc import Generator, Iterable, Iterator, Mapping, Sequence
 from typing import IO
 
 from .wildmatch import MalformedPattern
@@ -195,6 +196,34 @@ def match_path(
     return attributes
 
 
+def compile_gitattributes_patterns(
+    entries: Iterable[tuple[bytes, Mapping[bytes, AttributeValue]]],
+    source: str | bytes = b"<attributes>",
+) -> list[tuple[Pattern, Mapping[bytes, AttributeValue]]]:
+    """Compile parsed gitattributes entries, skipping malformed patterns.
+
+    Git's wildmatch() treats a malformed pattern as matching nothing rather
+    than as a broken file, so one bad line is logged and dropped instead of
+    aborting the load.
+
+    Args:
+        entries: (pattern, attributes) pairs, as from parse_git_attributes
+        source: Where the entries came from, used in the warning
+
+    Returns:
+        List of (Pattern, attributes) tuples
+    """
+    patterns = []
+    for pattern_bytes, attrs in entries:
+        try:
+            pattern = Pattern(pattern_bytes)
+        except MalformedPattern:
+            logger.warning("Ignoring malformed pattern %r in %r", pattern_bytes, source)
+            continue
+        patterns.append((pattern, attrs))
+    return patterns
+
+
 def parse_gitattributes_file(
     filename: str | bytes,
 ) -> list[tuple[Pattern, Mapping[bytes, AttributeValue]]]:
@@ -209,23 +238,11 @@ def parse_gitattributes_file(
     Returns:
         List of (Pattern, attributes) tuples
     """
-    patterns = []
-
     if isinstance(filename, str):
         filename = filename.encode("utf-8")
 
     with open(filename, "rb") as f:
-        for pattern_bytes, attrs in parse_git_attributes(f):
-            try:
-                pattern = Pattern(pattern_bytes)
-            except MalformedPattern:
-                logger.warning(
-                    "Ignoring malformed pattern %r in %r", pattern_bytes, filename
-                )
-                continue
-            patterns.append((pattern, attrs))
-
-    return patterns
+        return compile_gitattributes_patterns(parse_git_attributes(f), filename)
 
 
 def read_gitattributes(

--- a/dulwich/attrs.py
+++ b/dulwich/attrs.py
@@ -32,10 +32,16 @@ __all__ = [
     "read_gitattributes",
 ]
 
+import logging
 import os
 import re
 from collections.abc import Generator, Iterator, Mapping, Sequence
 from typing import IO
+
+from .wildmatch import MalformedPattern
+from .wildmatch import translate as translate_wildmatch
+
+logger = logging.getLogger(__name__)
 
 AttributeValue = bytes | bool | None
 
@@ -106,10 +112,12 @@ def _translate_pattern(pattern: bytes) -> bytes:
 
     Similar to gitignore patterns, but simpler as gitattributes doesn't support
     all the same features (e.g., no directory-only patterns with trailing /).
+
+    Raises:
+      MalformedPattern: if wildmatch() would refuse the pattern outright;
+        see :func:`dulwich.wildmatch.translate`.
     """
     res = b""
-    i = 0
-    n = len(pattern)
 
     # If pattern doesn't contain /, it can match at any level
     if b"/" not in pattern:
@@ -117,58 +125,8 @@ def _translate_pattern(pattern: bytes) -> bytes:
     elif pattern.startswith(b"/"):
         # Leading / means root of repository
         pattern = pattern[1:]
-        n = len(pattern)
 
-    while i < n:
-        c = pattern[i : i + 1]
-        i += 1
-
-        if c == b"*":
-            # Consume the whole run of '*' so consecutive stars collapse to
-            # a single wildcard. Emitting one quantifier per star produces
-            # adjacent unbounded quantifiers (e.g. '.*.*.*') that backtrack
-            # catastrophically on non-matching input (ReDoS); collapsing is
-            # also semantically correct since repeated '*' are redundant.
-            double = i < n and pattern[i : i + 1] == b"*"
-            while i < n and pattern[i : i + 1] == b"*":
-                i += 1
-            if double:
-                # Double asterisk - matches across directory separators
-                if i < n and pattern[i : i + 1] == b"/":
-                    # **/ - match zero or more directories
-                    res += b"(?:.*/)??"
-                    i += 1
-                else:
-                    # ** at end or in the middle
-                    res += b".*"
-            else:
-                # Single * - match any character except /
-                res += b"[^/]*"
-        elif c == b"?":
-            res += b"[^/]"
-        elif c == b"[":
-            # Character class
-            j = i
-            if j < n and pattern[j : j + 1] == b"!":
-                j += 1
-            if j < n and pattern[j : j + 1] == b"]":
-                j += 1
-            while j < n and pattern[j : j + 1] != b"]":
-                j += 1
-            if j >= n:
-                res += b"\\["
-            else:
-                stuff = pattern[i:j].replace(b"\\", b"\\\\")
-                i = j + 1
-                if stuff.startswith(b"!"):
-                    stuff = b"^" + stuff[1:]
-                elif stuff.startswith(b"^"):
-                    stuff = b"\\" + stuff
-                res += b"[" + stuff + b"]"
-        else:
-            res += re.escape(c)
-
-    return res
+    return res + translate_wildmatch(pattern)
 
 
 class Pattern:
@@ -242,6 +200,9 @@ def parse_gitattributes_file(
 ) -> list[tuple[Pattern, Mapping[bytes, AttributeValue]]]:
     """Parse a gitattributes file and return compiled patterns.
 
+    A malformed pattern is logged and skipped rather than raised, so one bad
+    line doesn't stop the rest of the file from loading.
+
     Args:
         filename: Path to the .gitattributes file
 
@@ -255,7 +216,13 @@ def parse_gitattributes_file(
 
     with open(filename, "rb") as f:
         for pattern_bytes, attrs in parse_git_attributes(f):
-            pattern = Pattern(pattern_bytes)
+            try:
+                pattern = Pattern(pattern_bytes)
+            except MalformedPattern:
+                logger.warning(
+                    "Ignoring malformed pattern %r in %r", pattern_bytes, filename
+                )
+                continue
             patterns.append((pattern, attrs))
 
     return patterns

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -37,6 +37,7 @@ __all__ = [
     "translate",
 ]
 
+import logging
 import os.path
 import re
 from collections.abc import Iterable, Sequence
@@ -47,6 +48,10 @@ if TYPE_CHECKING:
     from .repo import Repo
 
 from .config import Config, get_xdg_config_home_path
+from .wildmatch import NO_MATCH, MalformedPattern
+from .wildmatch import translate as translate_wildmatch
+
+logger = logging.getLogger(__name__)
 
 
 def _pattern_to_str(pattern: "Pattern | bytes | str") -> str:
@@ -156,89 +161,6 @@ def _pattern_excludes_parent(
     return False
 
 
-def _translate_segment(segment: bytes) -> bytes:
-    """Translate a single path segment to regex, following Git rules exactly."""
-    if segment == b"*":
-        return b"[^/]+"
-
-    res = b""
-    i, n = 0, len(segment)
-    while i < n:
-        c = segment[i : i + 1]
-        i += 1
-        if c == b"*":
-            # Collapse a run of consecutive '*' into a single quantifier.
-            # Within a segment repeated '*' are redundant ([^/]*[^/]* is
-            # equivalent to [^/]*), and emitting one quantifier per star
-            # builds a regex with adjacent unbounded quantifiers that
-            # backtracks catastrophically on non-matching input (ReDoS).
-            while i < n and segment[i : i + 1] == b"*":
-                i += 1
-            res += b"[^/]*"
-        elif c == b"?":
-            res += b"[^/]"
-        elif c == b"\\":
-            if i < n:
-                res += re.escape(segment[i : i + 1])
-                i += 1
-            else:
-                res += re.escape(c)
-        elif c == b"[":
-            j = i
-            if j < n and segment[j : j + 1] == b"!":
-                j += 1
-            if j < n and segment[j : j + 1] == b"]":
-                j += 1
-            while j < n and segment[j : j + 1] != b"]":
-                j += 1
-            if j >= n:
-                res += b"\\["
-            else:
-                stuff = segment[i:j].replace(b"\\", b"\\\\")
-                i = j + 1
-                if stuff.startswith(b"!"):
-                    stuff = b"^" + stuff[1:]
-                elif stuff.startswith(b"^"):
-                    stuff = b"\\" + stuff
-                res += b"[" + stuff + b"]"
-        else:
-            res += re.escape(c)
-    return res
-
-
-def _handle_double_asterisk(segments: Sequence[bytes], i: int) -> tuple[bytes, bool]:
-    """Handle ** segment processing, returns (regex_part, skip_next)."""
-    # Check if ** is at end
-    remaining = segments[i + 1 :]
-    if all(s == b"" for s in remaining):
-        # ** at end - matches everything
-        return b".*", False
-
-    # Check if next segment is also **
-    if i + 1 < len(segments) and segments[i + 1] == b"**":
-        # Consecutive ** segments
-        # Check if this ends with a directory pattern (trailing /)
-        remaining_after_next = segments[i + 2 :]
-        is_dir_pattern = (
-            len(remaining_after_next) == 1 and remaining_after_next[0] == b""
-        )
-
-        if is_dir_pattern:
-            # Pattern like c/**/**/ - requires at least one intermediate directory
-            return b"[^/]+/(?:[^/]+/)*", True
-        else:
-            # Pattern like c/**/**/d - allows zero intermediate directories
-            return b"(?:[^/]+/)*", True
-    else:
-        # ** in middle - handle differently depending on what follows
-        if i == 0:
-            # ** at start - any prefix
-            return b"(?:.*/)??", False
-        else:
-            # ** in middle - match zero or more complete directory segments
-            return b"(?:[^/]+/)*", False
-
-
 def _handle_leading_patterns(pat: bytes, res: bytes) -> tuple[bytes, bytes]:
     """Handle leading patterns like ``/**/``, ``**/``, or ``/``."""
     if pat.startswith(b"/**/"):
@@ -255,13 +177,18 @@ def _handle_leading_patterns(pat: bytes, res: bytes) -> tuple[bytes, bytes]:
 
 
 def translate(pat: bytes) -> bytes:
-    """Translate a gitignore pattern to a regular expression following Git rules exactly."""
+    """Translate a gitignore pattern to a regular expression following Git rules exactly.
+
+    Raises:
+      MalformedPattern: if wildmatch() would refuse the pattern outright;
+        see :func:`dulwich.wildmatch.translate`.
+    """
     res = b"(?ms)"
 
-    # Check for invalid patterns with // - Git treats these as broken patterns
+    # A "//" is well-formed but Git treats it as matching nothing, not as
+    # an error - distinct from a malformed pattern, which raises above.
     if b"//" in pat:
-        # Pattern with // doesn't match anything in Git
-        return b"(?!.*)"  # Negative lookahead - matches nothing
+        return NO_MATCH
 
     # Don't normalize consecutive ** patterns - Git treats them specially
     # c/**/**/ requires at least one intermediate directory
@@ -276,30 +203,8 @@ def translate(pat: bytes) -> bytes:
     if prefix_added:
         res += prefix_added
 
-    # Process the rest of the pattern
-    if pat == b"**":
-        res += b".*"
-    else:
-        segments = pat.split(b"/")
-        i = 0
-        while i < len(segments):
-            segment = segments[i]
-
-            # Add slash separator (except for first segment)
-            if i > 0 and segments[i - 1] != b"**":
-                res += re.escape(b"/")
-
-            if segment == b"**":
-                regex_part, skip_next = _handle_double_asterisk(segments, i)
-                res += regex_part
-                if regex_part == b".*":  # End of pattern
-                    break
-                if skip_next:
-                    i += 1
-            else:
-                res += _translate_segment(segment)
-
-            i += 1
+    # Everything left of the gitignore-specific decoration is plain wildmatch
+    res += translate_wildmatch(pat)
 
     # Add optional trailing slash for files
     if not pat.endswith(b"/"):
@@ -356,6 +261,12 @@ class Pattern:
         Args:
             pattern: The gitignore pattern as bytes.
             ignorecase: Whether to perform case-insensitive matching.
+
+        Raises:
+            MalformedPattern: if wildmatch() would refuse the pattern
+              outright. Loading a whole file of patterns should go through
+              :meth:`IgnoreFilter.append_pattern` instead, which catches
+              this and warns.
         """
         self.pattern = pattern
         self.ignorecase = ignorecase
@@ -475,8 +386,22 @@ class IgnoreFilter:
             self.append_pattern(pattern)
 
     def append_pattern(self, pattern: bytes) -> None:
-        """Add a pattern to the set."""
-        self._patterns.append(Pattern(pattern, self._ignorecase))
+        """Add a pattern to the set.
+
+        A malformed pattern is logged and skipped rather than raised, so one
+        bad line in a gitignore file doesn't stop the rest from loading. To
+        fail loudly instead, construct the ``Pattern`` directly.
+        """
+        try:
+            compiled = Pattern(pattern, self._ignorecase)
+        except MalformedPattern:
+            logger.warning(
+                "Ignoring malformed pattern %r in %s",
+                pattern,
+                self._path or "<patterns>",
+            )
+            return
+        self._patterns.append(compiled)
 
     def find_matching(self, path: bytes | str) -> Iterable[Pattern]:
         """Yield all matching patterns for path.

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
     from .repo import Repo
 
 from .config import Config, get_xdg_config_home_path
-from .wildmatch import NO_MATCH, MalformedPattern
+from .wildmatch import MalformedPattern
 from .wildmatch import translate as translate_wildmatch
 
 logger = logging.getLogger(__name__)
@@ -184,11 +184,6 @@ def translate(pat: bytes) -> bytes:
         see :func:`dulwich.wildmatch.translate`.
     """
     res = b"(?ms)"
-
-    # A "//" is well-formed but Git treats it as matching nothing, not as
-    # an error - distinct from a malformed pattern, which raises above.
-    if b"//" in pat:
-        return NO_MATCH
 
     # Don't normalize consecutive ** patterns - Git treats them specially
     # c/**/**/ requires at least one intermediate directory

--- a/dulwich/line_ending.py
+++ b/dulwich/line_ending.py
@@ -166,6 +166,7 @@ from .filters import FilterBlobNormalizer, FilterContext, FilterDriver, FilterRe
 from .object_store import iter_tree_contents
 from .objects import Blob, ObjectID
 from .patch import is_binary
+from .wildmatch import MalformedPattern
 
 CRLF = b"\r\n"
 LF = b"\n"
@@ -476,7 +477,11 @@ class BlobNormalizer(FilterBlobNormalizer):
                 pattern_bytes = pattern_str.encode("utf-8")
             else:
                 pattern_bytes = pattern_str
-            pattern = Pattern(pattern_bytes)
+            try:
+                pattern = Pattern(pattern_bytes)
+            except MalformedPattern:
+                logger.warning("Ignoring malformed pattern %r", pattern_bytes)
+                continue
             git_attrs_patterns.append((pattern, attrs))
 
         git_attributes = GitAttributes(git_attrs_patterns)

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -2647,7 +2647,7 @@ class Repo(BaseRepo):
         """
         from .attrs import (
             GitAttributes,
-            Pattern,
+            compile_gitattributes_patterns,
             parse_git_attributes,
         )
 
@@ -2685,9 +2685,11 @@ class Repo(BaseRepo):
                     attrs_blob = self[attrs_sha]
                     if isinstance(attrs_blob, Blob):
                         attrs_data = BytesIO(attrs_blob.data)
-                        for pattern_bytes, attrs in parse_git_attributes(attrs_data):
-                            pattern = Pattern(pattern_bytes)
-                            patterns.append((pattern, attrs))
+                        patterns.extend(
+                            compile_gitattributes_patterns(
+                                parse_git_attributes(attrs_data), b".gitattributes"
+                            )
+                        )
             except (KeyError, NotTreeError):
                 pass
 
@@ -2695,17 +2697,21 @@ class Repo(BaseRepo):
         info_attrs_path = os.path.join(self.controldir(), "info", "attributes")
         if os.path.exists(info_attrs_path):
             with open(info_attrs_path, "rb") as f:
-                for pattern_bytes, attrs in parse_git_attributes(f):
-                    pattern = Pattern(pattern_bytes)
-                    patterns.append((pattern, attrs))
+                patterns.extend(
+                    compile_gitattributes_patterns(
+                        parse_git_attributes(f), info_attrs_path
+                    )
+                )
 
         # Read .gitattributes from working directory (if it exists)
         working_attrs_path = os.path.join(self.path, ".gitattributes")
         if os.path.exists(working_attrs_path):
             with open(working_attrs_path, "rb") as f:
-                for pattern_bytes, attrs in parse_git_attributes(f):
-                    pattern = Pattern(pattern_bytes)
-                    patterns.append((pattern, attrs))
+                patterns.extend(
+                    compile_gitattributes_patterns(
+                        parse_git_attributes(f), working_attrs_path
+                    )
+                )
 
         return GitAttributes(patterns)
 

--- a/dulwich/wildmatch.py
+++ b/dulwich/wildmatch.py
@@ -38,7 +38,6 @@ shared between :mod:`dulwich.ignore` and :mod:`dulwich.attrs`. It is not
 """
 
 __all__ = [
-    "NO_MATCH",
     "MalformedPattern",
     "translate",
     "translate_bracket_expression",
@@ -46,11 +45,6 @@ __all__ = [
 
 import re
 from collections.abc import Sequence
-
-# Regex that never matches. Exported for callers (dulwich.ignore,
-# dulwich.attrs) with their own well-formed-but-vacuous patterns, e.g. one
-# containing a bare "//". Not produced by this module itself.
-NO_MATCH = b"(?!.*)"
 
 _SLASH = 0x2F
 

--- a/dulwich/wildmatch.py
+++ b/dulwich/wildmatch.py
@@ -1,0 +1,322 @@
+# wildmatch.py -- Git's wildmatch() pattern language
+# Copyright (C) 2026 Vincent Gao <gaobing1230@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+r"""Git's wildmatch() pattern language.
+
+Git matches ``.gitignore`` and ``.gitattributes`` patterns with the same
+``wildmatch()`` (``wildmatch.c``) under ``WM_PATHNAME``, so the grammar is
+shared between :mod:`dulwich.ignore` and :mod:`dulwich.attrs`. It is not
+:mod:`fnmatch`, whose semantics neither file follows:
+
+* ``*`` and ``?`` never match ``/``; only a whole ``**`` component does.
+* ``^`` negates a bracket class exactly like ``!`` (``NEGATE_CLASS2``).
+* ``[:alpha:]`` and the eleven other POSIX classes are supported.
+* A backslash escapes the following member, so ``[a\-c]`` is ``a``, ``-``, ``c``
+  rather than the range ``\`` to ``c``.
+* A bracket expression never matches ``/``, not even a negated one.
+* A malformed bracket expression raises :exc:`MalformedPattern`; callers that
+  read a whole file of patterns should catch it per pattern and warn, rather
+  than let one bad line abort the load.
+"""
+
+__all__ = [
+    "NO_MATCH",
+    "MalformedPattern",
+    "translate",
+    "translate_bracket_expression",
+]
+
+import re
+from collections.abc import Sequence
+
+# Regex that never matches. Exported for callers (dulwich.ignore,
+# dulwich.attrs) with their own well-formed-but-vacuous patterns, e.g. one
+# containing a bare "//". Not produced by this module itself.
+NO_MATCH = b"(?!.*)"
+
+_SLASH = 0x2F
+
+# Git's character classes come from sane-ctype.h and are ASCII-only; the
+# sane_ctype[] table has no entries in the 128.. range. '/' is left out of
+# every class because a bracket expression can never match it.
+_POSIX_CLASSES = {
+    b"alnum": rb"0-9A-Za-z",
+    b"alpha": rb"A-Za-z",
+    b"blank": b"\\t ",
+    b"cntrl": b"\\x00-\\x1f\\x7f",
+    b"digit": rb"0-9",
+    b"graph": rb"!-.0-~",
+    b"lower": rb"a-z",
+    b"print": rb" -.0-~",
+    b"punct": rb"!-.:-@\[-`{-~",
+    b"space": b"\\t\\n\\r ",
+    b"upper": rb"A-Z",
+    b"xdigit": rb"0-9A-Fa-f",
+}
+
+
+class MalformedPattern(Exception):
+    """A pattern Git's wildmatch() gives up on (WM_ABORT_ALL).
+
+    Such a pattern matches nothing at all, not even literally.
+    """
+
+
+def _render(members: list[tuple[int, int]]) -> bytes:
+    """Render member ranges, dropping '/' and ranges that cannot match."""
+    out = []
+    for low, high in members:
+        for a, b in ((low, min(high, _SLASH - 1)), (max(low, _SLASH + 1), high)):
+            if a > b:
+                continue
+            piece = re.escape(bytes([a]))
+            if a != b:
+                piece += b"-" + re.escape(bytes([b]))
+            out.append(piece)
+    return b"".join(out)
+
+
+def _posix_class(
+    pattern: bytes, i: int, members: list[tuple[int, int]], classes: list[bytes]
+) -> tuple[int, int | None]:
+    """Consume a ``[:name:]`` starting at ``pattern[i]``."""
+    start = i + 2
+    j = start
+    while j < len(pattern) and pattern[j : j + 1] != b"]":
+        j += 1
+    if j >= len(pattern):
+        raise MalformedPattern(pattern)
+    if j == start or pattern[j - 1 : j] != b":":
+        # No closing ":]", so wildmatch() backs up and takes '[' as a member.
+        members.append((0x5B, 0x5B))
+        return start - 2, 0x5B
+    try:
+        classes.append(_POSIX_CLASSES[pattern[start : j - 1]])
+    except KeyError:
+        raise MalformedPattern(pattern) from None
+    return j, None
+
+
+def translate_bracket_expression(pattern: bytes, i: int) -> tuple[int, bytes]:
+    """Translate the bracket expression opened by ``pattern[i - 1]``.
+
+    Args:
+      pattern: Pattern being translated
+      i: Index just past the opening ``[``
+    Returns:
+      Tuple of the index just past the closing ``]`` and the regex fragment
+    Raises:
+      MalformedPattern: if wildmatch() would refuse the pattern outright
+    """
+    n = len(pattern)
+    negated = pattern[i : i + 1] in (b"!", b"^")
+    if negated:
+        i += 1
+    members: list[tuple[int, int]] = []
+    classes: list[bytes] = []
+    prev: int | None = None
+    first = True
+    while True:
+        if i >= n:
+            raise MalformedPattern(pattern)
+        c = pattern[i : i + 1]
+        if c == b"]" and not first:
+            break
+        first = False
+        if c == b"\\":
+            i += 1
+            if i >= n:
+                raise MalformedPattern(pattern)
+            prev = pattern[i]
+            members.append((prev, prev))
+        elif (
+            c == b"-"
+            and prev is not None
+            and i + 1 < n
+            and pattern[i + 1 : i + 2] != b"]"
+        ):
+            i += 1
+            if pattern[i : i + 1] == b"\\":
+                i += 1
+                if i >= n:
+                    raise MalformedPattern(pattern)
+            if prev <= pattern[i]:
+                members[-1] = (prev, pattern[i])
+            # An inverted range matches nothing, but wildmatch() has already
+            # taken the low end as a plain member by the time it sees the '-',
+            # so "[z-a]" still matches "z"; leave that member in place.
+            prev = None
+        elif c == b"[" and pattern[i + 1 : i + 2] == b":":
+            i, prev = _posix_class(pattern, i, members, classes)
+        else:
+            prev = pattern[i]
+            members.append((prev, prev))
+        i += 1
+    body = _render(members) + b"".join(classes)
+    if negated:
+        return i + 1, b"[^/" + body + b"]"
+    if not body:
+        # Well-formed but unmatchable, e.g. [z-a] or [/].
+        return i + 1, b"(?!)"
+    return i + 1, b"[" + body + b"]"
+
+
+def _translate_segment(segment: bytes) -> bytes:
+    """Translate a single path segment to regex, following Git rules exactly."""
+    if segment == b"*":
+        return b"[^/]+"
+
+    res = b""
+    i, n = 0, len(segment)
+    while i < n:
+        c = segment[i : i + 1]
+        i += 1
+        if c == b"*":
+            # Collapse a run of consecutive '*' into a single quantifier.
+            # Within a segment repeated '*' are redundant ([^/]*[^/]* is
+            # equivalent to [^/]*), and emitting one quantifier per star
+            # builds a regex with adjacent unbounded quantifiers that
+            # backtracks catastrophically on non-matching input (ReDoS).
+            while i < n and segment[i : i + 1] == b"*":
+                i += 1
+            res += b"[^/]*"
+        elif c == b"?":
+            res += b"[^/]"
+        elif c == b"\\":
+            if i < n:
+                res += re.escape(segment[i : i + 1])
+                i += 1
+            else:
+                res += re.escape(c)
+        elif c == b"[":
+            i, bracket = translate_bracket_expression(segment, i)
+            res += bracket
+        else:
+            res += re.escape(c)
+    return res
+
+
+def _split_segments(pat: bytes) -> list[bytes]:
+    """Split a pattern into path segments, skipping slashes inside brackets.
+
+    wildmatch() itself walks the whole pattern in one pass rather than
+    splitting it, so a bracket expression may span a ``/`` (it just can
+    never match one). This function exists only so :func:`_translate` can
+    special-case ``**`` per segment; it must respect the same bracket
+    boundaries a one-pass walk would, which is why it can't just call
+    ``pat.split(b"/")``.
+    """
+    if b"[" not in pat:
+        return pat.split(b"/")
+    segments = []
+    start = i = 0
+    while i < len(pat):
+        c = pat[i : i + 1]
+        if c == b"\\" and i + 1 < len(pat):
+            i += 2
+        elif c == b"[":
+            i, _bracket = translate_bracket_expression(pat, i + 1)
+        else:
+            if c == b"/":
+                segments.append(pat[start:i])
+                start = i + 1
+            i += 1
+    segments.append(pat[start:])
+    return segments
+
+
+def _translate_double_asterisk(segments: Sequence[bytes], i: int) -> tuple[bytes, bool]:
+    """Handle ** segment processing, returns (regex_part, skip_next)."""
+    # Check if ** is at end
+    remaining = segments[i + 1 :]
+    if all(s == b"" for s in remaining):
+        # ** at end - matches everything
+        return b".*", False
+
+    # Check if next segment is also **
+    if i + 1 < len(segments) and segments[i + 1] == b"**":
+        # Consecutive ** segments
+        # Check if this ends with a directory pattern (trailing /)
+        remaining_after_next = segments[i + 2 :]
+        is_dir_pattern = (
+            len(remaining_after_next) == 1 and remaining_after_next[0] == b""
+        )
+
+        if is_dir_pattern:
+            # Pattern like c/**/**/ - requires at least one intermediate directory
+            return b"[^/]+/(?:[^/]+/)*", True
+        else:
+            # Pattern like c/**/**/d - allows zero intermediate directories
+            return b"(?:[^/]+/)*", True
+    else:
+        # ** in middle - handle differently depending on what follows
+        if i == 0:
+            # ** at start - any prefix
+            return b"(?:.*/)??", False
+        else:
+            # ** in middle - match zero or more complete directory segments
+            return b"(?:[^/]+/)*", False
+
+
+def _translate(pat: bytes) -> bytes:
+    if pat == b"**":
+        return b".*"
+    res = b""
+    segments = _split_segments(pat)
+    i = 0
+    while i < len(segments):
+        segment = segments[i]
+
+        # Add slash separator (except for first segment)
+        if i > 0 and segments[i - 1] != b"**":
+            res += re.escape(b"/")
+
+        if segment == b"**":
+            regex_part, skip_next = _translate_double_asterisk(segments, i)
+            res += regex_part
+            if regex_part == b".*":  # End of pattern
+                break
+            if skip_next:
+                i += 1
+        else:
+            res += _translate_segment(segment)
+
+        i += 1
+    return res
+
+
+def translate(pattern: bytes) -> bytes:
+    """Translate a wildmatch() pattern to a regular expression.
+
+    Args:
+      pattern: Pattern in Git's wildmatch() language (``WM_PATHNAME``)
+
+    Returns:
+      An unanchored regular expression.
+
+    Raises:
+      MalformedPattern: if wildmatch() would abort on this pattern outright
+        (``WM_ABORT_ALL``, e.g. an unterminated or unknown bracket
+        expression). Callers reading a file of patterns should catch this
+        per pattern and warn rather than let one bad line fail the load;
+        see :meth:`dulwich.ignore.IgnoreFilter.append_pattern`.
+    """
+    return _translate(pattern)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -267,6 +267,7 @@ def self_test_suite() -> unittest.TestSuite:
         "walk",
         "web",
         "whitespace",
+        "wildmatch",
         "worktree",
     ]
     module_names = ["tests.test_" + name for name in names]

--- a/tests/compat/__init__.py
+++ b/tests/compat/__init__.py
@@ -31,6 +31,7 @@ def test_suite() -> unittest.TestSuite:
         "bitmap",
         "bundle",
         "bundle_uri",
+        "check_attr",
         "check_ignore",
         "client",
         "commit_graph",

--- a/tests/compat/test_check_attr.py
+++ b/tests/compat/test_check_attr.py
@@ -1,0 +1,247 @@
+# test_check_attr.py -- Compatibility tests for git check-attr
+# Copyright (C) 2026 Jelmer Vernooĳ <jelmer@jelmer.uk>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Compatibility tests for git check-attr functionality."""
+
+import os
+import shutil
+import tempfile
+from collections.abc import Sequence
+
+from dulwich.attrs import AttributeValue, GitAttributes
+from dulwich.repo import Repo
+
+from .utils import CompatTestCase, run_git_or_fail
+
+
+class CheckAttrCompatTestCase(CompatTestCase):
+    """Test that dulwich matches git check-attr.
+
+    Both read .gitattributes patterns with wildmatch() under WM_PATHNAME, the
+    same matcher .gitignore uses, so the pattern grammar is shared with
+    tests.compat.test_check_ignore.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.test_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.test_dir)
+        self.repo = Repo.init(self.test_dir)
+        self.addCleanup(self.repo.close)
+
+    def _write_gitattributes(self, content: str) -> None:
+        path = os.path.join(self.test_dir, ".gitattributes")
+        with open(path, "w") as f:
+            f.write(content)
+
+    def _create_file(self, path: str) -> None:
+        full_path = os.path.join(self.test_dir, path)
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        with open(full_path, "w"):
+            pass
+
+    def _git_check_attr(
+        self, attr: str, paths: Sequence[str]
+    ) -> dict[str, AttributeValue]:
+        """Return each path's value for attr, as git reports it."""
+        output = run_git_or_fail(
+            ["check-attr", "-z", attr, "--", *paths], cwd=self.test_dir
+        )
+        # -z emits a flat NUL-separated run of (path, attr, value) triples.
+        fields = output.split(b"\0")
+        result: dict[str, AttributeValue] = {}
+        for i in range(0, len(fields) - 2, 3):
+            path, _name, value = fields[i : i + 3]
+            if value == b"unspecified":
+                continue
+            if value == b"set":
+                result[path.decode()] = True
+            elif value == b"unset":
+                result[path.decode()] = False
+            else:
+                result[path.decode()] = value
+        return result
+
+    def _dulwich_check_attr(
+        self, attr: str, paths: Sequence[str]
+    ) -> dict[str, AttributeValue]:
+        """Return each path's value for attr, as dulwich reports it."""
+        attrs = GitAttributes.from_path(self.test_dir)
+        name = attr.encode()
+        result: dict[str, AttributeValue] = {}
+        for path in paths:
+            matched = attrs.match_path(path.encode())
+            if name in matched and matched[name] is not None:
+                result[path] = matched[name]
+        return result
+
+    def _assert_attr_match(self, attr: str, paths: Sequence[str]) -> None:
+        self.assertEqual(
+            self._git_check_attr(attr, paths),
+            self._dulwich_check_attr(attr, paths),
+            f"attr {attr!r} over {list(paths)}",
+        )
+
+    def test_basic_attributes(self) -> None:
+        self._write_gitattributes("*.c text\n*.bin -text\n*.dat !text\n")
+        paths = ["a.c", "a.bin", "a.dat", "a.txt", "sub/a.c"]
+        for path in paths:
+            self._create_file(path)
+        self._assert_attr_match("text", paths)
+
+    def test_attribute_values(self) -> None:
+        self._write_gitattributes("*.c diff=cpp\n*.py diff=python\n*.o -diff\n")
+        paths = ["a.c", "a.py", "a.o", "a.txt"]
+        for path in paths:
+            self._create_file(path)
+        self._assert_attr_match("diff", paths)
+
+    def test_later_pattern_wins(self) -> None:
+        self._write_gitattributes("*.txt text\nbig.txt -text\n*.md text\n")
+        paths = ["a.txt", "big.txt", "a.md"]
+        for path in paths:
+            self._create_file(path)
+        self._assert_attr_match("text", paths)
+
+    def test_anchored_and_directory_patterns(self) -> None:
+        self._write_gitattributes("/root.c text\nsub/nested.c text\ndir/ text\n")
+        paths = [
+            "root.c",
+            "deep/root.c",
+            "sub/nested.c",
+            "deep/sub/nested.c",
+            "dir/file",
+        ]
+        for path in paths:
+            self._create_file(path)
+        self._assert_attr_match("text", paths)
+
+    def test_double_asterisk_is_a_whole_component(self) -> None:
+        # "a**b" is not slash-crossing: ** is only special as a full path
+        # component, so it behaves like a single '*' here.
+        self._write_gitattributes("a**b text\n**/deep text\nx/**/y text\n")
+        paths = ["ab", "axb", "a/x/b", "deep", "n/deep", "x/y", "x/m/y", "x/m/n/y"]
+        for path in paths:
+            self._create_file(path)
+        self._assert_attr_match("text", paths)
+
+    def test_wildcards_do_not_cross_slash(self) -> None:
+        self._write_gitattributes("a*c text\na?c text\n")
+        paths = ["abc", "ac", "a/c", "abbc", "axc"]
+        for path in paths:
+            self._create_file(path)
+        self._assert_attr_match("text", paths)
+
+    def test_bracket_expression_grammar(self) -> None:
+        """Test the bracket grammar against git, as test_check_ignore does.
+
+        wildmatch() takes '^' as a negation character, understands [:name:]
+        classes, lets a backslash escape a member and never matches '/'.
+        """
+        paths = [
+            "a",
+            "b",
+            "c",
+            "d",
+            "z",
+            "Q",
+            "0",
+            "9",
+            "-",
+            "^",
+            "]",
+            "[",
+            "abc",
+            "a-c",
+            "sub/a",
+            "sub/0",
+        ]
+        for path in paths:
+            self._create_file(path)
+
+        patterns = [
+            "[abc]",
+            "[a-c]",
+            "[!a-c]",
+            "[^a-c]",
+            "[!0-9]",
+            "[^0-9]",
+            "[[:digit:]]",
+            "[[:alpha:]]",
+            "[[:punct:]]",
+            "[[:xdigit:]]",
+            "[![:digit:]]",
+            "[^[:digit:]]",
+            "[[:digit:]abc]",
+            "[a[:digit:]]",
+            "[]]",
+            "[]a]",
+            "[!]]",
+            "[\\]]",
+            "[\\[]",
+            "a[a\\-c]c",
+            "[a-]",
+            "[-a]",
+            "[z-a]",
+            "[a/c]",
+            "[!/]",
+            "[^/]",
+            "*[^a]",
+            "?[^a]",
+            "[[:digit:]]*",
+            "sub/[^a]",
+            "sub/[[:digit:]]",
+            "**/[[:digit:]]",
+        ]
+        for pattern in patterns:
+            self._write_gitattributes(pattern + " text\n")
+            self.assertEqual(
+                self._git_check_attr("text", paths),
+                self._dulwich_check_attr("text", paths),
+                f"pattern: {pattern}",
+            )
+
+    def test_malformed_pattern_is_skipped(self) -> None:
+        """A malformed bracket expression matches nothing, and git keeps going.
+
+        wildmatch() returns WM_ABORT_ALL for these rather than treating the
+        file as broken, so the surrounding patterns must still apply.
+        """
+        self._write_gitattributes("*.[ch text\ngood.txt text\n")
+        paths = ["a.c", "a.h", "a.txt", "good.txt"]
+        for path in paths:
+            self._create_file(path)
+
+        # The bad line is dropped, so only good.txt has the attribute.
+        self.assertEqual({"good.txt": True}, self._git_check_attr("text", paths))
+        self._assert_attr_match("text", paths)
+
+    def test_unmatched_bracket_does_not_abort_file(self) -> None:
+        self._write_gitattributes("before.txt text\n[unclosed text\nafter.txt text\n")
+        paths = ["before.txt", "after.txt"]
+        for path in paths:
+            self._create_file(path)
+
+        self.assertEqual(
+            {"before.txt": True, "after.txt": True},
+            self._git_check_attr("text", paths),
+        )
+        self._assert_attr_match("text", paths)

--- a/tests/compat/test_check_ignore.py
+++ b/tests/compat/test_check_ignore.py
@@ -687,6 +687,98 @@ class CheckIgnoreCompatTestCase(CompatTestCase):
         ]
         self._assert_ignore_match(paths)
 
+    def test_bracket_expression_grammar(self) -> None:
+        """Test the whole bracket expression grammar against git.
+
+        git matches these with wildmatch(), which unlike fnmatch takes '^' as a
+        negation character, understands [:name:] classes, lets a backslash
+        escape a member, never matches '/' and gives up entirely on a malformed
+        class.
+        """
+        paths = [
+            "a",
+            "b",
+            "c",
+            "d",
+            "Q",
+            "z",
+            "0",
+            "9",
+            "_",
+            "^",
+            "!",
+            "]",
+            "[",
+            "ab",
+            "0a",
+            "a-c",
+            "abc",
+            "sub/a",
+            "sub/b",
+            "sub/0",
+        ]
+        for path in paths:
+            self._create_file(path)
+
+        # Patterns git's wildmatch() refuses outright, so nothing is ignored.
+        malformed = {"[abc", "[", "[]", "[!]", "[^]", "[[:foo:]]", "foo["}
+        patterns = [
+            "[abc]",
+            "[a-c]",
+            "[!a-c]",
+            "[^a-c]",
+            "[!0-9]",
+            "[^0-9]",
+            "[^^]",
+            "[[:digit:]]",
+            "[[:alpha:]]",
+            "[[:punct:]]",
+            "[[:xdigit:]]",
+            "[![:digit:]]",
+            "[^[:digit:]]",
+            "[[:digit:]abc]",
+            "[a[:digit:]]",
+            "[]]",
+            "[]a]",
+            "[!]]",
+            "[^]]",
+            "[\\]]",
+            "[\\[]",
+            "[x\\]y]",
+            "a[a\\-c]c",
+            "[a-]",
+            "[-a]",
+            "[a-c-]",
+            "[z-a]",
+            "[/-9]",
+            "[a/c]",
+            "[!/]",
+            "[^/]",
+            "*[^a]",
+            "?[^a]",
+            "[[:digit:]]*",
+            "*[[:digit:]]",
+            "sub/[^a]",
+            "sub/[[:digit:]]",
+            "**/[^a]",
+            "**/[[:digit:]]",
+            *sorted(malformed),
+        ]
+        for pattern in patterns:
+            self._write_gitignore(pattern + "\n")
+            git_ignored = self._git_check_ignore(paths)
+            # An erroring git would look like "nothing is ignored", so check
+            # that it really answered before comparing.
+            if pattern in malformed:
+                self.assertEqual(set(), git_ignored, f"pattern: {pattern}")
+            else:
+                self.assertNotEqual(set(), git_ignored, f"pattern: {pattern}")
+            self.assertEqual(
+                git_ignored,
+                self._dulwich_check_ignore(paths),
+                f"pattern: {pattern}",
+            )
+
     def test_mixed_single_double_asterisk_patterns(self) -> None:
         """Test patterns that mix single (*) and double (**) asterisks."""
         self._write_gitignore(

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -35,6 +35,7 @@ from dulwich.attrs import (
     parse_gitattributes_file,
     read_gitattributes,
 )
+from dulwich.wildmatch import MalformedPattern
 
 from . import TestCase
 
@@ -183,6 +184,10 @@ class ParseGitAttributesTests(TestCase):
 class PatternTests(TestCase):
     """Test the Pattern class."""
 
+    def test_malformed_raises(self):
+        """A malformed bracket expression raises rather than matching nothing."""
+        self.assertRaises(MalformedPattern, Pattern, b"a[bc")
+
     def test_exact_match(self):
         """Test exact filename matching without path."""
         pattern = Pattern(b"README.txt")
@@ -233,6 +238,58 @@ class PatternTests(TestCase):
         self.assertTrue(pattern.match(b"file_.txt"))
         self.assertFalse(pattern.match(b"file0.txt"))
         self.assertFalse(pattern.match(b"file5.txt"))
+
+    def test_caret_negated_character_class(self):
+        """Test '^' as a negation character, like git's wildmatch()."""
+        pattern = Pattern(b"file[^0-9].txt")
+        self.assertTrue(pattern.match(b"fileA.txt"))
+        self.assertTrue(pattern.match(b"file_.txt"))
+        self.assertFalse(pattern.match(b"file0.txt"))
+        self.assertFalse(pattern.match(b"file5.txt"))
+
+    def test_posix_character_class(self):
+        """Test POSIX [:name:] character classes."""
+        pattern = Pattern(b"file[[:digit:]].txt")
+        self.assertTrue(pattern.match(b"file0.txt"))
+        self.assertTrue(pattern.match(b"file9.txt"))
+        self.assertFalse(pattern.match(b"fileA.txt"))
+        self.assertFalse(pattern.match(b"file_.txt"))
+
+        pattern = Pattern(b"file[![:digit:]].txt")
+        self.assertTrue(pattern.match(b"fileA.txt"))
+        self.assertFalse(pattern.match(b"file0.txt"))
+
+    def test_character_class_escapes_and_brackets(self):
+        """Test escaped members and ']' as the first member."""
+        pattern = Pattern(b"file[a\\-c].txt")
+        self.assertTrue(pattern.match(b"filea.txt"))
+        self.assertTrue(pattern.match(b"file-.txt"))
+        self.assertTrue(pattern.match(b"filec.txt"))
+        self.assertFalse(pattern.match(b"fileb.txt"))
+        self.assertFalse(pattern.match(b"file\\.txt"))
+
+        pattern = Pattern(b"file[]a].txt")
+        self.assertTrue(pattern.match(b"file].txt"))
+        self.assertTrue(pattern.match(b"filea.txt"))
+        self.assertFalse(pattern.match(b"fileb.txt"))
+
+    def test_character_class_never_matches_slash(self):
+        """A bracket expression cannot match '/' under WM_PATHNAME."""
+        for pattern in (Pattern(b"a[!x]b"), Pattern(b"a[^x]b")):
+            self.assertTrue(pattern.match(b"acb"))
+            self.assertFalse(pattern.match(b"a/b"))
+
+    def test_malformed_character_class_raises(self):
+        """wildmatch() gives up on these; compiling one raises rather than
+        silently matching nothing."""
+        for pattern in (b"file[0-9.txt", b"file[", b"file[[:foo:]].txt"):
+            self.assertRaises(MalformedPattern, Pattern, pattern)
+
+    def test_double_asterisk_within_component(self):
+        """'**' is only special as a whole path component."""
+        pattern = Pattern(b"a**b")
+        self.assertTrue(pattern.match(b"axb"))
+        self.assertFalse(pattern.match(b"a/x/b"))
 
     def test_directory_pattern(self):
         """Test pattern with directory."""
@@ -343,6 +400,20 @@ class FileOperationsTests(TestCase):
         pattern, attrs = patterns[1]
         self.assertEqual(pattern.pattern, b"*.jpg")
         self.assertEqual(attrs, {b"text": False, b"binary": True})
+
+    def test_parse_gitattributes_file_skips_malformed_pattern(self):
+        """A malformed line is logged and skipped; the rest of the file still loads."""
+        with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+            f.write(b"*.txt text\n")
+            f.write(b"a[bc binary\n")
+            f.write(b"*.jpg -text binary\n")
+            temp_path = f.name
+
+        self.addCleanup(os.unlink, temp_path)
+
+        with self.assertLogs("dulwich.attrs", level="WARNING"):
+            patterns = parse_gitattributes_file(temp_path)
+        self.assertEqual([p.pattern for p, _ in patterns], [b"*.txt", b"*.jpg"])
 
     def test_read_gitattributes(self):
         """Test reading gitattributes from a directory."""

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -40,6 +40,7 @@ from dulwich.ignore import (
     translate,
 )
 from dulwich.repo import Repo
+from dulwich.wildmatch import MalformedPattern
 
 from . import TestCase
 
@@ -61,6 +62,10 @@ POSITIVE_MATCH_TESTS = [
     (b"foo/bar/", b"bar/"),
     (b"foo/bar/", b"bar"),
     (b"foo/bar/something", b"foo/bar/*"),
+    (b"foo.d", b"foo.[^ch]"),
+    (b"foo.5", b"foo.[[:digit:]]"),
+    (b"a-c", b"a[a\\-c]c"),
+    (b"a]c", b"a[]x]c"),
 ]
 
 NEGATIVE_MATCH_TESTS = [
@@ -70,6 +75,9 @@ NEGATIVE_MATCH_TESTS = [
     (b"foo/bar/", b"/bar/"),
     (b"foo/bar/", b"foo/bar/*"),
     (b"foo/bar", b"foo?bar"),
+    (b"foo.c", b"foo.[^ch]"),
+    (b"foo.x", b"foo.[[:digit:]]"),
+    (b"a/b", b"a[!x]b"),
 ]
 
 
@@ -89,6 +97,13 @@ TRANSLATE_TESTS = [
     (b"/foo\\[bar\\]", b"(?ms)foo\\[bar\\]/?\\Z"),
     (b"/foo[bar]", b"(?ms)foo[bar]/?\\Z"),
     (b"/foo[0-9]", b"(?ms)foo[0-9]/?\\Z"),
+    (b"/[!a-c]", b"(?ms)[^/a-c]/?\\Z"),
+    (b"/[^a-c]", b"(?ms)[^/a-c]/?\\Z"),
+    (b"/[[:digit:]]", b"(?ms)[0-9]/?\\Z"),
+    (b"/[![:digit:]x]", b"(?ms)[^/x0-9]/?\\Z"),
+    (b"/[a\\-c]", b"(?ms)[a\\-c]/?\\Z"),
+    (b"/[]a]", b"(?ms)[\\]a]/?\\Z"),
+    (b"/[a/c]", b"(?ms)[ac]/?\\Z"),
 ]
 
 
@@ -104,6 +119,10 @@ class TranslateTests(TestCase):
                 translate(pattern),
                 f"orig pattern: {pattern!r}, regex: {translate(pattern)!r}, expected: {regex!r}",
             )
+
+    def test_malformed_raises(self) -> None:
+        self.assertRaises(MalformedPattern, translate, b"/[abc")
+        self.assertRaises(MalformedPattern, translate, b"/[[:foo:]]")
 
     def test_collapses_consecutive_stars(self) -> None:
         # A run of '*' in a segment is redundant and must collapse to a
@@ -157,6 +176,114 @@ class MatchPatternTests(TestCase):
                 match_pattern(path, pattern),
                 f"path: {path!r}, pattern: {pattern!r}",
             )
+
+
+class BracketExpressionTests(TestCase):
+    """Bracket expressions follow Git's wildmatch(), not fnmatch.
+
+    The same patterns are checked against the real ``git check-ignore`` in
+    tests/compat/test_check_ignore.py.
+    """
+
+    def assertMatches(
+        self, pattern: bytes, matching: list[bytes], non_matching: list[bytes]
+    ) -> None:
+        for path in matching:
+            self.assertTrue(
+                match_pattern(path, pattern),
+                f"{pattern!r} should match {path!r}",
+            )
+        for path in non_matching:
+            self.assertFalse(
+                match_pattern(path, pattern),
+                f"{pattern!r} should not match {path!r}",
+            )
+
+    def test_caret_negates_class(self) -> None:
+        # wildmatch.c has NEGATE_CLASS '!' and NEGATE_CLASS2 '^'; both spellings
+        # invert the class rather than adding a literal member.
+        for pattern in (b"[!a-c]", b"[^a-c]"):
+            self.assertMatches(
+                pattern, [b"d", b"0", b"!", b"^", b"]"], [b"a", b"b", b"c"]
+            )
+        self.assertMatches(b"[^0-9]", [b"a", b"^"], [b"0", b"5", b"9"])
+
+    def test_posix_classes(self) -> None:
+        cases = [
+            (b"[[:alnum:]]", [b"a", b"Q", b"0"], [b"_", b"-"]),
+            (b"[[:alpha:]]", [b"a", b"Q"], [b"0", b"_"]),
+            (b"[[:blank:]]", [b" ", b"\t"], [b"a", b"\r"]),
+            (b"[[:cntrl:]]", [b"\x01", b"\x7f"], [b"a", b" "]),
+            (b"[[:digit:]]", [b"0", b"9"], [b"a", b"_"]),
+            (b"[[:graph:]]", [b"a", b"!", b"~"], [b" ", b"\t"]),
+            (b"[[:lower:]]", [b"a", b"z"], [b"Q", b"0"]),
+            (b"[[:print:]]", [b"a", b" "], [b"\x01", b"\x7f"]),
+            (b"[[:punct:]]", [b"!", b"_", b"]"], [b"a", b"0", b" "]),
+            (b"[[:space:]]", [b" ", b"\t", b"\r"], [b"a", b"0"]),
+            (b"[[:upper:]]", [b"Q"], [b"a", b"0"]),
+            (b"[[:xdigit:]]", [b"0", b"f", b"F"], [b"g", b"_"]),
+        ]
+        for pattern, matching, non_matching in cases:
+            self.assertMatches(pattern, matching, non_matching)
+
+    def test_posix_class_combined_with_members(self) -> None:
+        self.assertMatches(b"[[:digit:]abc]", [b"0", b"a"], [b"d", b"_"])
+        self.assertMatches(b"[![:digit:]]", [b"a", b"_"], [b"0", b"9"])
+        self.assertMatches(b"[[:digit:][:upper:]]", [b"0", b"Q"], [b"a"])
+
+    def test_posix_class_ascii_only(self) -> None:
+        # Git classifies through sane-ctype.h, whose table has no entries
+        # above 0x7f, so no high byte belongs to any class.
+        self.assertMatches(b"[[:alpha:]]", [b"a"], [b"\xc3", b"\xa9"])
+
+    def test_closing_bracket_first(self) -> None:
+        # A ']' straight after '[' or after the negation character is a member.
+        self.assertMatches(b"[]]", [b"]"], [b"a", b"["])
+        self.assertMatches(b"[]a]", [b"]", b"a"], [b"b"])
+        self.assertMatches(b"[!]]", [b"a", b"["], [b"]"])
+        self.assertMatches(b"[^]]", [b"a", b"["], [b"]"])
+
+    def test_backslash_escapes_member(self) -> None:
+        # A backslash escapes the next member, so [a\-c] is a, - and c -- not
+        # the range '\' to 'c'.
+        self.assertMatches(b"[a\\-c]", [b"a", b"-", b"c"], [b"b", b"\\", b"]"])
+        self.assertMatches(b"[\\]]", [b"]"], [b"\\", b"a"])
+        self.assertMatches(b"[x\\]y]", [b"x", b"]", b"y"], [b"\\"])
+        self.assertMatches(b"[\\\\]", [b"\\"], [b"a"])
+
+    def test_dash_is_literal_at_either_end(self) -> None:
+        self.assertMatches(b"[a-]", [b"a", b"-"], [b"b"])
+        self.assertMatches(b"[-a]", [b"a", b"-"], [b"b"])
+        self.assertMatches(b"[a-c-]", [b"a", b"b", b"c", b"-"], [b"d"])
+
+    def test_inverted_range(self) -> None:
+        # wildmatch() takes 'z' as a plain member before it reaches the '-',
+        # then the inverted range adds nothing, so only 'z' matches. re would
+        # reject the range outright.
+        self.assertMatches(b"[z-a]", [b"z"], [b"a", b"b", b"-"])
+        self.assertMatches(b"[9-0]", [b"9"], [b"0", b"5", b"-"])
+        self.assertMatches(b"[!z-a]", [b"a", b"-"], [b"z"])
+
+    def test_range_low_end_is_also_a_member(self) -> None:
+        self.assertMatches(b"[/-9]", [b"0", b"9"], [b"a", b"a/b"])
+        self.assertMatches(b"[\\a-c]", [b"a", b"b", b"c"], [b"\\"])
+
+    def test_never_matches_slash(self) -> None:
+        # WM_PATHNAME makes a bracket expression fail on '/' whether it is
+        # negated or lists the slash explicitly.
+        self.assertMatches(b"a[!x]b", [b"acb"], [b"a/b"])
+        self.assertMatches(b"a[^x]b", [b"acb"], [b"a/b"])
+        self.assertMatches(b"/[a/c]", [b"a", b"c"], [b"b"])
+        self.assertMatches(b"/[!/]", [b"a", b"0"], [b"a/b"])
+
+    def test_malformed_raises(self) -> None:
+        # wildmatch() returns WM_ABORT_ALL on these; constructing a Pattern
+        # from one raises rather than silently matching nothing.
+        for pattern in (b"[abc", b"[", b"[]", b"[!]", b"[^]", b"foo["):
+            self.assertRaises(MalformedPattern, match_pattern, b"a", pattern)
+
+    def test_unknown_posix_class_raises(self) -> None:
+        self.assertRaises(MalformedPattern, match_pattern, b"a", b"[[:foo:]]")
 
 
 class ParentExclusionTests(TestCase):
@@ -258,6 +385,16 @@ class IgnoreFilterTests(TestCase):
         self.assertIs(None, filter.is_ignored(b"c.c"))
         self.assertEqual([Pattern(b"a.c")], list(filter.find_matching(b"a.c")))
         self.assertEqual([], list(filter.find_matching(b"c.c")))
+
+    def test_malformed_pattern_raises(self) -> None:
+        self.assertRaises(MalformedPattern, Pattern, b"a[bc")
+
+    def test_malformed_pattern_skipped_with_warning(self) -> None:
+        with self.assertLogs("dulwich.ignore", level="WARNING"):
+            filter = IgnoreFilter([b"a.c", b"a[bc", b"b.c"])
+        # The malformed pattern is dropped; the good ones on either side load.
+        self.assertTrue(filter.is_ignored(b"a.c"))
+        self.assertTrue(filter.is_ignored(b"b.c"))
 
     def test_included_ignorecase(self) -> None:
         filter = IgnoreFilter([b"a.c", b"b.c"], ignorecase=False)

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -124,6 +124,13 @@ class TranslateTests(TestCase):
         self.assertRaises(MalformedPattern, translate, b"/[abc")
         self.assertRaises(MalformedPattern, translate, b"/[[:foo:]]")
 
+    def test_double_slash_matches_nothing(self) -> None:
+        # Git has no special case for "//"; the empty segment becomes a
+        # literal slash that no path can match.
+        for pattern in [b"a//b", b"//foo", b"foo//"]:
+            self.assertFalse(Pattern(pattern, False).match(b"a/b"))
+            self.assertFalse(Pattern(pattern, False).match(b"foo"))
+
     def test_collapses_consecutive_stars(self) -> None:
         # A run of '*' in a segment is redundant and must collapse to a
         # single quantifier so the regex does not contain adjacent

--- a/tests/test_line_ending.py
+++ b/tests/test_line_ending.py
@@ -259,6 +259,17 @@ class BlobNormalizerTests(TestCase):
         self.config = ConfigDict()
         self.gitattributes = {}
 
+    def test_malformed_pattern_skipped(self) -> None:
+        """A malformed pattern is skipped rather than aborting normalizer setup."""
+        gitattributes = {"*.[ch": {b"text": True}, "*.txt": {b"text": True}}
+        with self.assertLogs("dulwich.line_ending", level="WARNING"):
+            normalizer = BlobNormalizer(self.config, gitattributes, autocrlf=b"true")
+
+        blob = Blob()
+        blob.data = b"line1\r\nline2\r\n"
+        result = normalizer.checkin_normalize(blob, b"test.txt")
+        self.assertEqual(result.data, b"line1\nline2\n")
+
     def test_autocrlf_true_checkin(self) -> None:
         """Test checkin with autocrlf=true."""
         normalizer = BlobNormalizer(self.config, self.gitattributes, autocrlf=b"true")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -384,6 +384,22 @@ class RepositoryRootTests(TestCase):
         jpg_attrs = attrs.match_path(b"image.jpg")
         self.assertEqual(jpg_attrs, {b"text": False, b"binary": True})
 
+    def test_get_gitattributes_malformed_pattern(self) -> None:
+        # Git treats a malformed pattern as matching nothing rather than as a
+        # broken file, so the bad line is skipped and the rest still applies.
+        r = self.open_repo("a.git")
+        info_dir = os.path.join(r.controldir(), "info")
+        if not os.path.exists(info_dir):
+            os.makedirs(info_dir)
+        with open(os.path.join(info_dir, "attributes"), "wb") as f:
+            f.write(b"*.[ch text=auto\n")
+            f.write(b"*.txt text\n")
+
+        with self.assertLogs("dulwich.attrs", level="WARNING"):
+            attrs = r.get_gitattributes()
+        self.assertEqual(len(attrs), 1)
+        self.assertEqual(attrs.match_path(b"file.txt"), {b"text": True})
+
     def test_contains_missing(self) -> None:
         r = self.open_repo("a.git")
         self.assertNotIn(b"bar", r)

--- a/tests/test_wildmatch.py
+++ b/tests/test_wildmatch.py
@@ -122,6 +122,13 @@ class TranslateTests(TestCase):
         self.assertMatches(b"a\\*c", b"a*c")
         self.assertNotMatches(b"a\\*c", b"abc")
 
+    def test_empty_segment_is_a_literal_slash(self) -> None:
+        # wildmatch() has no special case for "//": each '/' is matched
+        # literally, so "a//b" matches only the text "a//b". Paths reaching
+        # dulwich.ignore are normalized, so nothing there can match it.
+        self.assertMatches(b"a//b", b"a//b")
+        self.assertNotMatches(b"a//b", b"a/b")
+
     def test_malformed_raises(self) -> None:
         self.assertRaises(MalformedPattern, translate, b"a[bc")
         self.assertRaises(MalformedPattern, translate, b"[[:bogus:]]")

--- a/tests/test_wildmatch.py
+++ b/tests/test_wildmatch.py
@@ -1,0 +1,127 @@
+# test_wildmatch.py -- tests for Git's wildmatch() pattern language
+# Copyright (C) 2026 Vincent Gao <gaobing1230@gmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+# Dulwich is dual-licensed under the Apache License, Version 2.0 and the GNU
+# General Public License as published by the Free Software Foundation; version 2.0
+# or (at your option) any later version. You can redistribute it and/or
+# modify it under the terms of either of these two licenses.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# You should have received a copy of the licenses; if not, see
+# <http://www.gnu.org/licenses/> for a copy of the GNU General Public License
+# and <http://www.apache.org/licenses/LICENSE-2.0> for a copy of the Apache
+# License, Version 2.0.
+#
+
+"""Tests for wildmatch pattern translation."""
+
+import re
+
+from dulwich.wildmatch import (
+    MalformedPattern,
+    translate,
+    translate_bracket_expression,
+)
+
+from . import TestCase
+
+
+class BracketExpressionTests(TestCase):
+    def assertBracketMatches(self, bracket: bytes, candidate: bytes) -> None:
+        self.assertTrue(self._matches(bracket, candidate))
+
+    def assertBracketNotMatches(self, bracket: bytes, candidate: bytes) -> None:
+        self.assertFalse(self._matches(bracket, candidate))
+
+    @staticmethod
+    def _matches(bracket: bytes, candidate: bytes) -> bool:
+        """Whether ``bracket`` (a full ``[...]`` expression) matches one byte."""
+        _, frag = translate_bracket_expression(bracket + b"Z", 1)
+        return re.compile(rb"^" + frag + rb"$").match(candidate) is not None
+
+    def test_posix_classes(self) -> None:
+        self.assertBracketMatches(b"[[:digit:]]", b"5")
+        self.assertBracketNotMatches(b"[[:digit:]]", b"a")
+        self.assertBracketMatches(b"[[:alpha:]]", b"a")
+        self.assertBracketNotMatches(b"[[:alpha:]]", b"1")
+        self.assertBracketMatches(b"[[:space:]]", b" ")
+        self.assertBracketMatches(b"[[:upper:]]", b"A")
+        self.assertBracketNotMatches(b"[[:upper:]]", b"a")
+
+    def test_negation(self) -> None:
+        self.assertBracketMatches(b"[^a-c]", b"d")
+        self.assertBracketNotMatches(b"[^a-c]", b"b")
+        self.assertBracketMatches(b"[!a-c]", b"d")
+        self.assertBracketNotMatches(b"[!a-c]", b"b")
+
+    def test_backslash_escapes_member(self) -> None:
+        self.assertBracketMatches(b"[a\\-c]", b"-")
+        self.assertBracketNotMatches(b"[a\\-c]", b"b")
+
+    def test_class_never_matches_slash(self) -> None:
+        self.assertBracketNotMatches(b"[^/]", b"/")
+
+    def test_inverted_range_keeps_low_end(self) -> None:
+        # Git takes "z" as a member before it sees the inverted "-a".
+        self.assertBracketMatches(b"[z-a]", b"z")
+        self.assertBracketNotMatches(b"[z-a]", b"a")
+
+    def test_composed_class(self) -> None:
+        self.assertBracketMatches(b"[[:digit:]a-f_]", b"_")
+        self.assertBracketMatches(b"[[:digit:]a-f_]", b"c")
+        self.assertBracketNotMatches(b"[[:digit:]a-f_]", b"g")
+
+    def test_malformed(self) -> None:
+        for pat in (b"[abc", b"[[:bogus:]]", b"[[:^alpha:]]"):
+            self.assertRaises(
+                MalformedPattern, translate_bracket_expression, pat + b"Z", 1
+            )
+
+
+class TranslateTests(TestCase):
+    def assertMatches(self, pattern: bytes, path: bytes) -> None:
+        self.assertTrue(self._matches(pattern, path))
+
+    def assertNotMatches(self, pattern: bytes, path: bytes) -> None:
+        self.assertFalse(self._matches(pattern, path))
+
+    @staticmethod
+    def _matches(pattern: bytes, path: bytes) -> bool:
+        regex = re.compile(rb"^" + translate(pattern) + rb"$")
+        return regex.match(path) is not None
+
+    def test_star_does_not_cross_slash(self) -> None:
+        self.assertMatches(b"a*c", b"abc")
+        self.assertNotMatches(b"a*c", b"a/c")
+
+    def test_question_mark(self) -> None:
+        self.assertMatches(b"a?c", b"abc")
+        self.assertNotMatches(b"a?c", b"a/c")
+
+    def test_double_asterisk_crosses_slash(self) -> None:
+        self.assertMatches(b"a/**/d", b"a/b/c/d")
+        self.assertMatches(b"a/**/d", b"a/d")
+        self.assertMatches(b"**/d", b"a/b/d")
+
+    def test_bracket(self) -> None:
+        self.assertMatches(b"a/[[:digit:]]", b"a/5")
+        self.assertNotMatches(b"a/[[:digit:]]", b"a/x")
+
+    def test_bracket_spanning_slash(self) -> None:
+        # Git never splits the pattern, so a class may span '/' but never match it.
+        self.assertMatches(b"x[b/c]y", b"xby")
+        self.assertNotMatches(b"x[b/c]y", b"x/y")
+
+    def test_escaped_wildcard(self) -> None:
+        self.assertMatches(b"a\\*c", b"a*c")
+        self.assertNotMatches(b"a\\*c", b"abc")
+
+    def test_malformed_raises(self) -> None:
+        self.assertRaises(MalformedPattern, translate, b"a[bc")
+        self.assertRaises(MalformedPattern, translate, b"[[:bogus:]]")


### PR DESCRIPTION
Follow Git's wildmatch() for .gitignore/.gitattributes bracket expressions

`_translate_segment()` and the twin code in `attrs.py` translated `[...]` with CPython fnmatch semantics: `[^a-c]` became the positive class `{^,a,b,c}`, POSIX classes like `[[:digit:]]` were unsupported, `[a\-c]` decayed into a range, a class could match `/`, malformed classes matched literally, and `[z-a]` raised `re.error`. Both modules now hand the whole pattern to one translator, the new public `dulwich.wildmatch`.

60 of 111 probed forms disagreed with `git check-ignore`. The new compat test diffs 46 patterns against real git; `dulwich.wildmatch` has its own unit tests (`tests/test_wildmatch.py`). Fixes #2326.
