### PR TITLE
don't grant other write for core.sharedRepository=all

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 1.2.13	UNRELEASED
 
+ * SECURITY: Stop granting write permission to other users for
+   ``core.sharedRepository = all``. ``parse_shared_repository`` returned masks
+   of ``0o666``/``0o2777``, so the control directory, loose objects, packs,
+   refs, the index and reflogs were chmodded world-writable, letting any local
+   user drop a hook or rewrite a ref in the repository. Git's
+   ``PERM_EVERYBODY`` grants others read, and execute on directories, but never
+   write. (Kartik Kenchi)
+
  * Always single-quote the repository path in the SSH command, matching git's
    ``sq_quote()``. ``shlex.quote`` left paths without shell metacharacters
    bare, which broke cloning from servers that parse the command themselves

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -422,8 +422,9 @@ def parse_shared_repository(
         return (0o664, 0o2775)
 
     if value_lower in ("all", "world", "everybody", "2"):
-        # World readable/writable (with setgid bit)
-        return (0o666, 0o2777)
+        # World readable (with setgid bit). Like git's PERM_EVERYBODY, others
+        # gain read, and execute on directories, but never write.
+        return (0o664, 0o2775)
 
     if value_lower == "umask":
         # Explicitly use umask

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -2246,11 +2246,31 @@ class SharedRepositoryTests(TestCase):
         repo = Repo.init_bare(tmp_dir, shared_repository="all")
         self.addCleanup(repo.close)
 
-        # Expected permissions for world sharing
-        expected_dir_mode = 0o2777  # setgid + rwxrwxrwx
-        expected_file_mode = 0o666  # rw-rw-rw-
+        # Expected permissions for world sharing. Others get read, and
+        # execute on directories, but no write bit.
+        expected_dir_mode = 0o2775  # setgid + rwxrwxr-x
+        expected_file_mode = 0o664  # rw-rw-r--
 
         self._check_permissions(repo, expected_file_mode, expected_dir_mode)
+
+    def test_init_bare_shared_all_not_world_writable(self):
+        """Test that sharedRepository=all never grants write to others."""
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+
+        os.umask(0)
+
+        repo = Repo.init_bare(tmp_dir, shared_repository="all")
+        self.addCleanup(repo.close)
+
+        for name in ("hooks", "refs", "objects", "info"):
+            path = os.path.join(repo.commondir(), name)
+            mode = self._get_file_mode(path)
+            self.assertEqual(
+                0,
+                mode & stat.S_IWOTH,
+                f"{name} is world-writable: {oct(mode)}",
+            )
 
     def test_init_bare_shared_umask(self):
         """Test initializing bare repo with sharedRepository=umask (default)."""
@@ -2326,7 +2346,7 @@ class SharedRepositoryTests(TestCase):
 
         # Check file permissions
         actual_mode = self._get_file_mode(obj_path)
-        expected_mode = 0o666  # rw-rw-rw-
+        expected_mode = 0o664  # rw-rw-r--
         self.assertEqual(
             expected_mode,
             actual_mode,


### PR DESCRIPTION
1. `parse_shared_repository` maps `core.sharedRepository` = `all`/`world`/`everybody`/`2` to `(0o666, 0o2777)`, so every path it governs is chmodded writable by any user on the machine.
2. those masks reach the control dir, loose objects, packs, refs, the index and reflogs through `_init_maybe_bare` and `DiskObjectStore.from_config`, so `.git/hooks` and `.git/refs/heads` end up `02777` and a local user can drop a hook or rewrite a ref in someone else's repository.

Returned git's `PERM_EVERYBODY` values instead (`0o664` file, `0o2775` directory). Others keep the read bit that separates `all` from `group`, and execute on directories, but not write. The explicit-octal branch is left alone since that is stated user intent.

Checked against git 2.39: `git init --shared=all` gives `775` for `.git/hooks`, `.git/refs` and `.git/objects`, and `664` for `.git/config`. In `path.c`, `PERM_EVERYBODY` is `0664` and the directory tweak only copies read bits into execute bits (`tweak |= (tweak & 0444) >> 2`), so write for others is never set.

Before the change, with umask 0:

```
$ python -c "from dulwich.repo import Repo; Repo.init('/tmp/r', shared_repository='all')"
$ stat -c '%a %n' /tmp/r/.git/hooks /tmp/r/.git/refs/heads /tmp/r/.git/objects
2777 /tmp/r/.git/hooks
2777 /tmp/r/.git/refs/heads
2777 /tmp/r/.git/objects
```

After it, the same walk finds no world-writable entry under `.git`.

Two existing tests in `SharedRepositoryTests` asserted the old masks and are updated. Added `test_init_bare_shared_all_not_world_writable`, which fails on the unpatched tree with `hooks is world-writable: 0o2777`. `tests/test_repository.py` and `tests/test_object_store.py` pass, and ruff check, ruff format and codespell are clean.
