### PR TITLE
Guard update_working_tree against symlinked leading dirs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,12 @@
 1.2.13	UNRELEASED
 
+ * Extend the ``verify_leading_dirs`` symlink guard to
+   ``update_working_tree`` (used by ``pull``, ``merge`` and ``checkout``).
+   The 1.2.12 fix only covered ``build_index_from_tree``, so a tree pairing a
+   symlink ``x`` with a descendant ``x/config`` could still write through the
+   link and overwrite ``.git/config`` on pull.
+   (Jelmer Vernooĳ, reported by Hugh Lewis)
+
  * Always single-quote the repository path in the SSH command, matching git's
    ``sq_quote()``. ``shlex.quote`` left paths without shell metacharacters
    bare, which broke cloning from servers that parse the command themselves

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -3125,6 +3125,9 @@ def update_working_tree(
             # leaving any changes already applied in place.
             if not validate_path(path, validate_path_element):
                 raise InvalidPathError(path)
+            # Refuse to write through a symlinked leading directory that
+            # would let open(..., "wb") escape the work tree.
+            verify_leading_dirs(path, [], repo_path)
             full_path = _tree_to_fs_path(repo_path, path, tree_encoding)
             try:
                 modify_stat: os.stat_result | None = os.lstat(full_path)

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -3431,6 +3431,45 @@ class TestUpdateWorkingTree(TestCase):
         update_working_tree(self.repo, tree1.id, tree3.id, change_iterator=changes)
         self.assertFalse(os.path.exists(link_path))
 
+    def test_update_working_tree_leading_symlink_not_followed(self):
+        """An entry below an on-disk symlink must not be written through it."""
+        if sys.platform == "win32":
+            self.skipTest("Symlinks not fully supported on Windows")
+
+        outside_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, outside_dir)
+        outside_file = os.path.join(outside_dir, "payload")
+
+        link = Blob.from_string(os.fsencode(outside_dir))
+        self.repo.object_store.add_object(link)
+
+        tree1 = Tree()
+        tree1[b"link"] = (0o120000, link.id)
+        self.repo.object_store.add_object(tree1)
+
+        changes = tree_changes(self.repo.object_store, None, tree1.id)
+        update_working_tree(self.repo, None, tree1.id, change_iterator=changes)
+        self.assertTrue(os.path.islink(os.path.join(self.tempdir, "link")))
+
+        # The symlink is retained and a descendant "link/payload" is added.
+        regular = Blob.from_string(b"pwned")
+        self.repo.object_store.add_object(regular)
+        tree2 = Tree()
+        tree2[b"link"] = (0o120000, link.id)
+        tree2[b"link/payload"] = (0o100644, regular.id)
+        self.repo.object_store.add_object(tree2)
+
+        changes = tree_changes(self.repo.object_store, tree1.id, tree2.id)
+        self.assertRaises(
+            InvalidPathError,
+            update_working_tree,
+            self.repo,
+            tree1.id,
+            tree2.id,
+            change_iterator=changes,
+        )
+        self.assertFalse(os.path.exists(outside_file))
+
     def test_update_working_tree_modified_file_to_dir_transition(self):
         """Test that modified files are not removed when they should be directories."""
         # Create tree with file


### PR DESCRIPTION
The 1.2.12 symlink-traversal fix only added verify_leading_dirs to build_index_from_tree, leaving the update_working_tree path (pull, merge, checkout) unguarded. A tree pairing a symlink x with a descendant x/config wrote through the link, letting a remote overwrite .git/config on pull.