### PR TITLE
fix commit-graph extra edge indexing in _parse_extra_edges

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 1.2.13	UNRELEASED
 
+ * Fix reading the commit-graph extra edge list, which stores a position in a
+   list of 4-byte values rather than a byte offset. Only the first octopus
+   merge in a graph sits at position 0, where the two coincide; every later
+   one was read from a misaligned offset, so ``CommitGraph.get_parents()``
+   dropped or invented parents. This fed ``ParentsProvider`` and therefore
+   merge-base, fast-forward and shallow-depth computations.
+   (netliomax25-code)
+
  * HARDEN: Validate shallow object ids received from the remote.
    (netliomax25-code)
 

--- a/NEWS
+++ b/NEWS
@@ -1,12 +1,8 @@
 1.2.13	UNRELEASED
 
- * Fix reading the commit-graph extra edge list, which stores a position in a
-   list of 4-byte values rather than a byte offset. Only the first octopus
-   merge in a graph sits at position 0, where the two coincide; every later
-   one was read from a misaligned offset, so ``CommitGraph.get_parents()``
-   dropped or invented parents. This fed ``ParentsProvider`` and therefore
-   merge-base, fast-forward and shallow-depth computations.
-   (netliomax25-code)
+ * Fix commit-graph extra edge indexing: the stored value is a position in a
+   list of 4-byte entries, not a byte offset, so every octopus merge after
+   the first got a wrong parent list. (netliomax25-code)
 
  * HARDEN: Validate shallow object ids received from the remote.
    (netliomax25-code)

--- a/dulwich/commit_graph.py
+++ b/dulwich/commit_graph.py
@@ -302,8 +302,8 @@ class CommitGraph:
                 parents.append(oids[parent2_pos])
             elif parent2_pos >= GRAPH_EXTRA_EDGES_NEEDED:
                 # Handle extra edges (3+ parents)
-                edge_offset = parent2_pos & ~GRAPH_EXTRA_EDGES_NEEDED
-                parents.extend(self._parse_extra_edges(edge_offset, oids))
+                edge_index = parent2_pos & ~GRAPH_EXTRA_EDGES_NEEDED
+                parents.extend(self._parse_extra_edges(edge_index, oids))
 
             entry = CommitGraphEntry(
                 commit_id=sha_to_hex(oids[i]),
@@ -315,15 +315,23 @@ class CommitGraph:
             self.entries.append(entry)
 
     def _parse_extra_edges(
-        self, offset: int, oids: Sequence[RawObjectID]
+        self, index: int, oids: Sequence[RawObjectID]
     ) -> list[RawObjectID]:
-        """Parse extra parent edges for commits with 3+ parents."""
+        """Parse extra parent edges for commits with 3+ parents.
+
+        Args:
+          index: Position in the extra edge list, as stored in the commit
+            data chunk. The list holds 4-byte values, so this is scaled by 4
+            to reach the corresponding byte.
+          oids: Commit ids, indexed by commit graph position.
+        """
         if CHUNK_EXTRA_EDGE_LIST not in self.chunks:
             return []
 
         edge_data = self.chunks[CHUNK_EXTRA_EDGE_LIST].data
         parents = []
 
+        offset = index * 4
         while offset + 4 <= len(edge_data):
             parent_pos = struct.unpack(">L", edge_data[offset : offset + 4])[0]
             offset += 4

--- a/tests/test_commit_graph.py
+++ b/tests/test_commit_graph.py
@@ -24,6 +24,7 @@ from dulwich.commit_graph import (
     COMMIT_GRAPH_SIGNATURE,
     COMMIT_GRAPH_VERSION,
     GRAPH_EXTRA_EDGES_NEEDED,
+    GRAPH_LAST_EDGE,
     GRAPH_PARENT_MISSING,
     HASH_VERSION_SHA1,
     CommitGraph,
@@ -37,7 +38,7 @@ from dulwich.commit_graph import (
 from dulwich.graph import can_fast_forward, find_merge_base
 from dulwich.object_format import SHA1
 from dulwich.object_store import DiskObjectStore, MemoryObjectStore
-from dulwich.objects import Commit, Tree, hex_to_sha
+from dulwich.objects import Commit, Tree, hex_to_sha, sha_to_hex
 from dulwich.repo import ParentsProvider, Repo
 
 
@@ -413,6 +414,90 @@ class CommitGraphTests(unittest.TestCase):
         # The incomplete third parent entry should be ignored
         entry3 = graph.entries[3]
         self.assertEqual(len(entry3.parents), 2)  # Should have commit0 and commit1
+
+    def test_parse_extra_edges_second_octopus_merge(self) -> None:
+        """Test that a second octopus merge reads its own extra edges.
+
+        The commit data chunk stores a position in the extra edge list, not a
+        byte offset. Only the first octopus merge sits at position 0, where the
+        two happen to coincide.
+        """
+        # 6 commits: commit0..commit3 parentless, commit4 and commit5 are
+        # octopus merges whose extra edges live at list positions 0 and 2.
+        oids = [b"\x00" + bytes([i]) + b"\x00" * 18 for i in range(6)]
+
+        header = (
+            COMMIT_GRAPH_SIGNATURE
+            + struct.pack(">B", COMMIT_GRAPH_VERSION)
+            + struct.pack(">B", HASH_VERSION_SHA1)
+            + struct.pack(">B", 4)  # 4 chunks
+            + struct.pack(">B", 0)  # 0 base graphs
+        )
+
+        # All commits start with 0x00, so every fanout entry is 6.
+        fanout = struct.pack(">L", 6) * 256
+        oid_lookup = b"".join(oids)
+
+        def commit_data_entry(index: int, parent1_pos: int, parent2_pos: int) -> bytes:
+            tree_oid = b"\xbb" + bytes([index]) + b"\x00" * 18
+            commit_time = 1234567890 + index
+            gen_and_time = (1 << 2) | (commit_time >> 32)
+            return (
+                tree_oid
+                + struct.pack(">LL", parent1_pos, parent2_pos)
+                + struct.pack(">LL", gen_and_time, commit_time & 0xFFFFFFFF)
+            )
+
+        commit_data = b""
+        for i in range(4):
+            commit_data += commit_data_entry(
+                i, GRAPH_PARENT_MISSING, GRAPH_PARENT_MISSING
+            )
+        # commit4: parents commit0, commit1, commit2 (edges at position 0)
+        commit_data += commit_data_entry(4, 0, GRAPH_EXTRA_EDGES_NEEDED | 0)
+        # commit5: parents commit0, commit2, commit3 (edges at position 2)
+        commit_data += commit_data_entry(5, 0, GRAPH_EXTRA_EDGES_NEEDED | 2)
+
+        extra_edges = (
+            struct.pack(">L", 1)
+            + struct.pack(">L", GRAPH_LAST_EDGE | 2)
+            + struct.pack(">L", 2)
+            + struct.pack(">L", GRAPH_LAST_EDGE | 3)
+        )
+
+        header_size = 8
+        toc_size = 5 * 12  # 4 chunks + terminator
+        chunk1_offset = header_size + toc_size
+        chunk2_offset = chunk1_offset + len(fanout)
+        chunk3_offset = chunk2_offset + len(oid_lookup)
+        chunk4_offset = chunk3_offset + len(commit_data)
+        terminator_offset = chunk4_offset + len(extra_edges)
+
+        toc = (
+            CHUNK_OID_FANOUT
+            + struct.pack(">Q", chunk1_offset)
+            + CHUNK_OID_LOOKUP
+            + struct.pack(">Q", chunk2_offset)
+            + CHUNK_COMMIT_DATA
+            + struct.pack(">Q", chunk3_offset)
+            + CHUNK_EXTRA_EDGE_LIST
+            + struct.pack(">Q", chunk4_offset)
+            + b"\x00\x00\x00\x00"
+            + struct.pack(">Q", terminator_offset)
+        )
+
+        data = header + toc + fanout + oid_lookup + commit_data + extra_edges
+        graph = CommitGraph.from_file(io.BytesIO(data))
+
+        self.assertEqual(len(graph), 6)
+        self.assertEqual(
+            graph.entries[4].parents,
+            [sha_to_hex(oids[0]), sha_to_hex(oids[1]), sha_to_hex(oids[2])],
+        )
+        self.assertEqual(
+            graph.entries[5].parents,
+            [sha_to_hex(oids[0]), sha_to_hex(oids[2]), sha_to_hex(oids[3])],
+        )
 
 
 class CommitGraphFileOperationsTests(unittest.TestCase):


### PR DESCRIPTION
1. For an octopus merge the commit data chunk stores an "array position within this list" into the Extra Edge List (gitformat-commit-graph), and that list holds 4-byte values, but `_parse_extra_edges` used the stored value directly as a byte offset into the EDGE chunk.
2. Position 0 is the only value where a position and a byte offset agree, so the first octopus merge in a graph reads correctly and every later one reads from a misaligned offset that splices halves of two neighboring entries together. Those values land past the end of the commit list, where the existing `parent_pos < len(oids)` check drops them without raising, so `get_parents()` quietly returns a short parent list.
3. `ParentsProvider.get_parents` consults the commit graph before falling back to the object store, so the wrong ancestry reaches `find_merge_base`, `can_fast_forward` and the shallow-depth walk.

Scaled the stored position by 4 at the single site that reads it. Dulwich's own writer never emits an EDGE chunk, so only graphs written by git are affected.

Checked against git 2.52 on a repository with seven octopus merges of 3 to 6 parents: six of the seven disagreed with `git rev-list --parents` before the change, and all 41 commits agree after. A sha256 repository was checked the same way. The tolerance for a truncated EDGE chunk added for #2054 is unchanged, and its test still passes.
