### PR TITLE
Retry loose object write when the fanout directory is pruned

### DIFF
--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -55,6 +55,7 @@ __all__ = [
 ]
 
 import binascii
+import errno
 import logging
 import os
 import stat
@@ -223,6 +224,10 @@ PACKDIR = "pack"
 # TODO: should packs also be non-writable on Windows? if so, that
 # would requite some rather significant adjustments to the test suite
 PACK_MODE = 0o444 if sys.platform != "win32" else 0o644
+
+# Number of times add_object() retries a loose object write when a concurrent
+# "git gc"/"git prune" removes the (still empty) fanout directory.
+_ADD_OBJECT_MAX_ATTEMPTS = 3
 
 # Grace period for cleaning up temporary pack files (in seconds)
 # Matches git's default of 2 weeks
@@ -2361,19 +2366,32 @@ class DiskObjectStore(PackBasedObjectStore):
         obj_id = ObjectID(obj.get_id(self.object_format))
         path = self._get_shafile_path(obj_id)
         dir = os.path.dirname(path)
-        try:
-            os.mkdir(dir)
-            if self.dir_mode is not None:
-                os.chmod(dir, self.dir_mode)
-        except FileExistsError:
-            pass
-        if os.path.exists(path):
-            return  # Already there, no need to write again
         mask = self.file_mode if self.file_mode is not None else PACK_MODE
-        with GitFile(path, "wb", mask=mask, fsync=self.fsync_object_files) as f:
-            f.write(
-                obj.as_legacy_object(compression_level=self.loose_compression_level)
-            )
+        # A concurrent "git gc"/"git prune" can rmdir() the still-empty fanout
+        # directory between our mkdir() and the lock file being created, so
+        # retry a bounded number of times rather than failing the write.
+        for _ in range(_ADD_OBJECT_MAX_ATTEMPTS):
+            try:
+                os.mkdir(dir)
+                if self.dir_mode is not None:
+                    os.chmod(dir, self.dir_mode)
+            except FileExistsError:
+                pass
+            if os.path.exists(path):
+                return  # Already there, no need to write again
+            try:
+                with GitFile(path, "wb", mask=mask, fsync=self.fsync_object_files) as f:
+                    f.write(
+                        obj.as_legacy_object(
+                            compression_level=self.loose_compression_level
+                        )
+                    )
+            except FileNotFoundError:
+                if os.path.isdir(dir):
+                    raise
+                continue
+            return
+        raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), path)
 
     @classmethod
     def init(

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -216,6 +216,24 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
             ValueError, self.store._get_shafile_path, b"../../../../etc/passwd"
         )
 
+    def test_add_object_retries_when_fanout_dir_is_pruned(self) -> None:
+        # A concurrent "git gc"/"git prune" can remove the still-empty fanout
+        # directory between the mkdir() and the lock file being created.
+        blob = make_object(Blob, data=b"hello race")
+        real_gitfile = GitFile
+        calls = []
+
+        def racing_gitfile(path, *args, **kwargs):
+            calls.append(path)
+            if len(calls) == 1:
+                shutil.rmtree(os.path.dirname(path))
+            return real_gitfile(path, *args, **kwargs)
+
+        with patch("dulwich.object_store.GitFile", racing_gitfile):
+            self.store.add_object(blob)
+        self.assertEqual(2, len(calls))
+        self.assertEqual(blob.data, self.store[blob.id].data)
+
     def test_loose_compression_level(self) -> None:
         alternate_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, alternate_dir)


### PR DESCRIPTION
Fixes #2336

`DiskObjectStore.add_object()` created the fanout directory and then opened the object lock file; a concurrent `git gc`/`git prune` `rmdir()`s still-empty fanout directories, so the directory could disappear in that window and the write failed with `FileNotFoundError`. The write is now wrapped in a bounded retry (3 attempts) that recreates the directory only when it is actually gone — an existing directory re-raises immediately, so a genuinely broken object store still errors instead of looping.

Regression test `test_add_object_retries_when_fanout_dir_is_pruned` patches `dulwich.object_store.GitFile` to remove the directory on the first call; it fails on main with the reported `FileNotFoundError` and passes with the fix. `tests/test_object_store.py` is green (153 passed).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
