### PR TITLE
Don't follow symlinks when writing patch files in format_patch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.2.13	UNRELEASED
 
+ * SECURITY: Don't follow symlinks when writing patch files in
+   ``porcelain.format_patch``. A symlink pre-planted at a patch's filename in
+   the output directory was followed, writing the patch outside that directory.
+   (Jelmer Vernooĳ; Reported by wzc)
+
  * Catch ``PackFileDisappeared`` in the bitmap probe in
    ``get_reachability_provider``, which only guarded ``FileNotFoundError``.
    (Jelmer Vernooĳ, #2344)

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -293,6 +293,7 @@ __all__ = [
 ]
 
 import datetime
+import errno
 import fnmatch
 import logging
 import os
@@ -8803,7 +8804,19 @@ def format_patch(
                 summary = get_summary(commit)
                 filename = os.path.join(outdir, f"{i:04d}-{summary}.patch")
 
-                with open(filename, "wb") as f:
+                # Refuse to follow a symlink at the target name: patch output
+                # directories are not necessarily private, so following one
+                # would write outside the directory the caller asked for.
+                flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+                if hasattr(os, "O_NOFOLLOW"):
+                    flags |= os.O_NOFOLLOW
+                elif os.path.islink(filename):
+                    # Windows has no O_NOFOLLOW; this check races, but creating
+                    # symlinks there requires privileges that make the attack
+                    # far less reachable.
+                    raise OSError(errno.ELOOP, os.strerror(errno.ELOOP), filename)
+
+                with os.fdopen(os.open(filename, flags, 0o666), "wb") as f:
                     write_commit_patch(
                         f,
                         commit,

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -3236,6 +3236,36 @@ class FormatPatchTests(PorcelainTestCase):
         )
         self.assertEqual(patches, [])
 
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_format_patch_does_not_follow_symlink_in_outdir(self) -> None:
+        # A symlink pre-planted at the patch's filename must not be followed,
+        # which would write the patch outside outdir.
+        tree1 = Tree()
+        c1 = make_commit(tree=tree1, message=b"Initial commit")
+        self.repo.object_store.add_objects([(tree1, None), (c1, None)])
+
+        blob = Blob.from_string(b"data")
+        tree2 = Tree()
+        tree2.add(b"f.txt", 0o100644, blob.id)
+        c2 = make_commit(tree=tree2, parents=[c1.id], message=b"subject here")
+        self.repo.object_store.add_objects([(blob, None), (tree2, None), (c2, None)])
+        self.repo[b"HEAD"] = c2.id
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outdir = os.path.join(tmpdir, "out")
+            os.mkdir(outdir)
+            target = os.path.join(tmpdir, "escaped")
+            os.symlink(target, os.path.join(outdir, "0001-subject-here.patch"))
+
+            self.assertRaises(
+                OSError,
+                porcelain.format_patch,
+                self.repo.path,
+                committish=c2.id,
+                outdir=outdir,
+            )
+            self.assertFalse(os.path.exists(target))
+
     def test_format_patch_subject_cannot_escape_outdir(self) -> None:
         # A malicious commit subject must not be able to direct the
         # generated patch file outside the requested output directory.


### PR DESCRIPTION
A symlink pre-planted at a patch's filename in the output directory was followed, writing the patch outside the directory the caller asked for.