### PR TITLE
Support uploadpack.allow*SHA1InWant on the server

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,6 +28,13 @@
    read from a buffer; the existing read-callable variants remain for streams.
    (Bojan Zivanovic, Jelmer Vernooĳ)
 
+ * Support ``uploadpack.allowTipSHA1InWant``,
+   ``uploadpack.allowReachableSHA1InWant`` and
+   ``uploadpack.allowAnySHA1InWant`` in ``UploadPackHandler``: unadvertised
+   wants are validated against the configured policy and the corresponding
+   capabilities are advertised. All three remain disabled by default.
+   (Bojan Zivanovic)
+
  * Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
    (``dulwich.object_store``). Both re-expanded a commit once per path that
    reached it, so a merge-heavy history walked in exponential time.

--- a/contrib/swift.py
+++ b/contrib/swift.py
@@ -88,7 +88,7 @@ from dulwich.pack import (
 )
 from dulwich.protocol import TCP_GIT_PORT, split_peeled_refs, write_info_refs
 from dulwich.refs import HEADREF, Ref, RefsContainer, read_info_refs
-from dulwich.repo import OBJECTDIR, BaseRepo
+from dulwich.repo import OBJECTDIR, BaseRepo, SHA1InWantPolicy
 from dulwich.server import Backend, BackendRepo, TCPGitServer
 
 from .greenthreads import GreenThreadsMissingObjectFinder
@@ -1181,6 +1181,14 @@ class SwiftRepo(BaseRepo):
         Returns: True if permissions can be trusted, False otherwise.
         """
         return False
+
+    def get_sha1_in_want_policy(self) -> SHA1InWantPolicy:
+        """Return the policy for serving unadvertised objects.
+
+        Swift repositories do not provide access to Git configuration, so use
+        Git's default policy of refusing all unadvertised wants.
+        """
+        return SHA1InWantPolicy()
 
     def _put_named_file(self, filename: str, contents: bytes) -> None:
         """Put an object in a Swift container.

--- a/contrib/test_swift.py
+++ b/contrib/test_swift.py
@@ -32,6 +32,7 @@ from unittest import skipIf
 from dulwich.object_format import DEFAULT_OBJECT_FORMAT
 from dulwich.objects import Blob, Commit, Tag, Tree, parse_timezone
 from dulwich.pack import OFS_DELTA, MemoryPackIndex, Pack
+from dulwich.repo import SHA1InWantPolicy
 from dulwich.tests.utils import build_pack
 from tests import TestCase
 from tests.test_object_store import ObjectStoreTests
@@ -306,6 +307,17 @@ class TestSwiftRepo(TestCase):
             desc = b"Fake repo"
             repo._put_named_file("description", desc)
         self.assertEqual(repo.scon.store["fakerepo/description"], desc)
+
+    def test_sha1_in_want_policy_defaults_to_disabled(self) -> None:
+        store = {"fakerepo/objects/pack": ""}
+        with patch(
+            "contrib.swift.SwiftConnector",
+            new_callable=create_swift_connector,
+            store=store,
+        ):
+            repo = swift.SwiftRepo("fakerepo", conf=self.conf)
+
+        self.assertEqual(SHA1InWantPolicy(), repo.get_sha1_in_want_policy())
 
     def test_init_bare(self) -> None:
         fsc = FakeSwiftConnector("fakeroot", conf=self.conf)

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -66,6 +66,7 @@ import sys
 import time
 import warnings
 from collections.abc import Callable, Generator, Iterable, Iterator, Mapping, Sequence
+from dataclasses import dataclass
 from io import BytesIO
 from types import TracebackType
 from typing import (
@@ -552,6 +553,20 @@ class ParentsProvider:
             commit = obj
         result: list[ObjectID] = commit.parents
         return result
+
+
+@dataclass(frozen=True)
+class SHA1InWantPolicy:
+    """Which unadvertised objects a client may request from upload-pack.
+
+    Mirrors git's ``uploadpack.allowAnySHA1InWant``,
+    ``uploadpack.allowReachableSHA1InWant`` and
+    ``uploadpack.allowTipSHA1InWant`` options.
+    """
+
+    allow_any: bool = False
+    allow_reachable: bool = False
+    allow_tip: bool = False
 
 
 class BaseRepo:
@@ -1162,6 +1177,28 @@ class BaseRepo:
 
         backends += StackedConfig.default_backends()
         return StackedConfig(backends, writable=local_config)
+
+    def get_sha1_in_want_policy(self) -> SHA1InWantPolicy:
+        """Read the uploadpack.allow*SHA1InWant settings for this repository.
+
+        Returns: The configured policy. ``allowAnySHA1InWant`` implies the
+            other two options, as in git. All three default to false.
+        """
+        config = self.get_config_stack()
+
+        def get(name: bytes) -> bool:
+            try:
+                return bool(config.get_boolean((b"uploadpack",), name, False))
+            except ValueError:
+                logger.warning("Ignoring invalid uploadpack.%s value", name.decode())
+                return False
+
+        allow_any = get(b"allowAnySHA1InWant")
+        return SHA1InWantPolicy(
+            allow_any=allow_any,
+            allow_reachable=allow_any or get(b"allowReachableSHA1InWant"),
+            allow_tip=allow_any or get(b"allowTipSHA1InWant"),
+        )
 
     def get_shallow(self) -> set[ObjectID]:
         """Get the set of shallow commits.

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -555,7 +555,7 @@ class ParentsProvider:
         return result
 
 
-@dataclass(frozen=True)
+@dataclass
 class SHA1InWantPolicy:
     """Which unadvertised objects a client may request from upload-pack.
 
@@ -567,6 +567,12 @@ class SHA1InWantPolicy:
     allow_any: bool = False
     allow_reachable: bool = False
     allow_tip: bool = False
+
+    def __post_init__(self) -> None:
+        # As in git, allowing any object implies the two narrower options.
+        if self.allow_any:
+            self.allow_reachable = True
+            self.allow_tip = True
 
 
 class BaseRepo:
@@ -1181,23 +1187,21 @@ class BaseRepo:
     def get_sha1_in_want_policy(self) -> SHA1InWantPolicy:
         """Read the uploadpack.allow*SHA1InWant settings for this repository.
 
-        Returns: The configured policy. ``allowAnySHA1InWant`` implies the
-            other two options, as in git. All three default to false.
+        Returns: The configured policy. All three options default to false.
         """
         config = self.get_config_stack()
 
         def get(name: bytes) -> bool:
             try:
-                return bool(config.get_boolean((b"uploadpack",), name, False))
+                return config.get_boolean((b"uploadpack",), name, False)
             except ValueError:
                 logger.warning("Ignoring invalid uploadpack.%s value", name.decode())
                 return False
 
-        allow_any = get(b"allowAnySHA1InWant")
         return SHA1InWantPolicy(
-            allow_any=allow_any,
-            allow_reachable=allow_any or get(b"allowReachableSHA1InWant"),
-            allow_tip=allow_any or get(b"allowTipSHA1InWant"),
+            allow_any=get(b"allowAnySHA1InWant"),
+            allow_reachable=get(b"allowReachableSHA1InWant"),
+            allow_tip=get(b"allowTipSHA1InWant"),
         )
 
     def get_shallow(self) -> set[ObjectID]:

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -112,6 +112,8 @@ from .pack import ObjectContainer, write_pack_from_container
 from .protocol import (
     CAPABILITIES_REF,
     CAPABILITY_AGENT,
+    CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT,
+    CAPABILITY_ALLOW_TIP_SHA1_IN_WANT,
     CAPABILITY_ATOMIC,
     CAPABILITY_DELETE_REFS,
     CAPABILITY_FILTER,
@@ -162,6 +164,9 @@ from .refs import Ref, RefsContainer
 from .repo import Repo
 
 logger = log_utils.getLogger(__name__)
+
+# Maximum number of nested tag objects to follow when peeling to a commit.
+_MAX_TAG_PEEL_DEPTH = 100
 
 
 class Backend:
@@ -455,6 +460,29 @@ class PackHandler(Handler):
         self._done_received = True
 
 
+def _peel_to_commit(object_store: "BaseObjectStore", sha: ObjectID) -> ObjectID | None:
+    """Peel an object down to a commit.
+
+    Args:
+      object_store: Object store to look objects up in.
+      sha: Object ID to peel.
+    Returns: The object ID of the commit, or None if sha is missing or does
+        not peel to a commit.
+    """
+    # Bounded so that a cycle of tag objects cannot spin forever.
+    for _ in range(_MAX_TAG_PEEL_DEPTH):
+        try:
+            obj = object_store[sha]
+        except KeyError:
+            return None
+        if obj.type_name == b"commit":
+            return sha
+        if obj.type_name != b"tag":
+            return None
+        sha = obj.object[1]  # type: ignore[attr-defined]
+    return None
+
+
 class UploadPackHandler(PackHandler):
     """Protocol handler for uploading a pack to the client."""
 
@@ -485,6 +513,8 @@ class UploadPackHandler(PackHandler):
         self._processing_have_lines = False
         # Filter specification for partial clone support
         self.filter_spec: FilterSpec | None = None
+        self._sha1_in_want_policy: tuple[bool, bool, bool] | None = None
+        self._sha1_in_want_ref_tips: set[ObjectID] | None = None
 
     def capabilities(self) -> list[bytes]:
         """Return the list of capabilities supported by upload-pack.
@@ -492,7 +522,7 @@ class UploadPackHandler(PackHandler):
         Returns:
             List of capabilities including object-format for the repository
         """
-        return [
+        caps = [
             CAPABILITY_MULTI_ACK_DETAILED,
             CAPABILITY_MULTI_ACK,
             CAPABILITY_SIDE_BAND_64K,
@@ -505,6 +535,133 @@ class UploadPackHandler(PackHandler):
             CAPABILITY_FILTER,
             capability_object_format(self.repo.object_format.name),
         ]
+        _allow_any, allow_reachable, allow_tip = self._get_sha1_in_want_policy()
+        if allow_tip:
+            caps.append(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT)
+        if allow_reachable:
+            caps.append(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT)
+        return caps
+
+    def _get_sha1_in_want_policy(self) -> tuple[bool, bool, bool]:
+        """Read the uploadpack.allow*SHA1InWant settings for this repository.
+
+        Returns: A (any, reachable, tip) tuple of booleans. Setting
+            ``allowAnySHA1InWant`` implies the other two, as in git.
+        """
+        if self._sha1_in_want_policy is None:
+            get_config_stack = getattr(self.repo, "get_config_stack", None)
+            if not callable(get_config_stack):
+                # BackendRepo intentionally does not require configuration
+                # access. Preserve compatibility with custom backends by
+                # leaving all opt-in policies disabled when it is unavailable.
+                self._sha1_in_want_policy = (False, False, False)
+                return self._sha1_in_want_policy
+            config = get_config_stack()
+
+            def get(name: bytes) -> bool:
+                try:
+                    return bool(config.get_boolean((b"uploadpack",), name, False))
+                except ValueError:
+                    logger.warning(
+                        "Ignoring invalid uploadpack.%s value", name.decode()
+                    )
+                    return False
+
+            allow_any = get(b"allowAnySHA1InWant")
+            self._sha1_in_want_policy = (
+                allow_any,
+                allow_any or get(b"allowReachableSHA1InWant"),
+                allow_any or get(b"allowTipSHA1InWant"),
+            )
+        return self._sha1_in_want_policy
+
+    def is_want_allowed(self, sha: ObjectID) -> bool:
+        """Check whether the client may ask for an object that was not advertised.
+
+        Mirrors git's ``uploadpack.allowAnySHA1InWant``,
+        ``uploadpack.allowReachableSHA1InWant`` and
+        ``uploadpack.allowTipSHA1InWant`` options. All default to false, so by
+        default a client may only ask for objects that were advertised to it.
+
+        Note that ``allowReachableSHA1InWant`` may need to walk the whole
+        commit graph to answer a single want, which is why git leaves it off
+        by default.
+
+        Args:
+          sha: Object ID the client asked for.
+        Returns: True if the object may be served to the client.
+        """
+        return sha in self.allowed_wants({sha})
+
+    def allowed_wants(self, wants: set[ObjectID]) -> set[ObjectID]:
+        """Return the unadvertised wants permitted by this repository.
+
+        Reachability for the entire request is checked in one graph walk so
+        its cost does not grow linearly with the number of want lines.
+
+        Args:
+          wants: Distinct, unadvertised object IDs requested by the client.
+        Returns: The subset of wants that may be served to the client.
+        """
+        if not wants:
+            return set()
+
+        allow_any, allow_reachable, allow_tip = self._get_sha1_in_want_policy()
+        if not (allow_any or allow_reachable or allow_tip):
+            return set()
+
+        existing = {sha for sha in wants if sha in self.repo.object_store}
+        if allow_any:
+            return existing
+
+        # Both of the remaining options accept the tip of any ref, including
+        # refs that were never advertised to this client.
+        tips = self._ref_tips()
+        allowed = existing & tips
+        if not allow_reachable:
+            return allowed
+        allowed.update(self._reachable_wants(existing - allowed, tips))
+        return allowed
+
+    def _ref_tips(self) -> set[ObjectID]:
+        """Return the exact object IDs at the tips of every ref."""
+        if self._sha1_in_want_ref_tips is None:
+            self._sha1_in_want_ref_tips = set(self.repo.get_refs().values())
+        return self._sha1_in_want_ref_tips
+
+    def _reachable_wants(
+        self, wants: set[ObjectID], tips: set[ObjectID]
+    ) -> set[ObjectID]:
+        """Return wants that peel to commits reachable from the ref tips."""
+        object_store = self.repo.object_store
+        targets: dict[ObjectID, set[ObjectID]] = {}
+        for want in wants:
+            target = _peel_to_commit(object_store, want)
+            if target is not None:
+                targets.setdefault(target, set()).add(want)
+
+        pending = []
+        for tip in tips:
+            commit_id = _peel_to_commit(object_store, tip)
+            if commit_id is not None:
+                pending.append(commit_id)
+
+        seen: set[ObjectID] = set()
+        reachable: set[ObjectID] = set()
+        while pending and targets:
+            commit_id = pending.pop()
+            if commit_id in seen:
+                continue
+            seen.add(commit_id)
+            matching_wants = targets.pop(commit_id, None)
+            if matching_wants is not None:
+                reachable.update(matching_wants)
+            try:
+                commit = object_store[commit_id]
+            except KeyError:
+                continue
+            pending.extend(commit.parents)  # type: ignore[attr-defined]
+        return reachable
 
     @classmethod
     def required_capabilities(cls) -> tuple[bytes, ...]:
@@ -949,12 +1106,20 @@ class _ProtocolGraphWalker:
         command, sha_result = _split_proto_line(line, allowed)
 
         want_revs: list[ObjectID] = []
+        seen_wants: set[ObjectID] = set()
         while command == COMMAND_WANT:
             assert isinstance(sha_result, bytes)
-            if sha_result not in values:
-                raise GitProtocolError(f"Client wants invalid object {sha_result!r}")
-            want_revs.append(ObjectID(sha_result))
+            want = ObjectID(sha_result)
+            if want not in seen_wants:
+                seen_wants.add(want)
+                want_revs.append(want)
             command, sha_result = self.read_proto_line(allowed)
+
+        unadvertised = {want for want in want_revs if want not in values}
+        allowed_wants = self.handler.allowed_wants(unadvertised)
+        for want in want_revs:
+            if want in unadvertised and want not in allowed_wants:
+                raise GitProtocolError(f"Client wants invalid object {want!r}")
 
         self.set_wants(want_revs)
 

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -76,6 +76,7 @@ import zlib
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
 from functools import partial
 from typing import IO, TYPE_CHECKING
 from typing import Protocol as TypingProtocol
@@ -106,12 +107,19 @@ from .object_filters import (
     filter_pack_objects_with_paths,
     parse_filter_spec,
 )
-from .object_store import MissingObjectFinder, PackBasedObjectStore, find_shallow
+from .object_store import (
+    MissingObjectFinder,
+    PackBasedObjectStore,
+    find_shallow,
+    peel_sha,
+)
 from .objects import Commit, ObjectID, Tree, valid_hexsha
 from .pack import ObjectContainer, write_pack_from_container
 from .protocol import (
     CAPABILITIES_REF,
     CAPABILITY_AGENT,
+    CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT,
+    CAPABILITY_ALLOW_TIP_SHA1_IN_WANT,
     CAPABILITY_ATOMIC,
     CAPABILITY_DELETE_REFS,
     CAPABILITY_FILTER,
@@ -159,7 +167,7 @@ from .protocol import (
     write_info_refs,
 )
 from .refs import Ref, RefsContainer
-from .repo import Repo
+from .repo import BaseRepo, Repo
 
 logger = log_utils.getLogger(__name__)
 
@@ -455,6 +463,15 @@ class PackHandler(Handler):
         self._done_received = True
 
 
+@dataclass(frozen=True)
+class _SHA1InWantPolicy:
+    """Configured policy for unadvertised object requests."""
+
+    allow_any: bool = False
+    allow_reachable: bool = False
+    allow_tip: bool = False
+
+
 class UploadPackHandler(PackHandler):
     """Protocol handler for uploading a pack to the client."""
 
@@ -485,6 +502,8 @@ class UploadPackHandler(PackHandler):
         self._processing_have_lines = False
         # Filter specification for partial clone support
         self.filter_spec: FilterSpec | None = None
+        self._sha1_in_want_policy: _SHA1InWantPolicy | None = None
+        self._sha1_in_want_ref_tips: set[ObjectID] | None = None
 
     def capabilities(self) -> list[bytes]:
         """Return the list of capabilities supported by upload-pack.
@@ -492,7 +511,7 @@ class UploadPackHandler(PackHandler):
         Returns:
             List of capabilities including object-format for the repository
         """
-        return [
+        caps = [
             CAPABILITY_MULTI_ACK_DETAILED,
             CAPABILITY_MULTI_ACK,
             CAPABILITY_SIDE_BAND_64K,
@@ -505,6 +524,141 @@ class UploadPackHandler(PackHandler):
             CAPABILITY_FILTER,
             capability_object_format(self.repo.object_format.name),
         ]
+        policy = self._get_sha1_in_want_policy()
+        if policy.allow_tip:
+            caps.append(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT)
+        if policy.allow_reachable:
+            caps.append(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT)
+        return caps
+
+    def _get_sha1_in_want_policy(self) -> _SHA1InWantPolicy:
+        """Read the uploadpack.allow*SHA1InWant settings for this repository.
+
+        Returns: The configured policy. ``allowAnySHA1InWant`` implies the
+            other two options, as in git.
+        """
+        if self._sha1_in_want_policy is None:
+            if not isinstance(self.repo, BaseRepo):
+                # BackendRepo intentionally does not require configuration
+                # access. Preserve compatibility with custom backends by
+                # leaving all opt-in policies disabled when it is unavailable.
+                self._sha1_in_want_policy = _SHA1InWantPolicy()
+                return self._sha1_in_want_policy
+            config = self.repo.get_config_stack()
+
+            def get(name: bytes) -> bool:
+                try:
+                    return bool(config.get_boolean((b"uploadpack",), name, False))
+                except ValueError:
+                    logger.warning(
+                        "Ignoring invalid uploadpack.%s value", name.decode()
+                    )
+                    return False
+
+            allow_any = get(b"allowAnySHA1InWant")
+            self._sha1_in_want_policy = _SHA1InWantPolicy(
+                allow_any=allow_any,
+                allow_reachable=allow_any or get(b"allowReachableSHA1InWant"),
+                allow_tip=allow_any or get(b"allowTipSHA1InWant"),
+            )
+        return self._sha1_in_want_policy
+
+    def is_want_allowed(self, sha: ObjectID) -> bool:
+        """Check whether the client may ask for an object that was not advertised.
+
+        Mirrors git's ``uploadpack.allowAnySHA1InWant``,
+        ``uploadpack.allowReachableSHA1InWant`` and
+        ``uploadpack.allowTipSHA1InWant`` options. All default to false, so by
+        default a client may only ask for objects that were advertised to it.
+
+        Note that ``allowReachableSHA1InWant`` may need to walk the whole
+        commit graph to answer a single want, which is why git leaves it off
+        by default.
+
+        Args:
+          sha: Object ID the client asked for.
+        Returns: True if the object may be served to the client.
+        """
+        return sha in self.allowed_wants({sha})
+
+    def allowed_wants(self, wants: set[ObjectID]) -> set[ObjectID]:
+        """Return the unadvertised wants permitted by this repository.
+
+        Reachability for the entire request is checked in one graph walk so
+        its cost does not grow linearly with the number of want lines.
+
+        Args:
+          wants: Distinct, unadvertised object IDs requested by the client.
+        Returns: The subset of wants that may be served to the client.
+        """
+        if not wants:
+            return set()
+
+        policy = self._get_sha1_in_want_policy()
+        if not (policy.allow_any or policy.allow_reachable or policy.allow_tip):
+            return set()
+
+        existing = {sha for sha in wants if sha in self.repo.object_store}
+        if policy.allow_any:
+            return existing
+
+        # Both of the remaining options accept the tip of any ref, including
+        # refs that were never advertised to this client.
+        tips = self._ref_tips()
+        allowed = existing & tips
+        if not policy.allow_reachable:
+            return allowed
+        allowed.update(self._reachable_wants(existing - allowed, tips))
+        return allowed
+
+    def _ref_tips(self) -> set[ObjectID]:
+        """Return the exact object IDs at the tips of every ref."""
+        if self._sha1_in_want_ref_tips is None:
+            self._sha1_in_want_ref_tips = set(self.repo.get_refs().values())
+        return self._sha1_in_want_ref_tips
+
+    def _reachable_wants(
+        self, wants: set[ObjectID], tips: set[ObjectID]
+    ) -> set[ObjectID]:
+        """Return wants that peel to commits reachable from the ref tips."""
+        object_store = self.repo.object_store
+        targets: dict[ObjectID, set[ObjectID]] = {}
+        # Match git-rev-list semantics: annotated tags on either side are
+        # peeled before walking the commit graph.
+        for want in wants:
+            try:
+                _unpeeled, target = peel_sha(object_store, want)
+            except KeyError:
+                continue
+            if isinstance(target, Commit):
+                targets.setdefault(target.id, set()).add(want)
+
+        pending = []
+        for tip in tips:
+            try:
+                _unpeeled, target = peel_sha(object_store, tip)
+            except KeyError:
+                continue
+            if isinstance(target, Commit):
+                pending.append(target.id)
+
+        seen: set[ObjectID] = set()
+        reachable: set[ObjectID] = set()
+        while pending and targets:
+            commit_id = pending.pop()
+            if commit_id in seen:
+                continue
+            seen.add(commit_id)
+            matching_wants = targets.pop(commit_id, None)
+            if matching_wants is not None:
+                reachable.update(matching_wants)
+            try:
+                commit = object_store[commit_id]
+            except KeyError:
+                continue
+            assert isinstance(commit, Commit)
+            pending.extend(commit.parents)
+        return reachable
 
     @classmethod
     def required_capabilities(cls) -> tuple[bytes, ...]:
@@ -949,12 +1103,20 @@ class _ProtocolGraphWalker:
         command, sha_result = _split_proto_line(line, allowed)
 
         want_revs: list[ObjectID] = []
+        seen_wants: set[ObjectID] = set()
         while command == COMMAND_WANT:
             assert isinstance(sha_result, bytes)
-            if sha_result not in values:
-                raise GitProtocolError(f"Client wants invalid object {sha_result!r}")
-            want_revs.append(ObjectID(sha_result))
+            want = ObjectID(sha_result)
+            if want not in seen_wants:
+                seen_wants.add(want)
+                want_revs.append(want)
             command, sha_result = self.read_proto_line(allowed)
+
+        unadvertised = {want for want in want_revs if want not in values}
+        allowed_wants = self.handler.allowed_wants(unadvertised)
+        for want in want_revs:
+            if want in unadvertised and want not in allowed_wants:
+                raise GitProtocolError(f"Client wants invalid object {want!r}")
 
         self.set_wants(want_revs)
 

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -76,6 +76,7 @@ import zlib
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from collections.abc import Set as AbstractSet
+from dataclasses import dataclass
 from functools import partial
 from typing import IO, TYPE_CHECKING
 from typing import Protocol as TypingProtocol
@@ -106,7 +107,12 @@ from .object_filters import (
     filter_pack_objects_with_paths,
     parse_filter_spec,
 )
-from .object_store import MissingObjectFinder, PackBasedObjectStore, find_shallow
+from .object_store import (
+    MissingObjectFinder,
+    PackBasedObjectStore,
+    find_shallow,
+    peel_sha,
+)
 from .objects import Commit, ObjectID, Tree, valid_hexsha
 from .pack import ObjectContainer, write_pack_from_container
 from .protocol import (
@@ -161,12 +167,9 @@ from .protocol import (
     write_info_refs,
 )
 from .refs import Ref, RefsContainer
-from .repo import Repo
+from .repo import BaseRepo, Repo
 
 logger = log_utils.getLogger(__name__)
-
-# Maximum number of nested tag objects to follow when peeling to a commit.
-_MAX_TAG_PEEL_DEPTH = 100
 
 
 class Backend:
@@ -460,27 +463,13 @@ class PackHandler(Handler):
         self._done_received = True
 
 
-def _peel_to_commit(object_store: "BaseObjectStore", sha: ObjectID) -> ObjectID | None:
-    """Peel an object down to a commit.
+@dataclass(frozen=True)
+class _SHA1InWantPolicy:
+    """Configured policy for unadvertised object requests."""
 
-    Args:
-      object_store: Object store to look objects up in.
-      sha: Object ID to peel.
-    Returns: The object ID of the commit, or None if sha is missing or does
-        not peel to a commit.
-    """
-    # Bounded so that a cycle of tag objects cannot spin forever.
-    for _ in range(_MAX_TAG_PEEL_DEPTH):
-        try:
-            obj = object_store[sha]
-        except KeyError:
-            return None
-        if obj.type_name == b"commit":
-            return sha
-        if obj.type_name != b"tag":
-            return None
-        sha = obj.object[1]  # type: ignore[attr-defined]
-    return None
+    allow_any: bool = False
+    allow_reachable: bool = False
+    allow_tip: bool = False
 
 
 class UploadPackHandler(PackHandler):
@@ -513,7 +502,7 @@ class UploadPackHandler(PackHandler):
         self._processing_have_lines = False
         # Filter specification for partial clone support
         self.filter_spec: FilterSpec | None = None
-        self._sha1_in_want_policy: tuple[bool, bool, bool] | None = None
+        self._sha1_in_want_policy: _SHA1InWantPolicy | None = None
         self._sha1_in_want_ref_tips: set[ObjectID] | None = None
 
     def capabilities(self) -> list[bytes]:
@@ -535,28 +524,27 @@ class UploadPackHandler(PackHandler):
             CAPABILITY_FILTER,
             capability_object_format(self.repo.object_format.name),
         ]
-        _allow_any, allow_reachable, allow_tip = self._get_sha1_in_want_policy()
-        if allow_tip:
+        policy = self._get_sha1_in_want_policy()
+        if policy.allow_tip:
             caps.append(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT)
-        if allow_reachable:
+        if policy.allow_reachable:
             caps.append(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT)
         return caps
 
-    def _get_sha1_in_want_policy(self) -> tuple[bool, bool, bool]:
+    def _get_sha1_in_want_policy(self) -> _SHA1InWantPolicy:
         """Read the uploadpack.allow*SHA1InWant settings for this repository.
 
-        Returns: A (any, reachable, tip) tuple of booleans. Setting
-            ``allowAnySHA1InWant`` implies the other two, as in git.
+        Returns: The configured policy. ``allowAnySHA1InWant`` implies the
+            other two options, as in git.
         """
         if self._sha1_in_want_policy is None:
-            get_config_stack = getattr(self.repo, "get_config_stack", None)
-            if not callable(get_config_stack):
+            if not isinstance(self.repo, BaseRepo):
                 # BackendRepo intentionally does not require configuration
                 # access. Preserve compatibility with custom backends by
                 # leaving all opt-in policies disabled when it is unavailable.
-                self._sha1_in_want_policy = (False, False, False)
+                self._sha1_in_want_policy = _SHA1InWantPolicy()
                 return self._sha1_in_want_policy
-            config = get_config_stack()
+            config = self.repo.get_config_stack()
 
             def get(name: bytes) -> bool:
                 try:
@@ -568,10 +556,10 @@ class UploadPackHandler(PackHandler):
                     return False
 
             allow_any = get(b"allowAnySHA1InWant")
-            self._sha1_in_want_policy = (
-                allow_any,
-                allow_any or get(b"allowReachableSHA1InWant"),
-                allow_any or get(b"allowTipSHA1InWant"),
+            self._sha1_in_want_policy = _SHA1InWantPolicy(
+                allow_any=allow_any,
+                allow_reachable=allow_any or get(b"allowReachableSHA1InWant"),
+                allow_tip=allow_any or get(b"allowTipSHA1InWant"),
             )
         return self._sha1_in_want_policy
 
@@ -606,19 +594,19 @@ class UploadPackHandler(PackHandler):
         if not wants:
             return set()
 
-        allow_any, allow_reachable, allow_tip = self._get_sha1_in_want_policy()
-        if not (allow_any or allow_reachable or allow_tip):
+        policy = self._get_sha1_in_want_policy()
+        if not (policy.allow_any or policy.allow_reachable or policy.allow_tip):
             return set()
 
         existing = {sha for sha in wants if sha in self.repo.object_store}
-        if allow_any:
+        if policy.allow_any:
             return existing
 
         # Both of the remaining options accept the tip of any ref, including
         # refs that were never advertised to this client.
         tips = self._ref_tips()
         allowed = existing & tips
-        if not allow_reachable:
+        if not policy.allow_reachable:
             return allowed
         allowed.update(self._reachable_wants(existing - allowed, tips))
         return allowed
@@ -635,16 +623,24 @@ class UploadPackHandler(PackHandler):
         """Return wants that peel to commits reachable from the ref tips."""
         object_store = self.repo.object_store
         targets: dict[ObjectID, set[ObjectID]] = {}
+        # Match git-rev-list semantics: annotated tags on either side are
+        # peeled before walking the commit graph.
         for want in wants:
-            target = _peel_to_commit(object_store, want)
-            if target is not None:
-                targets.setdefault(target, set()).add(want)
+            try:
+                _unpeeled, target = peel_sha(object_store, want)
+            except KeyError:
+                continue
+            if isinstance(target, Commit):
+                targets.setdefault(target.id, set()).add(want)
 
         pending = []
         for tip in tips:
-            commit_id = _peel_to_commit(object_store, tip)
-            if commit_id is not None:
-                pending.append(commit_id)
+            try:
+                _unpeeled, target = peel_sha(object_store, tip)
+            except KeyError:
+                continue
+            if isinstance(target, Commit):
+                pending.append(target.id)
 
         seen: set[ObjectID] = set()
         reachable: set[ObjectID] = set()
@@ -660,7 +656,8 @@ class UploadPackHandler(PackHandler):
                 commit = object_store[commit_id]
             except KeyError:
                 continue
-            pending.extend(commit.parents)  # type: ignore[attr-defined]
+            assert isinstance(commit, Commit)
+            pending.extend(commit.parents)
         return reachable
 
     @classmethod

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -501,7 +501,6 @@ class UploadPackHandler(PackHandler):
         # Filter specification for partial clone support
         self.filter_spec: FilterSpec | None = None
         self._sha1_in_want_policy: SHA1InWantPolicy | None = None
-        self._sha1_in_want_ref_tips: set[ObjectID] | None = None
 
     def capabilities(self) -> list[bytes]:
         """Return the list of capabilities supported by upload-pack.
@@ -534,29 +533,18 @@ class UploadPackHandler(PackHandler):
             self._sha1_in_want_policy = self.repo.get_sha1_in_want_policy()
         return self._sha1_in_want_policy
 
-    def is_want_allowed(self, sha: ObjectID) -> bool:
-        """Check whether the client may ask for an object that was not advertised.
+    def allowed_wants(self, wants: set[ObjectID]) -> set[ObjectID]:
+        """Return the unadvertised wants permitted by this repository.
 
         Mirrors git's ``uploadpack.allowAnySHA1InWant``,
         ``uploadpack.allowReachableSHA1InWant`` and
         ``uploadpack.allowTipSHA1InWant`` options. All default to false, so by
         default a client may only ask for objects that were advertised to it.
 
-        Note that ``allowReachableSHA1InWant`` may need to walk the whole
-        commit graph to answer a single want, which is why git leaves it off
-        by default.
-
-        Args:
-          sha: Object ID the client asked for.
-        Returns: True if the object may be served to the client.
-        """
-        return sha in self.allowed_wants({sha})
-
-    def allowed_wants(self, wants: set[ObjectID]) -> set[ObjectID]:
-        """Return the unadvertised wants permitted by this repository.
-
         Reachability for the entire request is checked in one graph walk so
-        its cost does not grow linearly with the number of want lines.
+        its cost does not grow linearly with the number of want lines. It may
+        still need to walk the whole commit graph, which is why git leaves
+        ``allowReachableSHA1InWant`` off by default.
 
         Args:
           wants: Distinct, unadvertised object IDs requested by the client.
@@ -566,52 +554,49 @@ class UploadPackHandler(PackHandler):
             return set()
 
         policy = self._get_sha1_in_want_policy()
-        if not (policy.allow_any or policy.allow_reachable or policy.allow_tip):
+        if not (policy.allow_reachable or policy.allow_tip):
             return set()
 
-        existing = {sha for sha in wants if sha in self.repo.object_store}
+        object_store = self.repo.object_store
         if policy.allow_any:
-            return existing
+            return {sha for sha in wants if sha in object_store}
 
         # Both of the remaining options accept the tip of any ref, including
         # refs that were never advertised to this client.
-        tips = self._ref_tips()
-        allowed = existing & tips
-        if not policy.allow_reachable:
-            return allowed
-        allowed.update(self._reachable_wants(existing - allowed, tips))
+        tips = set(self.repo.get_refs().values())
+        allowed = wants & tips
+        if policy.allow_reachable:
+            allowed |= self._reachable_wants(wants - allowed, tips)
         return allowed
-
-    def _ref_tips(self) -> set[ObjectID]:
-        """Return the exact object IDs at the tips of every ref."""
-        if self._sha1_in_want_ref_tips is None:
-            self._sha1_in_want_ref_tips = set(self.repo.get_refs().values())
-        return self._sha1_in_want_ref_tips
 
     def _reachable_wants(
         self, wants: set[ObjectID], tips: set[ObjectID]
     ) -> set[ObjectID]:
         """Return wants that peel to commits reachable from the ref tips."""
         object_store = self.repo.object_store
-        targets: dict[ObjectID, set[ObjectID]] = {}
+
+        def peel_to_commit(sha: ObjectID) -> ObjectID | None:
+            try:
+                _unpeeled, target = peel_sha(object_store, sha)
+            except KeyError:
+                return None
+            return target.id if isinstance(target, Commit) else None
+
         # Match git-rev-list semantics: annotated tags on either side are
         # peeled before walking the commit graph.
+        targets: dict[ObjectID, set[ObjectID]] = {}
         for want in wants:
-            try:
-                _unpeeled, target = peel_sha(object_store, want)
-            except KeyError:
-                continue
-            if isinstance(target, Commit):
-                targets.setdefault(target.id, set()).add(want)
+            commit_id = peel_to_commit(want)
+            if commit_id is not None:
+                targets.setdefault(commit_id, set()).add(want)
+        if not targets:
+            return set()
 
         pending = []
         for tip in tips:
-            try:
-                _unpeeled, target = peel_sha(object_store, tip)
-            except KeyError:
-                continue
-            if isinstance(target, Commit):
-                pending.append(target.id)
+            commit_id = peel_to_commit(tip)
+            if commit_id is not None:
+                pending.append(commit_id)
 
         seen: set[ObjectID] = set()
         reachable: set[ObjectID] = set()
@@ -1083,10 +1068,10 @@ class _ProtocolGraphWalker:
                 want_revs.append(want)
             command, sha_result = self.read_proto_line(allowed)
 
-        unadvertised = {want for want in want_revs if want not in values}
-        allowed_wants = self.handler.allowed_wants(unadvertised)
+        unadvertised = seen_wants.difference(values)
+        rejected = unadvertised - self.handler.allowed_wants(unadvertised)
         for want in want_revs:
-            if want in unadvertised and want not in allowed_wants:
+            if want in rejected:
                 raise GitProtocolError(f"Client wants invalid object {want!r}")
 
         self.set_wants(want_revs)

--- a/dulwich/server.py
+++ b/dulwich/server.py
@@ -76,7 +76,6 @@ import zlib
 from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from collections.abc import Set as AbstractSet
-from dataclasses import dataclass
 from functools import partial
 from typing import IO, TYPE_CHECKING
 from typing import Protocol as TypingProtocol
@@ -167,7 +166,7 @@ from .protocol import (
     write_info_refs,
 )
 from .refs import Ref, RefsContainer
-from .repo import BaseRepo, Repo
+from .repo import Repo, SHA1InWantPolicy
 
 logger = log_utils.getLogger(__name__)
 
@@ -232,6 +231,14 @@ class BackendRepo(TypingProtocol):
             but it should attempt to peel the tag if possible.
         """
         return None
+
+    def get_sha1_in_want_policy(self) -> SHA1InWantPolicy:
+        """Return the policy for serving objects that were not advertised.
+
+        Returns: The policy to apply. The default refuses all unadvertised
+            wants, matching git's defaults.
+        """
+        return SHA1InWantPolicy()
 
     def find_missing_objects(
         self,
@@ -463,15 +470,6 @@ class PackHandler(Handler):
         self._done_received = True
 
 
-@dataclass(frozen=True)
-class _SHA1InWantPolicy:
-    """Configured policy for unadvertised object requests."""
-
-    allow_any: bool = False
-    allow_reachable: bool = False
-    allow_tip: bool = False
-
-
 class UploadPackHandler(PackHandler):
     """Protocol handler for uploading a pack to the client."""
 
@@ -502,7 +500,7 @@ class UploadPackHandler(PackHandler):
         self._processing_have_lines = False
         # Filter specification for partial clone support
         self.filter_spec: FilterSpec | None = None
-        self._sha1_in_want_policy: _SHA1InWantPolicy | None = None
+        self._sha1_in_want_policy: SHA1InWantPolicy | None = None
         self._sha1_in_want_ref_tips: set[ObjectID] | None = None
 
     def capabilities(self) -> list[bytes]:
@@ -531,36 +529,9 @@ class UploadPackHandler(PackHandler):
             caps.append(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT)
         return caps
 
-    def _get_sha1_in_want_policy(self) -> _SHA1InWantPolicy:
-        """Read the uploadpack.allow*SHA1InWant settings for this repository.
-
-        Returns: The configured policy. ``allowAnySHA1InWant`` implies the
-            other two options, as in git.
-        """
+    def _get_sha1_in_want_policy(self) -> SHA1InWantPolicy:
         if self._sha1_in_want_policy is None:
-            if not isinstance(self.repo, BaseRepo):
-                # BackendRepo intentionally does not require configuration
-                # access. Preserve compatibility with custom backends by
-                # leaving all opt-in policies disabled when it is unavailable.
-                self._sha1_in_want_policy = _SHA1InWantPolicy()
-                return self._sha1_in_want_policy
-            config = self.repo.get_config_stack()
-
-            def get(name: bytes) -> bool:
-                try:
-                    return bool(config.get_boolean((b"uploadpack",), name, False))
-                except ValueError:
-                    logger.warning(
-                        "Ignoring invalid uploadpack.%s value", name.decode()
-                    )
-                    return False
-
-            allow_any = get(b"allowAnySHA1InWant")
-            self._sha1_in_want_policy = _SHA1InWantPolicy(
-                allow_any=allow_any,
-                allow_reachable=allow_any or get(b"allowReachableSHA1InWant"),
-                allow_tip=allow_any or get(b"allowTipSHA1InWant"),
-            )
+            self._sha1_in_want_policy = self.repo.get_sha1_in_want_policy()
         return self._sha1_in_want_policy
 
     def is_want_allowed(self, sha: ObjectID) -> bool:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -561,17 +561,22 @@ class UploadPackSHA1InWantTestCase(TestCase):
         self.assertFalse(handler.is_want_allowed(TWO))
         self.assertFalse(handler.is_want_allowed(SIX))
 
-    def test_allow_tip_does_not_include_peeled_tag_target(self) -> None:
+    def test_annotated_tag_policy(self) -> None:
         target = self._repo.object_store[SIX]
         tag = make_tag(target, name=b"hidden-tag")
         self._repo.object_store.add_object(tag)
-        self._repo.refs[b"refs/tags/hidden"] = tag.id
+        outer_tag = make_tag(tag, name=b"outer-hidden-tag")
+        self._repo.object_store.add_object(outer_tag)
+        self._repo.refs[b"refs/tags/hidden"] = outer_tag.id
 
         handler = self._handler(b"allowTipSHA1InWant")
-        self.assertTrue(handler.is_want_allowed(tag.id))
+        self.assertTrue(handler.is_want_allowed(outer_tag.id))
+        self.assertFalse(handler.is_want_allowed(tag.id))
         self.assertFalse(handler.is_want_allowed(SIX))
 
         reachable_handler = self._handler(b"allowReachableSHA1InWant")
+        self.assertTrue(reachable_handler.is_want_allowed(outer_tag.id))
+        self.assertTrue(reachable_handler.is_want_allowed(tag.id))
         self.assertTrue(reachable_handler.is_want_allowed(SIX))
 
     def test_allow_reachable(self) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,7 +38,12 @@ from dulwich.errors import (
 from dulwich.object_filters import BlobNoneFilter
 from dulwich.object_store import MemoryObjectStore, find_shallow
 from dulwich.objects import Tree
-from dulwich.protocol import ZERO_SHA, format_capability_line
+from dulwich.protocol import (
+    CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT,
+    CAPABILITY_ALLOW_TIP_SHA1_IN_WANT,
+    ZERO_SHA,
+    format_capability_line,
+)
 from dulwich.repo import MemoryRepo, Repo
 from dulwich.server import (
     Backend,
@@ -510,6 +515,172 @@ class ReceivePackHandlerTestCase(TestCase):
         # Verify hook declined the ref
         self.assertIsNotNone(ref_status)
         self.assertIn(b"update hook declined", ref_status)
+
+
+class UploadPackSHA1InWantTestCase(TestCase):
+    """Tests for the uploadpack.allow*SHA1InWant options."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # 1---2---4    refs/heads/advertised
+        #  \
+        #   3---5      refs/heads/hidden
+        #
+        # SIX is in the object store, but no ref reaches it.
+        commits = [
+            make_commit(id=ONE, parents=[], commit_time=111),
+            make_commit(id=TWO, parents=[ONE], commit_time=222),
+            make_commit(id=THREE, parents=[ONE], commit_time=333),
+            make_commit(id=FOUR, parents=[TWO], commit_time=444),
+            make_commit(id=FIVE, parents=[THREE], commit_time=555),
+            make_commit(id=SIX, parents=[], commit_time=666),
+        ]
+        self._repo = MemoryRepo.init_bare(commits, {})
+        self._repo.refs._update(
+            {b"refs/heads/advertised": FOUR, b"refs/heads/hidden": FIVE}
+        )
+
+    def _handler(self, *allow: bytes) -> UploadPackHandler:
+        """Build a handler with the given uploadpack options enabled."""
+        config = self._repo.get_config()
+        for name in allow:
+            config.set((b"uploadpack",), name, b"true")
+        backend = DictBackend({b"/": self._repo})
+        return TestUploadPackHandler(backend, [b"/", b"host=lolcats"], TestProto())
+
+    def test_disallowed_by_default(self) -> None:
+        handler = self._handler()
+        for sha in (ONE, TWO, THREE, FIVE, SIX):
+            self.assertFalse(handler.is_want_allowed(sha))
+
+    def test_allow_tip(self) -> None:
+        handler = self._handler(b"allowTipSHA1InWant")
+        # Tip of a ref that was never advertised to this client.
+        self.assertTrue(handler.is_want_allowed(FIVE))
+        # Reachable, but not the tip of any ref.
+        self.assertFalse(handler.is_want_allowed(TWO))
+        self.assertFalse(handler.is_want_allowed(SIX))
+
+    def test_allow_tip_does_not_include_peeled_tag_target(self) -> None:
+        target = self._repo.object_store[SIX]
+        tag = make_tag(target, name=b"hidden-tag")
+        self._repo.object_store.add_object(tag)
+        self._repo.refs[b"refs/tags/hidden"] = tag.id
+
+        handler = self._handler(b"allowTipSHA1InWant")
+        self.assertTrue(handler.is_want_allowed(tag.id))
+        self.assertFalse(handler.is_want_allowed(SIX))
+
+        reachable_handler = self._handler(b"allowReachableSHA1InWant")
+        self.assertTrue(reachable_handler.is_want_allowed(SIX))
+
+    def test_allow_reachable(self) -> None:
+        handler = self._handler(b"allowReachableSHA1InWant")
+        self.assertTrue(handler.is_want_allowed(FIVE))
+        for sha in (ONE, TWO, THREE):
+            self.assertTrue(handler.is_want_allowed(sha))
+        # Present, but not reachable from any ref.
+        self.assertFalse(handler.is_want_allowed(SIX))
+
+    def test_allow_any(self) -> None:
+        handler = self._handler(b"allowAnySHA1InWant")
+        self.assertTrue(handler.is_want_allowed(SIX))
+        # Objects that are not in the store at all are still refused.
+        self.assertFalse(handler.is_want_allowed(b"f" * 40))
+
+    def test_no_unadvertised_wants_does_not_enumerate_refs(self) -> None:
+        # Every want being advertised is the common case, and an enabled
+        # policy should cost it nothing.
+        handler = self._handler(b"allowTipSHA1InWant")
+        self._repo.get_refs = Mock(wraps=self._repo.get_refs)
+
+        self.assertEqual(set(), handler.allowed_wants(set()))
+        self._repo.get_refs.assert_not_called()
+
+    def test_capabilities(self) -> None:
+        self.assertNotIn(
+            CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, self._handler().capabilities()
+        )
+
+        caps = self._handler(b"allowTipSHA1InWant").capabilities()
+        self.assertIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
+        self.assertNotIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
+
+    def test_capabilities_allow_any_implies_both(self) -> None:
+        caps = self._handler(b"allowAnySHA1InWant").capabilities()
+        self.assertIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
+        self.assertIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
+
+    def test_configless_backend_defaults_to_disabled(self) -> None:
+        class ConfiglessRepo:
+            def __init__(self, repo):
+                self.object_store = repo.object_store
+                self.refs = repo.refs
+                self.object_format = repo.object_format
+
+            def get_refs(self):
+                return self.refs.as_dict()
+
+            def get_peeled(self, ref):
+                return self.refs.get_peeled(ref)
+
+            def find_missing_objects(self, *args, **kwargs):
+                return self.object_store.find_missing_objects(*args, **kwargs)
+
+        backend = DictBackend({b"/": ConfiglessRepo(self._repo)})
+        handler = TestUploadPackHandler(backend, [b"/", b"host=lolcats"], TestProto())
+
+        caps = handler.capabilities()
+        self.assertNotIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
+        self.assertNotIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
+        self.assertFalse(handler.is_want_allowed(FIVE))
+
+    def test_determine_wants_accepts_unadvertised(self) -> None:
+        handler = self._handler(b"allowAnySHA1InWant")
+        walker = _ProtocolGraphWalker(
+            handler,
+            self._repo.object_store,
+            self._repo.get_peeled,
+            self._repo.refs.get_symrefs,
+        )
+        walker.proto.set_output([b"want " + SIX + b" multi_ack", None])
+        self.assertEqual(
+            [SIX], walker.determine_wants({b"refs/heads/advertised": FOUR})
+        )
+
+    def test_determine_wants_deduplicates_and_batches_reachability(self) -> None:
+        handler = self._handler(b"allowReachableSHA1InWant")
+        reachable_wants = Mock(wraps=handler._reachable_wants)
+        handler._reachable_wants = reachable_wants
+        walker = _ProtocolGraphWalker(
+            handler,
+            self._repo.object_store,
+            self._repo.get_peeled,
+            self._repo.refs.get_symrefs,
+        )
+        walker.proto.set_output(
+            [b"want " + ONE + b" multi_ack", b"want " + ONE, b"want " + TWO, None]
+        )
+
+        self.assertEqual(
+            [ONE, TWO], walker.determine_wants({b"refs/heads/advertised": FOUR})
+        )
+        reachable_wants.assert_called_once()
+
+    def test_determine_wants_still_rejects_when_disabled(self) -> None:
+        handler = self._handler()
+        walker = _ProtocolGraphWalker(
+            handler,
+            self._repo.object_store,
+            self._repo.get_peeled,
+            self._repo.refs.get_symrefs,
+        )
+        walker.proto.set_output([b"want " + SIX + b" multi_ack", None])
+        self.assertRaises(
+            GitProtocolError,
+            walker.determine_wants,
+            {b"refs/heads/advertised": FOUR},
+        )
 
 
 class ProtocolGraphWalkerEmptyTestCase(TestCase):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -47,6 +47,7 @@ from dulwich.protocol import (
 from dulwich.repo import MemoryRepo, Repo
 from dulwich.server import (
     Backend,
+    BackendRepo,
     DictBackend,
     FileSystemBackend,
     MultiAckDetailedGraphWalkerImpl,
@@ -617,11 +618,21 @@ class UploadPackSHA1InWantTestCase(TestCase):
         self.assertIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
 
     def test_configless_backend_defaults_to_disabled(self) -> None:
-        class ConfiglessRepo:
+        class ConfiglessRepo(BackendRepo):
             def __init__(self, repo):
-                self.object_store = repo.object_store
-                self.refs = repo.refs
-                self.object_format = repo.object_format
+                self._repo = repo
+
+            @property
+            def object_store(self):
+                return self._repo.object_store
+
+            @property
+            def refs(self):
+                return self._repo.refs
+
+            @property
+            def object_format(self):
+                return self._repo.object_format
 
             def get_refs(self):
                 return self.refs.as_dict()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -549,18 +549,21 @@ class UploadPackSHA1InWantTestCase(TestCase):
         backend = DictBackend({b"/": self._repo})
         return TestUploadPackHandler(backend, [b"/", b"host=lolcats"], TestProto())
 
+    def _allowed(self, handler: UploadPackHandler, sha: bytes) -> bool:
+        return sha in handler.allowed_wants({sha})
+
     def test_disallowed_by_default(self) -> None:
         handler = self._handler()
         for sha in (ONE, TWO, THREE, FIVE, SIX):
-            self.assertFalse(handler.is_want_allowed(sha))
+            self.assertFalse(self._allowed(handler, sha))
 
     def test_allow_tip(self) -> None:
         handler = self._handler(b"allowTipSHA1InWant")
         # Tip of a ref that was never advertised to this client.
-        self.assertTrue(handler.is_want_allowed(FIVE))
+        self.assertTrue(self._allowed(handler, FIVE))
         # Reachable, but not the tip of any ref.
-        self.assertFalse(handler.is_want_allowed(TWO))
-        self.assertFalse(handler.is_want_allowed(SIX))
+        self.assertFalse(self._allowed(handler, TWO))
+        self.assertFalse(self._allowed(handler, SIX))
 
     def test_annotated_tag_policy(self) -> None:
         target = self._repo.object_store[SIX]
@@ -571,28 +574,28 @@ class UploadPackSHA1InWantTestCase(TestCase):
         self._repo.refs[b"refs/tags/hidden"] = outer_tag.id
 
         handler = self._handler(b"allowTipSHA1InWant")
-        self.assertTrue(handler.is_want_allowed(outer_tag.id))
-        self.assertFalse(handler.is_want_allowed(tag.id))
-        self.assertFalse(handler.is_want_allowed(SIX))
+        self.assertTrue(self._allowed(handler, outer_tag.id))
+        self.assertFalse(self._allowed(handler, tag.id))
+        self.assertFalse(self._allowed(handler, SIX))
 
         reachable_handler = self._handler(b"allowReachableSHA1InWant")
-        self.assertTrue(reachable_handler.is_want_allowed(outer_tag.id))
-        self.assertTrue(reachable_handler.is_want_allowed(tag.id))
-        self.assertTrue(reachable_handler.is_want_allowed(SIX))
+        self.assertTrue(self._allowed(reachable_handler, outer_tag.id))
+        self.assertTrue(self._allowed(reachable_handler, tag.id))
+        self.assertTrue(self._allowed(reachable_handler, SIX))
 
     def test_allow_reachable(self) -> None:
         handler = self._handler(b"allowReachableSHA1InWant")
-        self.assertTrue(handler.is_want_allowed(FIVE))
+        self.assertTrue(self._allowed(handler, FIVE))
         for sha in (ONE, TWO, THREE):
-            self.assertTrue(handler.is_want_allowed(sha))
+            self.assertTrue(self._allowed(handler, sha))
         # Present, but not reachable from any ref.
-        self.assertFalse(handler.is_want_allowed(SIX))
+        self.assertFalse(self._allowed(handler, SIX))
 
     def test_allow_any(self) -> None:
         handler = self._handler(b"allowAnySHA1InWant")
-        self.assertTrue(handler.is_want_allowed(SIX))
+        self.assertTrue(self._allowed(handler, SIX))
         # Objects that are not in the store at all are still refused.
-        self.assertFalse(handler.is_want_allowed(b"f" * 40))
+        self.assertFalse(self._allowed(handler, b"f" * 40))
 
     def test_no_unadvertised_wants_does_not_enumerate_refs(self) -> None:
         # Every want being advertised is the common case, and an enabled
@@ -637,19 +640,13 @@ class UploadPackSHA1InWantTestCase(TestCase):
             def get_refs(self):
                 return self.refs.as_dict()
 
-            def get_peeled(self, ref):
-                return self.refs.get_peeled(ref)
-
-            def find_missing_objects(self, *args, **kwargs):
-                return self.object_store.find_missing_objects(*args, **kwargs)
-
         backend = DictBackend({b"/": ConfiglessRepo(self._repo)})
         handler = TestUploadPackHandler(backend, [b"/", b"host=lolcats"], TestProto())
 
         caps = handler.capabilities()
         self.assertNotIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
         self.assertNotIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
-        self.assertFalse(handler.is_want_allowed(FIVE))
+        self.assertFalse(self._allowed(handler, FIVE))
 
     def test_determine_wants_accepts_unadvertised(self) -> None:
         handler = self._handler(b"allowAnySHA1InWant")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -38,7 +38,12 @@ from dulwich.errors import (
 from dulwich.object_filters import BlobNoneFilter
 from dulwich.object_store import MemoryObjectStore, find_shallow
 from dulwich.objects import Tree
-from dulwich.protocol import ZERO_SHA, format_capability_line
+from dulwich.protocol import (
+    CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT,
+    CAPABILITY_ALLOW_TIP_SHA1_IN_WANT,
+    ZERO_SHA,
+    format_capability_line,
+)
 from dulwich.repo import MemoryRepo, Repo
 from dulwich.server import (
     Backend,
@@ -510,6 +515,177 @@ class ReceivePackHandlerTestCase(TestCase):
         # Verify hook declined the ref
         self.assertIsNotNone(ref_status)
         self.assertIn(b"update hook declined", ref_status)
+
+
+class UploadPackSHA1InWantTestCase(TestCase):
+    """Tests for the uploadpack.allow*SHA1InWant options."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # 1---2---4    refs/heads/advertised
+        #  \
+        #   3---5      refs/heads/hidden
+        #
+        # SIX is in the object store, but no ref reaches it.
+        commits = [
+            make_commit(id=ONE, parents=[], commit_time=111),
+            make_commit(id=TWO, parents=[ONE], commit_time=222),
+            make_commit(id=THREE, parents=[ONE], commit_time=333),
+            make_commit(id=FOUR, parents=[TWO], commit_time=444),
+            make_commit(id=FIVE, parents=[THREE], commit_time=555),
+            make_commit(id=SIX, parents=[], commit_time=666),
+        ]
+        self._repo = MemoryRepo.init_bare(commits, {})
+        self._repo.refs._update(
+            {b"refs/heads/advertised": FOUR, b"refs/heads/hidden": FIVE}
+        )
+
+    def _handler(self, *allow: bytes) -> UploadPackHandler:
+        """Build a handler with the given uploadpack options enabled."""
+        config = self._repo.get_config()
+        for name in allow:
+            config.set((b"uploadpack",), name, b"true")
+        backend = DictBackend({b"/": self._repo})
+        return TestUploadPackHandler(backend, [b"/", b"host=lolcats"], TestProto())
+
+    def test_disallowed_by_default(self) -> None:
+        handler = self._handler()
+        for sha in (ONE, TWO, THREE, FIVE, SIX):
+            self.assertFalse(handler.is_want_allowed(sha))
+
+    def test_allow_tip(self) -> None:
+        handler = self._handler(b"allowTipSHA1InWant")
+        # Tip of a ref that was never advertised to this client.
+        self.assertTrue(handler.is_want_allowed(FIVE))
+        # Reachable, but not the tip of any ref.
+        self.assertFalse(handler.is_want_allowed(TWO))
+        self.assertFalse(handler.is_want_allowed(SIX))
+
+    def test_annotated_tag_policy(self) -> None:
+        target = self._repo.object_store[SIX]
+        tag = make_tag(target, name=b"hidden-tag")
+        self._repo.object_store.add_object(tag)
+        outer_tag = make_tag(tag, name=b"outer-hidden-tag")
+        self._repo.object_store.add_object(outer_tag)
+        self._repo.refs[b"refs/tags/hidden"] = outer_tag.id
+
+        handler = self._handler(b"allowTipSHA1InWant")
+        self.assertTrue(handler.is_want_allowed(outer_tag.id))
+        self.assertFalse(handler.is_want_allowed(tag.id))
+        self.assertFalse(handler.is_want_allowed(SIX))
+
+        reachable_handler = self._handler(b"allowReachableSHA1InWant")
+        self.assertTrue(reachable_handler.is_want_allowed(outer_tag.id))
+        self.assertTrue(reachable_handler.is_want_allowed(tag.id))
+        self.assertTrue(reachable_handler.is_want_allowed(SIX))
+
+    def test_allow_reachable(self) -> None:
+        handler = self._handler(b"allowReachableSHA1InWant")
+        self.assertTrue(handler.is_want_allowed(FIVE))
+        for sha in (ONE, TWO, THREE):
+            self.assertTrue(handler.is_want_allowed(sha))
+        # Present, but not reachable from any ref.
+        self.assertFalse(handler.is_want_allowed(SIX))
+
+    def test_allow_any(self) -> None:
+        handler = self._handler(b"allowAnySHA1InWant")
+        self.assertTrue(handler.is_want_allowed(SIX))
+        # Objects that are not in the store at all are still refused.
+        self.assertFalse(handler.is_want_allowed(b"f" * 40))
+
+    def test_no_unadvertised_wants_does_not_enumerate_refs(self) -> None:
+        # Every want being advertised is the common case, and an enabled
+        # policy should cost it nothing.
+        handler = self._handler(b"allowTipSHA1InWant")
+        self._repo.get_refs = Mock(wraps=self._repo.get_refs)
+
+        self.assertEqual(set(), handler.allowed_wants(set()))
+        self._repo.get_refs.assert_not_called()
+
+    def test_capabilities(self) -> None:
+        self.assertNotIn(
+            CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, self._handler().capabilities()
+        )
+
+        caps = self._handler(b"allowTipSHA1InWant").capabilities()
+        self.assertIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
+        self.assertNotIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
+
+    def test_capabilities_allow_any_implies_both(self) -> None:
+        caps = self._handler(b"allowAnySHA1InWant").capabilities()
+        self.assertIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
+        self.assertIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
+
+    def test_configless_backend_defaults_to_disabled(self) -> None:
+        class ConfiglessRepo:
+            def __init__(self, repo):
+                self.object_store = repo.object_store
+                self.refs = repo.refs
+                self.object_format = repo.object_format
+
+            def get_refs(self):
+                return self.refs.as_dict()
+
+            def get_peeled(self, ref):
+                return self.refs.get_peeled(ref)
+
+            def find_missing_objects(self, *args, **kwargs):
+                return self.object_store.find_missing_objects(*args, **kwargs)
+
+        backend = DictBackend({b"/": ConfiglessRepo(self._repo)})
+        handler = TestUploadPackHandler(backend, [b"/", b"host=lolcats"], TestProto())
+
+        caps = handler.capabilities()
+        self.assertNotIn(CAPABILITY_ALLOW_TIP_SHA1_IN_WANT, caps)
+        self.assertNotIn(CAPABILITY_ALLOW_REACHABLE_SHA1_IN_WANT, caps)
+        self.assertFalse(handler.is_want_allowed(FIVE))
+
+    def test_determine_wants_accepts_unadvertised(self) -> None:
+        handler = self._handler(b"allowAnySHA1InWant")
+        walker = _ProtocolGraphWalker(
+            handler,
+            self._repo.object_store,
+            self._repo.get_peeled,
+            self._repo.refs.get_symrefs,
+        )
+        walker.proto.set_output([b"want " + SIX + b" multi_ack", None])
+        self.assertEqual(
+            [SIX], walker.determine_wants({b"refs/heads/advertised": FOUR})
+        )
+
+    def test_determine_wants_deduplicates_and_batches_reachability(self) -> None:
+        handler = self._handler(b"allowReachableSHA1InWant")
+        reachable_wants = Mock(wraps=handler._reachable_wants)
+        handler._reachable_wants = reachable_wants
+        walker = _ProtocolGraphWalker(
+            handler,
+            self._repo.object_store,
+            self._repo.get_peeled,
+            self._repo.refs.get_symrefs,
+        )
+        walker.proto.set_output(
+            [b"want " + ONE + b" multi_ack", b"want " + ONE, b"want " + TWO, None]
+        )
+
+        self.assertEqual(
+            [ONE, TWO], walker.determine_wants({b"refs/heads/advertised": FOUR})
+        )
+        reachable_wants.assert_called_once()
+
+    def test_determine_wants_still_rejects_when_disabled(self) -> None:
+        handler = self._handler()
+        walker = _ProtocolGraphWalker(
+            handler,
+            self._repo.object_store,
+            self._repo.get_peeled,
+            self._repo.refs.get_symrefs,
+        )
+        walker.proto.set_output([b"want " + SIX + b" multi_ack", None])
+        self.assertRaises(
+            GitProtocolError,
+            walker.determine_wants,
+            {b"refs/heads/advertised": FOUR},
+        )
 
 
 class ProtocolGraphWalkerEmptyTestCase(TestCase):


### PR DESCRIPTION
Honor uploadpack.allowTipSHA1InWant, uploadpack.allowReachableSHA1InWant, and uploadpack.allowAnySHA1InWant when validating unadvertised wants, and advertise the corresponding protocol capabilities. All three remain disabled by default.
    
Batch and deduplicate reachability checks to avoid repeated graph walks. Treat only exact ref object IDs as tips, and leave the feature disabled for custom backends without configuration access.
