### PR TITLE
Don't grant other write for core.sharedRepository

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@
    ``get_reachability_provider``, which only guarded ``FileNotFoundError``.
    (Jelmer Vernooĳ, #2344)
 
+ * SECURITY: Widen modes for ``core.sharedRepository`` as git does rather than
+   chmodding to a precomputed one, which left ``.git/hooks`` and ``.git/refs``
+   world-writable for ``all``. (netliomax25-code, Jelmer Vernooĳ, #2323)
+
+ * ``parse_shared_repository`` now returns a ``SharedPerm``, and
+   ``DiskObjectStore``, ``Index`` and ``GitFile`` take a ``shared_perm``
+   argument in place of ``file_mode``/``dir_mode``. (Jelmer Vernooĳ)
+
  * Fix commit-graph extra edge indexing: the stored value is a position in a
    list of 4-byte entries, not a byte offset, so every octopus merge after
    the first got a wrong parent list. (netliomax25-code)

--- a/dulwich/file.py
+++ b/dulwich/file.py
@@ -22,15 +22,22 @@
 """Safe access to git files."""
 
 __all__ = [
+    "PERM_EVERYBODY",
+    "PERM_GROUP",
     "FileLocked",
     "GitFile",
+    "SharedPerm",
+    "adjust_shared_perm",
+    "calc_shared_perm",
     "ensure_dir_exists",
 ]
 
 import os
+import stat
 import sys
 import warnings
 from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
 from types import TracebackType
 from typing import IO, Any, ClassVar, Literal, overload
 
@@ -40,6 +47,82 @@ if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
+
+
+@dataclass(frozen=True)
+class SharedPerm:
+    """A parsed core.sharedRepository setting.
+
+    Attributes:
+      tweak: Permission bits the setting asks for
+      replace: Whether those bits state the mode outright, as an explicit
+        octal setting does, rather than only loosening the existing mode
+    """
+
+    tweak: int
+    replace: bool = False
+
+
+# git's PERM_GROUP and PERM_EVERYBODY.
+PERM_GROUP = SharedPerm(tweak=0o660)
+PERM_EVERYBODY = SharedPerm(tweak=0o664)
+
+
+def calc_shared_perm(mode: int, perm: "SharedPerm") -> int:
+    """Apply a shared permission setting to an existing mode.
+
+    Mirrors git's calc_shared_perm(). The umask never appears here: it has
+    already been applied by the kernel when the file was created, and named
+    settings only ever loosen the mode that resulted.
+
+    Args:
+      mode: Current permission bits of the file or directory
+      perm: Shared permission setting to apply
+
+    Returns:
+      The adjusted permission bits
+    """
+    tweak = perm.tweak
+    if not mode & stat.S_IWUSR:
+        tweak &= ~0o222
+    if mode & stat.S_IXUSR:
+        # Copy read bits to execute bits
+        tweak |= (tweak & 0o444) >> 2
+    if perm.replace:
+        return (mode & ~0o777) | tweak
+    return mode | tweak
+
+
+def adjust_shared_perm(
+    path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+    perm: "SharedPerm | None",
+) -> None:
+    """Widen the permissions of a path per core.sharedRepository.
+
+    Mirrors git's adjust_shared_perm(). The mode is read back from the path,
+    so whatever the umask already removed at creation time stays removed for
+    named settings.
+
+    Args:
+      path: File or directory to adjust
+      perm: Shared permission setting, or None to leave the path alone
+    """
+    if perm is None:
+        return
+
+    st = os.stat(path)
+    old_mode = stat.S_IMODE(st.st_mode)
+    new_mode = calc_shared_perm(old_mode, perm)
+
+    if stat.S_ISDIR(st.st_mode):
+        # Copy read bits to execute bits
+        new_mode |= (new_mode & 0o444) >> 2
+        # g+s matters only if group membership grants extra access
+        if new_mode & 0o060:
+            new_mode |= stat.S_ISGID
+
+    if new_mode != old_mode:
+        os.chmod(path, new_mode)
 
 
 def ensure_dir_exists(
@@ -81,6 +164,7 @@ def GitFile(
     bufsize: int = -1,
     mask: int = 0o644,
     fsync: bool = True,
+    shared_perm: "SharedPerm | None" = None,
 ) -> "_GitFile": ...
 
 
@@ -91,6 +175,7 @@ def GitFile(
     bufsize: int = -1,
     mask: int = 0o644,
     fsync: bool = True,
+    shared_perm: "SharedPerm | None" = None,
 ) -> IO[bytes]: ...
 
 
@@ -101,6 +186,7 @@ def GitFile(
     bufsize: int = -1,
     mask: int = 0o644,
     fsync: bool = True,
+    shared_perm: "SharedPerm | None" = None,
 ) -> "IO[bytes] | _GitFile": ...
 
 
@@ -110,6 +196,7 @@ def GitFile(
     bufsize: int = -1,
     mask: int = 0o644,
     fsync: bool = True,
+    shared_perm: "SharedPerm | None" = None,
 ) -> "IO[bytes] | _GitFile":
     """Create a file object that obeys the git file locking protocol.
 
@@ -131,6 +218,7 @@ def GitFile(
       bufsize: Buffer size for file operations
       mask: File mask for created files
       fsync: Whether to call fsync() before closing (default: True)
+      shared_perm: core.sharedRepository setting to widen the mode with
 
     """
     if "a" in mode:
@@ -140,7 +228,7 @@ def GitFile(
     if "b" not in mode:
         raise OSError("text mode not supported for Git files")
     if "w" in mode:
-        return _GitFile(filename, mode, bufsize, mask, fsync)
+        return _GitFile(filename, mode, bufsize, mask, fsync, shared_perm)
     else:
         return open(filename, mode, bufsize)
 
@@ -214,10 +302,12 @@ class _GitFile(IO[bytes]):
         bufsize: int,
         mask: int,
         fsync: bool = True,
+        shared_perm: "SharedPerm | None" = None,
     ) -> None:
         # Convert PathLike to str/bytes for our internal use
         self._filename: str | bytes = os.fspath(filename)
         self._fsync = fsync
+        self._shared_perm = shared_perm
         if isinstance(self._filename, bytes):
             self._lockfilename: str | bytes = self._filename + b".lock"
         else:
@@ -271,6 +361,9 @@ class _GitFile(IO[bytes]):
         if self._fsync:
             os.fsync(self._file.fileno())
         self._file.close()
+        # Adjust before the rename, so the file is never visible at the
+        # final path with the wrong permissions.
+        adjust_shared_perm(self._lockfilename, self._shared_perm)
         try:
             if getattr(os, "replace", None) is not None:
                 os.replace(self._lockfilename, self._filename)

--- a/dulwich/index.py
+++ b/dulwich/index.py
@@ -121,7 +121,7 @@ if TYPE_CHECKING:
     from .object_store import BaseObjectStore
     from .repo import Repo
 
-from .file import GitFile
+from .file import GitFile, SharedPerm
 from .object_store import iter_tree_contents
 from .objects import (
     S_IFGITLINK,
@@ -1128,7 +1128,7 @@ class Index:
         skip_hash: bool = False,
         version: int | None = None,
         *,
-        file_mode: int | None = None,
+        shared_perm: "SharedPerm | None" = None,
         path_normalizer: Callable[[bytes], bytes] | None = None,
     ) -> None:
         """Create an index object associated with the given filename.
@@ -1138,7 +1138,7 @@ class Index:
           read: Whether to initialize the index from the given file, should it exist.
           skip_hash: Whether to skip SHA1 hash when writing (for manyfiles feature)
           version: Index format version to use (None = auto-detect from file or use default)
-          file_mode: Optional file permission mask for shared repository
+          shared_perm: Optional shared repository permission setting
           path_normalizer: Optional function mapping a filesystem path to a
             canonical form (e.g. case-folded, NFC-normalized). When provided,
             lookups (``index[path]``, ``path in index``, ``del index[path]``)
@@ -1149,7 +1149,7 @@ class Index:
         # TODO(jelmer): Store the version returned by read_index
         self._version = version
         self._skip_hash = skip_hash
-        self._file_mode = file_mode
+        self._shared_perm = shared_perm
         self._extensions: list[IndexExtension] = []
         self._path_normalizer = path_normalizer
         self._normalized: dict[bytes, bytes] | None = (
@@ -1193,8 +1193,7 @@ class Index:
 
     def write(self) -> None:
         """Write current contents of index to disk."""
-        mask = self._file_mode if self._file_mode is not None else 0o644
-        f = GitFile(self._filename, "wb", mask=mask)
+        f = GitFile(self._filename, "wb", shared_perm=self._shared_perm)
         try:
             # Filter out extensions with no meaningful data
             meaningful_extensions = []

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
     from .object_format import ObjectFormat
 
 from .errors import NotTreeError
-from .file import GitFile, _GitFile
+from .file import GitFile, SharedPerm, _GitFile, adjust_shared_perm
 from .midx import MultiPackIndex, load_midx
 from .objects import (
     DEFAULT_LOOSE_OBJECT_SIZE_LIMIT,
@@ -1604,8 +1604,7 @@ class DiskObjectStore(PackBasedObjectStore):
         pack_write_bitmaps: bool = False,
         pack_write_bitmap_hash_cache: bool = True,
         pack_write_bitmap_lookup_table: bool = True,
-        file_mode: int | None = None,
-        dir_mode: int | None = None,
+        shared_perm: "SharedPerm | None" = None,
         object_format: "ObjectFormat | None" = None,
         loose_object_size_limit: int | None = None,
         alternates: "Iterable[str | os.PathLike[str]] | None" = None,
@@ -1629,8 +1628,7 @@ class DiskObjectStore(PackBasedObjectStore):
           pack_write_bitmaps: whether to write bitmap indexes for packs
           pack_write_bitmap_hash_cache: whether to include name-hash cache in bitmaps
           pack_write_bitmap_lookup_table: whether to include lookup table in bitmaps
-          file_mode: File permission mask for shared repository
-          dir_mode: Directory permission mask for shared repository
+          shared_perm: Shared repository permission setting
           object_format: Hash algorithm to use (SHA1 or SHA256)
           loose_object_size_limit: Maximum inflated size of a single loose
             object. Defaults to core.bigFileThreshold's Git default (512 MiB)
@@ -1671,8 +1669,7 @@ class DiskObjectStore(PackBasedObjectStore):
         self.pack_write_bitmaps = pack_write_bitmaps
         self.pack_write_bitmap_hash_cache = pack_write_bitmap_hash_cache
         self.pack_write_bitmap_lookup_table = pack_write_bitmap_lookup_table
-        self.file_mode = file_mode
-        self.dir_mode = dir_mode
+        self.shared_perm = shared_perm
         self.loose_object_size_limit = (
             loose_object_size_limit
             if loose_object_size_limit is not None
@@ -1701,8 +1698,7 @@ class DiskObjectStore(PackBasedObjectStore):
         path: str | os.PathLike[str],
         config: "Config",
         *,
-        file_mode: int | None = None,
-        dir_mode: int | None = None,
+        shared_perm: "SharedPerm | None" = None,
         alternates: "Iterable[str | os.PathLike[str]] | None" = None,
     ) -> "DiskObjectStore":
         """Create a DiskObjectStore from a configuration object.
@@ -1710,8 +1706,7 @@ class DiskObjectStore(PackBasedObjectStore):
         Args:
           path: Path to the object store directory
           config: Configuration object to read settings from
-          file_mode: Optional file permission mask for shared repository
-          dir_mode: Optional directory permission mask for shared repository
+          shared_perm: Optional shared repository permission setting
           alternates: Extra alternate object directory paths to consult,
             appended to those listed in ``objects/info/alternates``.
 
@@ -1854,8 +1849,7 @@ class DiskObjectStore(PackBasedObjectStore):
             pack_write_bitmaps=pack_write_bitmaps,
             pack_write_bitmap_hash_cache=pack_write_bitmap_hash_cache,
             pack_write_bitmap_lookup_table=pack_write_bitmap_lookup_table,
-            file_mode=file_mode,
-            dir_mode=dir_mode,
+            shared_perm=shared_perm,
             object_format=object_format,
             loose_object_size_limit=loose_object_size_limit,
             alternates=alternates,
@@ -1902,13 +1896,11 @@ class DiskObjectStore(PackBasedObjectStore):
         info_dir = os.path.join(self.path, INFODIR)
         try:
             os.mkdir(info_dir)
-            if self.dir_mode is not None:
-                os.chmod(info_dir, self.dir_mode)
+            adjust_shared_perm(info_dir, self.shared_perm)
         except FileExistsError:
             pass
         alternates_path = os.path.join(self.path, INFODIR, "alternates")
-        mask = self.file_mode if self.file_mode is not None else 0o644
-        with GitFile(alternates_path, "wb", mask=mask) as f:
+        with GitFile(alternates_path, "wb", shared_perm=self.shared_perm) as f:
             try:
                 orig_f = open(alternates_path, "rb")
             except FileNotFoundError:
@@ -2177,12 +2169,12 @@ class DiskObjectStore(PackBasedObjectStore):
         os.rename(path, target_pack_path)
 
         # Write the index.
-        mask = self.file_mode if self.file_mode is not None else PACK_MODE
         with GitFile(
             target_index_path,
             "wb",
-            mask=mask,
+            mask=PACK_MODE,
             fsync=self.fsync_object_files,
+            shared_perm=self.shared_perm,
         ) as index_file:
             write_pack_index(
                 index_file, entries, pack_sha, version=self.pack_index_version
@@ -2327,8 +2319,8 @@ class DiskObjectStore(PackBasedObjectStore):
 
         fd, path = tempfile.mkstemp(dir=self.pack_dir, suffix=".pack")
         f = os.fdopen(fd, "w+b")
-        mask = self.file_mode if self.file_mode is not None else PACK_MODE
-        os.chmod(path, mask)
+        os.chmod(path, PACK_MODE)
+        adjust_shared_perm(path, self.shared_perm)
 
         def commit() -> "Pack | None":
             if f.tell() > 0:
@@ -2363,8 +2355,7 @@ class DiskObjectStore(PackBasedObjectStore):
         dir = os.path.dirname(path)
         try:
             os.mkdir(dir)
-            if self.dir_mode is not None:
-                os.chmod(dir, self.dir_mode)
+            adjust_shared_perm(dir, self.shared_perm)
         except FileExistsError:
             pass
         try:
@@ -2381,8 +2372,13 @@ class DiskObjectStore(PackBasedObjectStore):
             pass
         else:
             return  # Already there and freshened, no need to write again
-        mask = self.file_mode if self.file_mode is not None else PACK_MODE
-        with GitFile(path, "wb", mask=mask, fsync=self.fsync_object_files) as f:
+        with GitFile(
+            path,
+            "wb",
+            mask=PACK_MODE,
+            fsync=self.fsync_object_files,
+            shared_perm=self.shared_perm,
+        ) as f:
             f.write(
                 obj.as_legacy_object(compression_level=self.loose_compression_level)
             )
@@ -2392,8 +2388,7 @@ class DiskObjectStore(PackBasedObjectStore):
         cls,
         path: str | os.PathLike[str],
         *,
-        file_mode: int | None = None,
-        dir_mode: int | None = None,
+        shared_perm: "SharedPerm | None" = None,
         object_format: "ObjectFormat | None" = None,
     ) -> "DiskObjectStore":
         """Initialize a new disk object store.
@@ -2402,8 +2397,7 @@ class DiskObjectStore(PackBasedObjectStore):
 
         Args:
           path: Path where the object store should be created
-          file_mode: Optional file permission mask for shared repository
-          dir_mode: Optional directory permission mask for shared repository
+          shared_perm: Optional shared repository permission setting
           object_format: Hash algorithm to use (SHA1 or SHA256)
 
         Returns:
@@ -2411,20 +2405,16 @@ class DiskObjectStore(PackBasedObjectStore):
         """
         try:
             os.mkdir(path)
-            if dir_mode is not None:
-                os.chmod(path, dir_mode)
+            adjust_shared_perm(path, shared_perm)
         except FileExistsError:
             pass
         info_path = os.path.join(path, "info")
         pack_path = os.path.join(path, PACKDIR)
         os.mkdir(info_path)
         os.mkdir(pack_path)
-        if dir_mode is not None:
-            os.chmod(info_path, dir_mode)
-            os.chmod(pack_path, dir_mode)
-        return cls(
-            path, file_mode=file_mode, dir_mode=dir_mode, object_format=object_format
-        )
+        adjust_shared_perm(info_path, shared_perm)
+        adjust_shared_perm(pack_path, shared_perm)
+        return cls(path, shared_perm=shared_perm, object_format=object_format)
 
     def iter_prefix(self, prefix: bytes) -> Iterator[ObjectID]:
         """Iterate over all object SHAs with the given prefix.
@@ -2713,13 +2703,11 @@ class DiskObjectStore(PackBasedObjectStore):
                 # Ensure the info directory exists
                 info_dir = os.path.join(self.path, "info")
                 os.makedirs(info_dir, exist_ok=True)
-                if self.dir_mode is not None:
-                    os.chmod(info_dir, self.dir_mode)
+                adjust_shared_perm(info_dir, self.shared_perm)
 
                 # Write using GitFile for atomic operation
                 graph_path = os.path.join(info_dir, "commit-graph")
-                mask = self.file_mode if self.file_mode is not None else 0o644
-                with GitFile(graph_path, "wb", mask=mask) as f:
+                with GitFile(graph_path, "wb", shared_perm=self.shared_perm) as f:
                     assert isinstance(
                         f, _GitFile
                     )  # GitFile in write mode always returns _GitFile

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -106,7 +106,13 @@ from .errors import (
     NotTreeError,
     RefFormatError,
 )
-from .file import GitFile
+from .file import (
+    PERM_EVERYBODY,
+    PERM_GROUP,
+    GitFile,
+    SharedPerm,
+    adjust_shared_perm,
+)
 from .hooks import (
     CommitMsgShellHook,
     Hook,
@@ -385,69 +391,49 @@ def _set_filesystem_hidden(path: str) -> None:
     # Could implement other platform specific filesystem hiding here
 
 
-def parse_shared_repository(
-    value: str | bytes | bool,
-) -> tuple[int | None, int | None]:
+def parse_shared_repository(value: str | bytes | bool) -> "SharedPerm | None":
     """Parse core.sharedRepository configuration value.
 
     Args:
       value: Configuration value (string, bytes, or boolean)
 
     Returns:
-      tuple of (file_mask, directory_mask) or (None, None) if not shared
-
-    The masks are permission bits to apply via chmod.
+      SharedPerm to apply, or None to leave permissions to the umask
     """
     if isinstance(value, bytes):
         value = value.decode("utf-8", errors="replace")
 
     # Handle boolean values
     if isinstance(value, bool):
-        if value:
-            # true = group (same as "group")
-            return (0o664, 0o2775)
-        else:
-            # false = umask (use system umask, no adjustment)
-            return (None, None)
+        # true = group (same as "group"), false = umask
+        return PERM_GROUP if value else None
 
     # Handle string values
     value_lower = value.lower()
 
-    if value_lower in ("false", "0", ""):
+    if value_lower in ("false", "0", "", "umask"):
         # Use umask (no adjustment)
-        return (None, None)
+        return None
 
     if value_lower in ("true", "1", "group"):
-        # Group writable (with setgid bit)
-        return (0o664, 0o2775)
+        return PERM_GROUP
 
     if value_lower in ("all", "world", "everybody", "2"):
-        # World readable/writable (with setgid bit)
-        return (0o666, 0o2777)
+        # Others gain read, and execute on directories, but never write.
+        return PERM_EVERYBODY
 
-    if value_lower == "umask":
-        # Explicitly use umask
-        return (None, None)
-
-    # Try to parse as octal
+    # Try to parse as octal. Unlike the named settings, this states the mode
+    # outright rather than loosening what the umask produced.
     if value.startswith("0"):
         try:
             mode = int(value, 8)
-            # For directories, add execute bits where read bits are set
-            # and add setgid bit for shared repositories
-            dir_mode = mode | 0o2000  # Add setgid bit
-            if mode & 0o004:
-                dir_mode |= 0o001
-            if mode & 0o040:
-                dir_mode |= 0o010
-            if mode & 0o400:
-                dir_mode |= 0o100
-            return (mode, dir_mode)
         except ValueError:
             pass
+        else:
+            return SharedPerm(tweak=mode, replace=True)
 
     # Default to umask for unrecognized values
-    return (None, None)
+    return None
 
 
 def _enable_relative_worktrees_extension(repo: "Repo") -> None:
@@ -1655,9 +1641,9 @@ class Repo(BaseRepo):
             # Get shared repository permissions from config
             try:
                 shared_value = config.get(("core",), "sharedRepository")
-                file_mode, dir_mode = parse_shared_repository(shared_value)
+                shared_perm = parse_shared_repository(shared_value)
             except KeyError:
-                file_mode, dir_mode = None, None
+                shared_perm = None
 
             if object_directory is not None:
                 object_dir_path = os.fspath(object_directory)
@@ -1668,8 +1654,7 @@ class Repo(BaseRepo):
             object_store = DiskObjectStore.from_config(
                 object_dir_path,
                 config,
-                file_mode=file_mode,
-                dir_mode=dir_mode,
+                shared_perm=shared_perm,
                 alternates=alternates,
             )
 
@@ -1744,7 +1729,7 @@ class Repo(BaseRepo):
         path = self._reflog_path(ref)
 
         # Get shared repository permissions
-        file_mode, dir_mode = self._get_shared_repository_permissions()
+        shared_perm = self._get_shared_repository_permissions()
 
         # Create directory with appropriate permissions
         parent_dir = os.path.dirname(path)
@@ -1757,8 +1742,7 @@ class Repo(BaseRepo):
         parts.reverse()
         for part in parts:
             os.mkdir(part)
-            if dir_mode is not None:
-                os.chmod(part, dir_mode)
+            adjust_shared_perm(part, shared_perm)
         if committer is None:
             config = self.get_config_stack()
             committer = get_user_identity(config)
@@ -1775,10 +1759,9 @@ class Repo(BaseRepo):
                 + b"\n"
             )
 
-        # Set file permissions (open() respects umask, so we need chmod to set the actual mode)
-        # Always chmod to ensure correct permissions even if file already existed
-        if file_mode is not None:
-            os.chmod(path, file_mode)
+        # Always adjust, so that permissions are right even if the file
+        # already existed.
+        adjust_shared_perm(path, shared_perm)
 
     def _reflog_path(self, ref: bytes) -> str:
         if ref.startswith((b"main-worktree/", b"worktrees/")):
@@ -1922,18 +1905,18 @@ class Repo(BaseRepo):
 
     def _get_shared_repository_permissions(
         self,
-    ) -> tuple[int | None, int | None]:
-        """Get shared repository file and directory permissions from config.
+    ) -> "SharedPerm | None":
+        """Get the shared repository permission setting from config.
 
         Returns:
-            tuple of (file_mask, directory_mask) or (None, None) if not shared
+            SharedPerm to apply, or None if not shared
         """
         try:
             config = self.get_config()
             value = config.get(("core",), "sharedRepository")
             return parse_shared_repository(value)
         except KeyError:
-            return (None, None)
+            return None
 
     def _put_named_file(self, path: str, contents: bytes) -> None:
         """Write a file to the control dir with the given name and contents.
@@ -1945,16 +1928,15 @@ class Repo(BaseRepo):
         path = path.lstrip(os.path.sep)
 
         # Get shared repository permissions
-        file_mode, _ = self._get_shared_repository_permissions()
+        shared_perm = self._get_shared_repository_permissions()
 
         # Create file with appropriate permissions
-        if file_mode is not None:
-            with GitFile(
-                os.path.join(self.controldir(), path), "wb", mask=file_mode
-            ) as f:
+        full_path = os.path.join(self.controldir(), path)
+        if shared_perm is not None:
+            with GitFile(full_path, "wb", shared_perm=shared_perm) as f:
                 f.write(contents)
         else:
-            with GitFile(os.path.join(self.controldir(), path), "wb") as f:
+            with GitFile(full_path, "wb") as f:
                 f.write(contents)
 
     def _del_named_file(self, path: str) -> None:
@@ -2038,13 +2020,13 @@ class Repo(BaseRepo):
             skip_hash = config.get_boolean(b"index", b"skipHash", False)
 
         # Get shared repository permissions for index file
-        file_mode, _ = self._get_shared_repository_permissions()
+        shared_perm = self._get_shared_repository_permissions()
 
         return Index(
             self.index_path(),
             skip_hash=skip_hash,
             version=index_version,
-            file_mode=file_mode,
+            shared_perm=shared_perm,
             path_normalizer=make_path_normalizer(config),
         )
 
@@ -2334,17 +2316,15 @@ class Repo(BaseRepo):
             controldir = os.fsdecode(controldir)
 
         # Determine shared repository permissions early
-        file_mode: int | None = None
-        dir_mode: int | None = None
+        shared_perm: SharedPerm | None = None
         if shared_repository is not None:
-            file_mode, dir_mode = parse_shared_repository(shared_repository)
+            shared_perm = parse_shared_repository(shared_repository)
 
         # Create base directories with appropriate permissions
         for d in BASE_DIRECTORIES:
             dir_path = os.path.join(controldir, *d)
             os.mkdir(dir_path)
-            if dir_mode is not None:
-                os.chmod(dir_path, dir_mode)
+            adjust_shared_perm(dir_path, shared_perm)
 
         # Determine hash algorithm
         from .object_format import get_object_format
@@ -2354,8 +2334,7 @@ class Repo(BaseRepo):
         if object_store is None:
             object_store = DiskObjectStore.init(
                 os.path.join(controldir, OBJECTDIR),
-                file_mode=file_mode,
-                dir_mode=dir_mode,
+                shared_perm=shared_perm,
                 object_format=hash_alg,
             )
         ret = cls(path, bare=bare, object_store=object_store)
@@ -2471,19 +2450,17 @@ class Repo(BaseRepo):
             f.write(b"gitdir: " + os.fsencode(gitdir_ref) + b"\n")
 
         # Get shared repository permissions from main repository
-        _, dir_mode = main_repo._get_shared_repository_permissions()
+        shared_perm = main_repo._get_shared_repository_permissions()
 
         # Create directories with appropriate permissions
         try:
             os.mkdir(main_worktreesdir)
-            if dir_mode is not None:
-                os.chmod(main_worktreesdir, dir_mode)
+            adjust_shared_perm(main_worktreesdir, shared_perm)
         except FileExistsError:
             pass
         try:
             os.mkdir(worktree_controldir)
-            if dir_mode is not None:
-                os.chmod(worktree_controldir, dir_mode)
+            adjust_shared_perm(worktree_controldir, shared_perm)
         except FileExistsError:
             pass
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -22,10 +22,17 @@
 import io
 import os
 import shutil
+import stat
 import sys
 import tempfile
 
-from dulwich.file import FileLocked, GitFile, _fancy_rename
+from dulwich.file import (
+    PERM_EVERYBODY,
+    PERM_GROUP,
+    FileLocked,
+    GitFile,
+    _fancy_rename,
+)
 
 from . import SkipTest, TestCase
 
@@ -209,3 +216,47 @@ class GitFileTests(TestCase):
 
         f.abort()
         self.assertTrue(f._closed)
+
+    def test_shared_perm_applied_on_close(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("Windows does not support Unix file permissions")
+        foo = self.path("foo")
+        old = os.umask(0o022)
+        self.addCleanup(os.umask, old)
+        with GitFile(foo, "wb", shared_perm=PERM_GROUP) as f:
+            f.write(b"data")
+        self.assertEqual(0o664, stat.S_IMODE(os.stat(foo).st_mode))
+
+    def test_shared_perm_only_widens(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("Windows does not support Unix file permissions")
+        foo = self.path("foo")
+        old = os.umask(0o077)
+        self.addCleanup(os.umask, old)
+        # "all" widens a 0o600 file to group write and other read, matching
+        # git init --shared=all under the same umask.
+        with GitFile(foo, "wb", shared_perm=PERM_EVERYBODY) as f:
+            f.write(b"data")
+        self.assertEqual(0o664, stat.S_IMODE(os.stat(foo).st_mode))
+
+    def test_shared_perm_keeps_read_only_files_read_only(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("Windows does not support Unix file permissions")
+        foo = self.path("foo")
+        old = os.umask(0o022)
+        self.addCleanup(os.umask, old)
+        # Loose objects and packs are written read-only; sharing must only
+        # widen who may read them, never grant write.
+        with GitFile(foo, "wb", mask=0o444, shared_perm=PERM_EVERYBODY) as f:
+            f.write(b"data")
+        self.assertEqual(0o444, stat.S_IMODE(os.stat(foo).st_mode))
+
+    def test_no_shared_perm_leaves_mask(self) -> None:
+        if sys.platform == "win32":
+            self.skipTest("Windows does not support Unix file permissions")
+        foo = self.path("foo")
+        old = os.umask(0o022)
+        self.addCleanup(os.umask, old)
+        with GitFile(foo, "wb") as f:
+            f.write(b"data")
+        self.assertEqual(0o644, stat.S_IMODE(os.stat(foo).st_mode))

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -39,6 +39,7 @@ from dulwich.attrs import GitAttributes
 from dulwich.client import LocalGitClient
 from dulwich.config import Config
 from dulwich.errors import NotGitRepository, ObjectFormatException
+from dulwich.file import PERM_EVERYBODY, PERM_GROUP, SharedPerm, calc_shared_perm
 from dulwich.index import get_unstaged_changes as _get_unstaged_changes
 from dulwich.object_store import tree_lookup_path
 from dulwich.repo import (
@@ -49,6 +50,7 @@ from dulwich.repo import (
     UnsupportedExtension,
     UnsupportedVersion,
     check_user_identity,
+    parse_shared_repository,
 )
 from dulwich.tests.utils import open_repo, setup_warning_catcher, tear_down_repo
 
@@ -2210,6 +2212,36 @@ class SharedRepositoryTests(TestCase):
         """Get the file mode bits (without file type bits)."""
         return stat.S_IMODE(os.stat(path).st_mode)
 
+    def test_calc_shared_perm_only_loosens(self):
+        """Named settings add bits but never remove them."""
+        # "all" adds other-read to a group-writable mode.
+        self.assertEqual(0o664, calc_shared_perm(0o644, PERM_EVERYBODY))
+        # It cannot restore write bits the umask stripped.
+        self.assertEqual(0o664, calc_shared_perm(0o664, PERM_EVERYBODY))
+        # "group" leaves others alone.
+        self.assertEqual(0o660, calc_shared_perm(0o640, PERM_GROUP))
+
+    def test_calc_shared_perm_read_only_stays_read_only(self):
+        """A mode without user write does not gain write bits."""
+        self.assertEqual(0o444, calc_shared_perm(0o444, PERM_EVERYBODY))
+
+    def test_calc_shared_perm_explicit_octal_replaces(self):
+        """An explicit octal setting states the mode outright."""
+        perm = parse_shared_repository("0600")
+        self.assertEqual(0o600, calc_shared_perm(0o666, perm))
+
+    def test_parse_shared_repository(self):
+        self.assertEqual(PERM_GROUP, parse_shared_repository("group"))
+        self.assertEqual(PERM_GROUP, parse_shared_repository(True))
+        self.assertEqual(PERM_EVERYBODY, parse_shared_repository("all"))
+        self.assertEqual(PERM_EVERYBODY, parse_shared_repository("2"))
+        self.assertIsNone(parse_shared_repository("umask"))
+        self.assertIsNone(parse_shared_repository(False))
+        self.assertIsNone(parse_shared_repository("bogus"))
+        self.assertEqual(
+            SharedPerm(tweak=0o666, replace=True), parse_shared_repository("0666")
+        )
+
     def _check_permissions(self, repo, expected_file_mode, expected_dir_mode):
         """Check that repository files and directories have expected permissions."""
         objects_dir = os.path.join(repo.commondir(), "objects")
@@ -2245,8 +2277,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         repo = Repo.init_bare(tmp_dir, shared_repository="group")
         self.addCleanup(repo.close)
@@ -2268,11 +2300,65 @@ class SharedRepositoryTests(TestCase):
         repo = Repo.init_bare(tmp_dir, shared_repository="all")
         self.addCleanup(repo.close)
 
-        # Expected permissions for world sharing
+        # With umask 0 nothing strips the write bits, so "all" keeps them,
+        # matching git init --shared=all under the same umask.
         expected_dir_mode = 0o2777  # setgid + rwxrwxrwx
         expected_file_mode = 0o666  # rw-rw-rw-
 
         self._check_permissions(repo, expected_file_mode, expected_dir_mode)
+
+    def test_init_bare_shared_all_default_umask(self):
+        """sharedRepository=all grants others read but not write."""
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+
+        os.umask(0o022)
+
+        repo = Repo.init_bare(tmp_dir, shared_repository="all")
+        self.addCleanup(repo.close)
+
+        # git init --shared=all under umask 022 produces these modes.
+        self._check_permissions(repo, 0o664, 0o2775)
+
+    def test_init_bare_shared_all_not_world_writable(self):
+        """sharedRepository=all must not leave the control dir world-writable."""
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+
+        os.umask(0o022)
+
+        repo = Repo.init_bare(tmp_dir, shared_repository="all")
+        self.addCleanup(repo.close)
+
+        for name in ("hooks", "refs", "objects", "info"):
+            path = os.path.join(repo.commondir(), name)
+            mode = self._get_file_mode(path)
+            self.assertEqual(
+                0,
+                mode & stat.S_IWOTH,
+                f"{name} is world-writable: {oct(mode)}",
+            )
+
+    def test_shared_all_and_group_differ_under_restrictive_umask(self):
+        """Sharing with all grants others read where group sharing does not."""
+        os.umask(0o077)
+
+        all_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, all_dir)
+        all_repo = Repo.init_bare(all_dir, shared_repository="all")
+        self.addCleanup(all_repo.close)
+
+        group_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, group_dir)
+        group_repo = Repo.init_bare(group_dir, shared_repository="group")
+        self.addCleanup(group_repo.close)
+
+        self.assertEqual(
+            0o2775, self._get_file_mode(os.path.join(all_repo.commondir(), "refs"))
+        )
+        self.assertEqual(
+            0o2770, self._get_file_mode(os.path.join(group_repo.commondir(), "refs"))
+        )
 
     def test_init_bare_shared_umask(self):
         """Test initializing bare repo with sharedRepository=umask (default)."""
@@ -2296,8 +2382,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         repo = Repo.init_bare(tmp_dir, shared_repository="group")
         self.addCleanup(repo.close)
@@ -2311,7 +2397,7 @@ class SharedRepositoryTests(TestCase):
 
         # Check file permissions
         actual_mode = self._get_file_mode(obj_path)
-        expected_mode = 0o664  # rw-rw-r--
+        expected_mode = 0o444  # r--r--r--
         self.assertEqual(
             expected_mode,
             actual_mode,
@@ -2348,11 +2434,34 @@ class SharedRepositoryTests(TestCase):
 
         # Check file permissions
         actual_mode = self._get_file_mode(obj_path)
-        expected_mode = 0o666  # rw-rw-rw-
+        # Objects are written read-only, so the shared setting only controls
+        # who may read them. git init --shared=all behaves the same way.
+        expected_mode = 0o444  # r--r--r--
         self.assertEqual(
             expected_mode,
             actual_mode,
             f"loose object mode: expected {oct(expected_mode)}, got {oct(actual_mode)}",
+        )
+
+    def test_loose_object_not_world_writable(self):
+        """Loose objects are not world-writable under a default umask."""
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+
+        os.umask(0o022)
+
+        repo = Repo.init_bare(tmp_dir, shared_repository="all")
+        self.addCleanup(repo.close)
+
+        blob = objects.Blob.from_string(b"test content")
+        repo.object_store.add_object(blob)
+
+        obj_path = repo.object_store._get_shafile_path(blob.id)
+        actual_mode = self._get_file_mode(obj_path)
+        self.assertEqual(
+            0,
+            actual_mode & stat.S_IWOTH,
+            f"loose object is world-writable: {oct(actual_mode)}",
         )
 
     def test_pack_file_permissions_group(self):
@@ -2360,8 +2469,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         repo = Repo.init_bare(tmp_dir, shared_repository="group")
         self.addCleanup(repo.close)
@@ -2380,7 +2489,7 @@ class SharedRepositoryTests(TestCase):
         # Check pack file permissions
         pack_path = os.path.join(pack_dir, pack_files[0])
         actual_mode = self._get_file_mode(pack_path)
-        expected_mode = 0o664  # rw-rw-r--
+        expected_mode = 0o444  # r--r--r--
         self.assertEqual(
             expected_mode,
             actual_mode,
@@ -2392,8 +2501,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         repo = Repo.init_bare(tmp_dir, shared_repository="group")
         self.addCleanup(repo.close)
@@ -2412,7 +2521,7 @@ class SharedRepositoryTests(TestCase):
         # Check pack index file permissions
         idx_path = os.path.join(pack_dir, idx_files[0])
         actual_mode = self._get_file_mode(idx_path)
-        expected_mode = 0o664  # rw-rw-r--
+        expected_mode = 0o444  # r--r--r--
         self.assertEqual(
             expected_mode,
             actual_mode,
@@ -2424,8 +2533,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         # Create non-bare repo (index only exists in non-bare repos)
         repo = Repo.init(tmp_dir, shared_repository="group")
@@ -2455,8 +2564,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         # Create repo with shared=group
         repo = Repo.init_bare(tmp_dir, shared_repository="group")
@@ -2472,7 +2581,7 @@ class SharedRepositoryTests(TestCase):
 
         obj_path = repo.object_store._get_shafile_path(blob.id)
         actual_mode = self._get_file_mode(obj_path)
-        expected_mode = 0o664  # rw-rw-r--
+        expected_mode = 0o444  # r--r--r--
         self.assertEqual(
             expected_mode,
             actual_mode,
@@ -2484,8 +2593,8 @@ class SharedRepositoryTests(TestCase):
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, tmp_dir)
 
-        # Set umask to 0 to see what permissions are actually set
-        os.umask(0)
+        # Use a conventional umask; git's shared masks only loosen it.
+        os.umask(0o022)
 
         repo = Repo.init(tmp_dir, shared_repository="group")
         self.addCleanup(repo.close)


### PR DESCRIPTION
Named sharedRepository settings replaced the mode outright instead of loosening the umask-derived one, so "group" and "all" chmodded directories to 0o2777 whatever the umask. Under a conventional umask that left .git/hooks and .git/refs world-writable, letting any local user install a hook or rewrite a ref.

Follow git's calc_shared_perm instead: named settings OR their bits onto the umask-derived mode, while an explicit octal setting still states the mode outright. Files written through GitFile now get an explicit chmod, since os.open() applies the umask to the requested mask.