### PR TITLE
Remove a packed ref even when packed-refs has not been read yet

### DIFF
--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -1086,8 +1086,9 @@ class DiskRefsContainer(RefsContainer):
             return None
 
     def _remove_packed_ref(self, name: Ref) -> None:
-        if self._packed_refs is None:
+        if name not in self.get_packed_refs():
             return
+
         filename = os.path.join(self.path, b"packed-refs")
         # reread cached refs from disk, while holding the lock
         f = GitFile(filename, "wb")

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -497,6 +497,29 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
             self._refs.get_packed_refs(),
         )
 
+    def test_remove_packed_ref_with_unread_packed_refs(self) -> None:
+        # An unconditional delete never reads packed-refs on the way in, so
+        # _remove_packed_ref() is reached without the cache being populated.
+        self.assertIsNone(self._refs._packed_refs)
+        self.assertTrue(self._refs.remove_if_equals(b"refs/heads/packed", None))
+
+        self.assertNotIn(b"refs/heads/packed", self._refs.get_packed_refs())
+        self.assertNotIn(b"refs/heads/packed", DiskRefsContainer(self._refs.path))
+
+    def test_remove_loose_ref_while_packed_refs_locked(self) -> None:
+        # refs/heads/master is loose in this fixture, so removing it has no
+        # reason to touch packed-refs at all.
+        self.assertNotIn(b"refs/heads/master", self._refs.get_packed_refs())
+
+        # Simulate a concurrent `git pack-refs` holding the packed-refs lock.
+        lockpath = os.path.join(self._refs.path, b"packed-refs.lock")
+        with open(lockpath, "wb"):
+            pass
+        self.addCleanup(lambda: os.path.exists(lockpath) and os.remove(lockpath))
+
+        self.assertTrue(self._refs.remove_if_equals(b"refs/heads/master", None))
+        self.assertNotIn(b"refs/heads/master", self._refs.keys())
+
     def test_get_peeled_not_packed(self) -> None:
         # not packed
         self.assertEqual(None, self._refs.get_peeled(b"refs/tags/refs-0.2"))


### PR DESCRIPTION
DiskRefsContainer treated an uninitialized packed-refs cache as proof that a ref was not packed. As a result, deleting a packed ref from a newly opened repository reported success but left the ref in packed-refs.
    
Load packed refs before deciding whether the ref needs to be removed. This also avoids locking packed-refs when deleting a loose-only ref.
