### PR TITLE
Add Pack.unkeep() to remove a pack's .keep file

### DIFF
--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -4504,6 +4504,20 @@ class Pack:
                 keepfile.write(b"\n")
         return keepfile_name
 
+    def unkeep(self) -> bool:
+        """Remove the .keep file for the pack, allowing git to garbage collect it.
+
+        This is the counterpart of :meth:`keep`. It is not an error to call
+        this on a pack that has no .keep file.
+
+        Returns: True if a .keep file was removed, False if there was none.
+        """
+        try:
+            os.unlink(f"{self._basename}.keep")
+        except FileNotFoundError:
+            return False
+        return True
+
     def get_ref(
         self, sha: RawObjectID | ObjectID
     ) -> tuple[int | None, int, OldUnpackedObject]:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -829,6 +829,25 @@ class TestPack(PackTests):
             buf = f.read()
             self.assertEqual(msg + b"\n", buf)
 
+    def test_unkeep(self) -> None:
+        with self.get_pack(pack1_sha) as p:
+            p = self._copy_pack(p)
+
+        with p:
+            keepfile_name = p.keep()
+            self.assertTrue(os.path.exists(keepfile_name))
+
+            self.assertTrue(p.unkeep())
+            self.assertFalse(os.path.exists(keepfile_name))
+
+    def test_unkeep_no_keepfile(self) -> None:
+        with self.get_pack(pack1_sha) as p:
+            p = self._copy_pack(p)
+
+        # Removing a .keep file that was never created is not an error.
+        with p:
+            self.assertFalse(p.unkeep())
+
     def test_name(self) -> None:
         with self.get_pack(pack1_sha) as p:
             self.assertEqual(pack1_sha, p.name())


### PR DESCRIPTION
Pack.keep() creates a .keep file to stop git from garbage collecting a pack, but there is no supported way to remove one again, so callers have to reconstruct the path from the private _basename attribute and unlink it themselves.

This comes up whenever a .keep file is used for its intended purpose of protecting a pack only while it is being wired up: a server receiving a push keeps the incoming pack so a concurrent gc cannot delete objects the refs do not point at yet, then drops the .keep once the refs are updated.

Add the counterpart to keep(). Removing a .keep file that does not exist is not treated as an error, since the common use is an unconditional cleanup in a finally block; the return value distinguishes the two cases for callers that care.