### PR TITLE
Catch PackFileDisappeared in the reachability bitmap probe

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.13	UNRELEASED
 
+ * Catch ``PackFileDisappeared`` in the bitmap probe in
+   ``get_reachability_provider``, which only guarded ``FileNotFoundError``.
+   (Jelmer Vernooĳ, #2344)
+
  * Fix commit-graph extra edge indexing: the stored value is a position in a
    list of 4-byte entries, not a byte offset, so every octopus merge after
    the first got a wrong parent list. (netliomax25-code)

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -972,20 +972,20 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
           or graph traversal)
         """
         if prefer_bitmaps:
-            # Check if any packs have bitmaps
-            has_bitmap = False
+            # Check if any packs have bitmaps. ``self.packs`` rescans the pack
+            # directory, so a pack removed by a concurrent repack is dropped
+            # from the cache and its replacement, if any, is probed here too.
             for pack in self.packs:
                 try:
-                    # Try to access bitmap property
                     if pack.bitmap is not None:
-                        has_bitmap = True
-                        break
+                        return BitmapReachability(self)
                 except FileNotFoundError:
                     # Bitmap file doesn't exist for this pack
                     continue
-
-            if has_bitmap:
-                return BitmapReachability(self)
+                except PackFileDisappeared as exc:
+                    # The pack vanished between the scan and the bitmap probe.
+                    self._evict_pack(exc.obj)
+                    continue
 
         # Fall back to graph traversal
         return GraphTraversalReachability(self)

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -41,6 +41,7 @@ from dulwich.object_format import DEFAULT_OBJECT_FORMAT
 from dulwich.object_store import (
     DEFAULT_TEMPFILE_GRACE_PERIOD,
     DiskObjectStore,
+    GraphTraversalReachability,
     MemoryObjectStore,
     ObjectStoreGraphWalker,
     OverlayObjectStore,
@@ -1377,6 +1378,34 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         store.write_midx()
         midx_path = os.path.join(store.pack_dir, "multi-pack-index")
         self.assertTrue(os.path.exists(midx_path))
+
+    def test_get_reachability_provider_handles_disappeared_pack(self) -> None:
+        """The bitmap probe must not raise when a cached pack file vanishes.
+
+        Regression for https://github.com/jelmer/dulwich/issues/2344: the
+        probe guarded only ``FileNotFoundError``, but ``Pack.bitmap`` reaches
+        ``Pack.index``, which raises ``PackFileDisappeared``. The pack here
+        has no bitmap at all, so the bug is not limited to repositories that
+        use bitmaps.
+        """
+        store = DiskObjectStore(self.store_dir)
+        self.addCleanup(store.close)
+
+        b1 = make_object(Blob, data=b"reachability-after-repack")
+        f, commit, _abort = store.add_pack()
+        write_pack_objects(f.write, [(b1, None)], object_format=DEFAULT_OBJECT_FORMAT)
+        doomed = commit()
+        self.assertIsNotNone(doomed)
+
+        assert doomed is not None
+        doomed.close()
+        os.remove(doomed._idx_path)
+        os.remove(doomed._data_path)
+
+        # Should not raise; the vanished pack is skipped and the store falls
+        # back to graph traversal.
+        provider = store.get_reachability_provider()
+        self.assertIsInstance(provider, GraphTraversalReachability)
 
     def test_contains_packed_hex_sha_with_midx(self) -> None:
         """contains_packed must accept hex SHAs even when a MIDX is loaded.


### PR DESCRIPTION
get_reachability_provider guarded only FileNotFoundError, but Pack.bitmap reaches Pack.index, which has raised PackFileDisappeared since #2171. A concurrent repack therefore broke reachability queries even in repositories that use no bitmaps at all.

Fixes #2344