### PR TITLE
Keep the directory constraint on patterns ending in "**/"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -40,6 +40,11 @@
    compat layer, so repositories carrying such paths could not be cloned
    elsewhere. (Jelmer Vernooĳ, #2351)
 
+ * Fix ``ignore`` and ``attrs`` matching for patterns ending in ``**/``. The
+   trailing slash was dropped when translating the pattern, so ``foo/**/`` also
+   matched ``foo/`` itself and every file directly inside it. Git only ignores
+   the directories below ``foo``. (adarshsm)
+
  * Catch ``PackFileDisappeared`` in the bitmap probe in
    ``get_reachability_provider``, which only guarded ``FileNotFoundError``.
    (Jelmer Vernooĳ, #2344)

--- a/dulwich/wildmatch.py
+++ b/dulwich/wildmatch.py
@@ -242,6 +242,12 @@ def _translate_double_asterisk(segments: Sequence[bytes], i: int) -> tuple[bytes
     # Check if ** is at end
     remaining = segments[i + 1 :]
     if all(s == b"" for s in remaining):
+        if remaining:
+            # Trailing "**/" is a directory pattern, so it has to consume at
+            # least one directory and end in a slash. Without this, "abc/**/"
+            # also matches "abc/" itself and every file directly inside it,
+            # while Git only ignores the directories below "abc".
+            return b".*/", False
         # ** at end - matches everything
         return b".*", False
 

--- a/tests/compat/test_check_attr.py
+++ b/tests/compat/test_check_attr.py
@@ -143,6 +143,45 @@ class CheckAttrCompatTestCase(CompatTestCase):
             self._create_file(path)
         self._assert_attr_match("text", paths)
 
+    def test_trailing_double_asterisk_slash(self) -> None:
+        # ``foo/**/`` in .gitattributes goes through the same wildmatch
+        # translation as .gitignore, so the trailing slash must be preserved:
+        # only directories under foo get the attribute.
+        self._write_gitattributes("foo/**/ text\n")
+        paths = ["foo/f.txt", "foo/sub/", "foo/sub/g.txt"]
+        for path in paths:
+            if not path.endswith("/"):
+                self._create_file(path)
+        os.makedirs(os.path.join(self.test_dir, "foo", "sub"), exist_ok=True)
+        self._assert_attr_match("text", paths)
+
+    def test_trailing_double_asterisk_slash_at_root(self) -> None:
+        # A bare ``**/`` gives the attribute to every directory below root.
+        self._write_gitattributes("**/ text\n")
+        self._create_file("keep.txt")
+        self._create_file("foo/bla.c")
+        os.makedirs(os.path.join(self.test_dir, "foo", "bar"), exist_ok=True)
+        paths = ["keep.txt", "foo/", "foo/bla.c", "foo/bar/"]
+        self._assert_attr_match("text", paths)
+
+    def test_trailing_double_asterisk_slash_nested(self) -> None:
+        # ``foo/**/`` against a deeper tree with its own subdirectories.
+        self._write_gitattributes("foo/**/ text\n")
+        self._create_file("foo/a.txt")
+        self._create_file("foo/bar/b.txt")
+        self._create_file("foo/bar/bla/c.txt")
+        self._create_file("keep/foo/d.txt")
+        paths = [
+            "foo/a.txt",
+            "foo/bar/",
+            "foo/bar/b.txt",
+            "foo/bar/bla/",
+            "foo/bar/bla/c.txt",
+            "keep/foo/",
+            "keep/foo/d.txt",
+        ]
+        self._assert_attr_match("text", paths)
+
     def test_wildcards_do_not_cross_slash(self) -> None:
         self._write_gitattributes("a*c text\na?c text\n")
         paths = ["abc", "ac", "a/c", "abbc", "axc"]

--- a/tests/compat/test_check_ignore.py
+++ b/tests/compat/test_check_ignore.py
@@ -1249,6 +1249,56 @@ class CheckIgnoreCompatTestCase(CompatTestCase):
         ]
         self._assert_ignore_match(paths)
 
+    def test_trailing_double_asterisk_slash(self) -> None:
+        """Test that "foo/**/" only covers the directories below foo.
+
+        "foo/" itself is left out: git answers it inconsistently. "git status
+        --ignored" leaves the directory untracked, while "git check-ignore
+        foo/" calls it ignored, because the pattern is matched against the
+        trailing slash of the argument and "**" happily matches nothing.
+        """
+        self._write_gitignore("foo/**/\n")
+        self._create_file("foo/keep.txt")
+        self._create_file("foo/bar/bla.c")
+        self._create_dir("foo/bar/bla")
+
+        paths = [
+            "foo/keep.txt",
+            "foo/bar/",
+            "foo/bar/bla.c",
+            "foo/bar/bla/",
+        ]
+        self._assert_ignore_match(paths)
+
+    def test_trailing_double_asterisk_slash_at_root(self) -> None:
+        """Test a bare "**/", which covers every directory below the root."""
+        self._write_gitignore("**/\n")
+        self._create_file("keep.txt")
+        self._create_file("foo/bla.c")
+        self._create_dir("foo/bar")
+
+        paths = ["keep.txt", "foo/", "foo/bla.c", "foo/bar/"]
+        self._assert_ignore_match(paths)
+
+    def test_trailing_double_asterisk_slash_nested(self) -> None:
+        """Test "foo/**/" against a deeper tree with its own subdirectories."""
+        self._write_gitignore("foo/**/\n")
+        self._create_file("foo/a.txt")
+        self._create_file("foo/bar/b.txt")
+        self._create_file("foo/bar/bla/c.txt")
+        self._create_file("keep/foo/d.txt")
+
+        paths = [
+            "foo/a.txt",
+            "foo/bar/",
+            "foo/bar/b.txt",
+            "foo/bar/bla/",
+            "foo/bar/bla/c.txt",
+            "keep/foo/",
+            "keep/foo/d.txt",
+        ]
+        self._assert_ignore_match(paths)
+
     def _git_check_ignore_quoted(self, paths: Sequence[str]) -> set[str]:
         """Run git check-ignore with default quoting and return set of ignored paths."""
         try:

--- a/tests/test_attrs.py
+++ b/tests/test_attrs.py
@@ -317,6 +317,15 @@ class PatternTests(TestCase):
         self.assertFalse(pattern.match(b"foo.txt"))
         self.assertFalse(pattern.match(b"other/foo.txt"))
 
+    def test_trailing_double_asterisk_slash(self):
+        """Trailing ``**/`` requires at least one subdirectory."""
+        pattern = Pattern(b"foo/**/")
+        self.assertTrue(pattern.match(b"foo/sub/"))
+        self.assertTrue(pattern.match(b"foo/a/b/"))
+        self.assertFalse(pattern.match(b"foo/"))
+        self.assertFalse(pattern.match(b"foo/f.txt"))
+        self.assertFalse(pattern.match(b"foo/sub/g.txt"))
+
     def test_leading_slash(self):
         """Test pattern with leading slash."""
         pattern = Pattern(b"/README.txt")

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -54,6 +54,8 @@ POSITIVE_MATCH_TESTS = [
     (b"foo.c", b"foo.c"),
     (b"foo.c", b"foo.[ch]"),
     (b"foo/bar/bla.c", b"foo/**"),
+    (b"foo/bar/", b"foo/**/"),
+    (b"foo/bar/bla/", b"foo/**/"),
     (b"foo/bar/bla/blie.c", b"foo/**/blie.c"),
     (b"foo/bar/bla.c", b"**/bla.c"),
     (b"bla.c", b"**/bla.c"),
@@ -78,6 +80,8 @@ NEGATIVE_MATCH_TESTS = [
     (b"foo.c", b"foo.[^ch]"),
     (b"foo.x", b"foo.[[:digit:]]"),
     (b"a/b", b"a[!x]b"),
+    (b"foo/bla.c", b"foo/**/"),
+    (b"foo/", b"foo/**/"),
 ]
 
 
@@ -90,6 +94,7 @@ TRANSLATE_TESTS = [
     (b"foo.[ch]", b"(?ms)(.*/)?foo\\.[ch]/?\\Z"),
     (b"bar/", b"(?ms)(.*/)?bar\\/\\Z"),
     (b"foo/**", b"(?ms)foo/.*/?\\Z"),
+    (b"foo/**/", b"(?ms)foo/.*/\\Z"),
     (b"foo/**/blie.c", b"(?ms)foo/(?:[^/]+/)*blie\\.c/?\\Z"),
     (b"**/bla.c", b"(?ms)(.*/)?bla\\.c/?\\Z"),
     (b"foo/**/bar", b"(?ms)foo/(?:[^/]+/)*bar/?\\Z"),
@@ -502,6 +507,20 @@ class IgnoreFilterManagerTests(TestCase):
         self.assertFalse(m.is_ignored("dir3"))
         self.assertTrue(m.is_ignored("dir3/"))
         self.assertTrue(m.is_ignored("dir3/bla"))
+
+    def test_trailing_double_asterisk_slash_is_directory_only(self) -> None:
+        # "foo/**/" is a directory pattern: Git ignores the directories below
+        # foo, but not a file sitting directly in foo.
+        tmp_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+        repo = Repo.init(tmp_dir)
+        with open(os.path.join(repo.path, ".gitignore"), "wb") as f:
+            f.write(b"foo/**/\n")
+        os.makedirs(os.path.join(repo.path, "foo", "sub"))
+        m = IgnoreFilterManager.from_repo(repo)
+        self.assertFalse(m.is_ignored("foo/keep.txt"))
+        self.assertTrue(m.is_ignored("foo/sub/"))
+        self.assertTrue(m.is_ignored("foo/sub/bla.txt"))
 
     def test_nested_gitignores(self) -> None:
         tmp_dir = tempfile.mkdtemp()

--- a/tests/test_wildmatch.py
+++ b/tests/test_wildmatch.py
@@ -109,6 +109,14 @@ class TranslateTests(TestCase):
         self.assertMatches(b"a/**/d", b"a/d")
         self.assertMatches(b"**/d", b"a/b/d")
 
+    def test_trailing_double_asterisk_slash_requires_subdir(self) -> None:
+        # 'a/**/' is directory-only: the trailing '/' must be preserved so
+        # 'a/f' (a file directly under 'a') does not match.
+        self.assertMatches(b"a/**/", b"a/b/")
+        self.assertMatches(b"a/**/", b"a/b/c/")
+        self.assertNotMatches(b"a/**/", b"a/")
+        self.assertNotMatches(b"a/**/", b"a/f")
+
     def test_bracket(self) -> None:
         self.assertMatches(b"a/[[:digit:]]", b"a/5")
         self.assertNotMatches(b"a/[[:digit:]]", b"a/x")


### PR DESCRIPTION
A trailing `**/` makes a gitignore pattern directory-only, but the translation dropped the
trailing slash:

```python
>>> from dulwich.ignore import translate
>>> translate(b"foo/**/")
b'(?ms)foo/.*\\Z'      # before
b'(?ms)foo/.*/\\Z'     # after
```

Without the slash the pattern also matches `foo/` itself and every file sitting directly in
`foo`, while Git only ignores the directories below `foo`.

Confirmed against Git in a real working tree, which is the behaviour that matters here:

```console
$ cat .gitignore
foo/**/
$ git status --porcelain -uall --ignored
?? foo/f.txt          # not ignored
!! foo/sub/g.txt      # ignored
```

`IgnoreFilterManager.is_ignored("foo/f.txt")` returned `True` before this change, so
`foo/f.txt` was hidden from anything walking a tree through dulwich.

Since `dulwich.attrs` shares the same `wildmatch` translation, gitattributes patterns
ending in `**/` were affected in the same way.

## A note on how this was verified

`git check-ignore` turned out to be an unreliable oracle for this, twice over, so I want to
flag it rather than have a reviewer trip on the same thing:

- With a path already in the index it reports "not ignored" regardless of the patterns,
  unless `--no-index` is passed.
- Even with `--no-index`, `git check-ignore foo/` reports `foo/` as ignored under
  `foo/**/`, which contradicts the working-tree behaviour above — if `foo/` really were
  ignored, `foo/f.txt` could not show up as untracked.

So the ground truth used here is `git status --porcelain -uall --ignored` on a real
repository. Comparing that against `IgnoreFilterManager` over a matrix of patterns
(`abc/**/`, `abc/**`, `abc/`, `**/tmp/`, `logs/**/`, `abc/**/def/`) and their contents:
**2 of 16 cases disagreed with Git before this change, 0 of 16 after.**

## Tests

Three regression tests, all of which fail without the change:

- `translate(b"foo/**/")` keeps the trailing slash (`TRANSLATE_TESTS`).
- `foo/bar/` and `foo/bar/bla/` match `foo/**/` (`POSITIVE_MATCH_TESTS`), while `foo/bla.c`
  and `foo/` do not (`NEGATIVE_MATCH_TESTS`).
- `IgnoreFilterManagerTests.test_trailing_double_asterisk_slash_is_directory_only` covers
  the end-to-end behaviour through a real repository.

```
pytest tests/test_ignore.py tests/test_attrs.py tests/test_wildmatch.py   # 118 passed
pytest tests/                                                            # 3732 passed
```

The full run also reports 12 failures in `tests/test_signature.py` and
`tests/test___main__.py`, all from `gpg`/`gpgsm` not being installed in my environment. The
failing test ids are identical with and without this change.

`ruff check` and `ruff format --check` are clean, and there is a NEWS entry.

## Out of scope

The same comparison surfaced a second, unrelated divergence: `abc/*` does not match `abc/`
in dulwich but does in Git. Different root cause, so I have left it out of this PR rather
than widen the change. Happy to look at it separately if you would like.
