### PR TITLE
Keep borrowed packs open after cache eviction

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 1.2.13	UNRELEASED
 
+ * Keep packs usable by existing readers after they are evicted from the
+   object-store cache. (Bojan Zivanovic)
+
  * SECURITY: Don't follow symlinks when writing patch files in
    ``porcelain.format_patch``. A symlink pre-planted at a patch's filename in
    the output directory was followed, writing the patch outside that directory.

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -1065,7 +1065,7 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
         if prev_pack is not pack:
             self._pack_cache[base_name] = pack
             if prev_pack:
-                prev_pack.close()
+                prev_pack._release_from_cache()
         self._mark_pack_used(base_name)
         self._enforce_packed_git_limit()
 
@@ -1131,8 +1131,8 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
             oldest = self._pack_access_order.pop(0)
             pack = self._pack_cache.get(oldest)
             if pack is not None:
-                pack.close()
                 del self._pack_cache[oldest]
+                pack._release_from_cache()
 
     def _iter_cached_packs(self) -> Iterator[Pack]:
         return iter(list(self._pack_cache.values()))
@@ -1151,10 +1151,7 @@ class PackBasedObjectStore(PackCapableObjectStore, PackedObjectContainer):
                     self._pack_access_order.remove(key)
                 except ValueError:
                     pass
-                try:
-                    cached.close()
-                except OSError:
-                    pass
+                cached._release_from_cache()
                 break
 
     def _lookup_in_packs(self, lookup: "Callable[[Pack], _T]") -> "_T":
@@ -1952,7 +1949,7 @@ class DiskObjectStore(PackBasedObjectStore):
                 self._mark_pack_used(basename)
         # Remove disappeared pack files
         for f in set(self._pack_cache) - pack_files:
-            self._pack_cache.pop(f).close()
+            self._pack_cache.pop(f)._release_from_cache()
             try:
                 self._pack_access_order.remove(f)
             except ValueError:
@@ -3676,7 +3673,7 @@ class BucketBasedObjectStore(PackBasedObjectStore):
                 self._pack_cache[f] = pack
         # Remove disappeared pack files
         for f in set(self._pack_cache) - pack_files:
-            self._pack_cache.pop(f).close()
+            self._pack_cache.pop(f)._release_from_cache()
         return new_packs
 
     def _upload_pack(

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -4128,8 +4128,12 @@ class Pack:
         self._idx = None
         self._bitmap = None
         self._released_from_cache = False
-        self._idx_path = self._basename + ".idx"
-        self._data_path = self._basename + ".pack"
+        # The loaders below must capture the paths as locals rather than read
+        # them off self, so that the closures don't make the Pack part of a
+        # reference cycle; a cycle would delay __del__ (and with it the file
+        # close) until a garbage collector pass.
+        idx_path = self._idx_path = self._basename + ".idx"
+        data_path = self._data_path = self._basename + ".pack"
         self._bitmap_path = self._basename + ".bitmap"
         self.delta_window_size = delta_window_size
         self.window_memory = window_memory
@@ -4138,9 +4142,9 @@ class Pack:
         self.threads = threads
         self.big_file_threshold = big_file_threshold
         self.delta_base_cache_limit = delta_base_cache_limit
-        self._idx_load = lambda: load_pack_index(self._idx_path, object_format)
+        self._idx_load = lambda: load_pack_index(idx_path, object_format)
         self._data_load = lambda: PackData(
-            self._data_path,
+            data_path,
             delta_window_size=delta_window_size,
             window_memory=window_memory,
             delta_cache_size=delta_cache_size,

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -4127,6 +4127,7 @@ class Pack:
         self._data = None
         self._idx = None
         self._bitmap = None
+        self._released_from_cache = False
         self._idx_path = self._basename + ".idx"
         self._data_path = self._basename + ".pack"
         self._bitmap_path = self._basename + ".bitmap"
@@ -4315,14 +4316,27 @@ class Pack:
             self._idx.close()
             self._idx = None
 
+    def _release_from_cache(self) -> None:
+        """Release cache ownership without invalidating other users.
+
+        The pack's resources are closed by ``__del__`` once the last reference
+        is gone. Since this is an intentional ownership transfer, finalization
+        should not report the pack as leaked.
+        """
+        self._released_from_cache = True
+
     def __del__(self) -> None:
         """Ensure pack file is closed when Pack is garbage collected."""
         if self._data is not None or self._idx is not None:
             import warnings
 
-            warnings.warn(
-                f"unclosed Pack {self!r}", ResourceWarning, stacklevel=2, source=self
-            )
+            if not self._released_from_cache:
+                warnings.warn(
+                    f"unclosed Pack {self!r}",
+                    ResourceWarning,
+                    stacklevel=2,
+                    source=self,
+                )
             try:
                 self.close()
             except Exception:

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -4376,7 +4376,7 @@ class Pack:
 
     def __iter__(self) -> Iterator[ObjectID]:
         """Iterate over all the sha1s of the objects in this pack."""
-        return iter(self.index)
+        yield from self.index
 
     def check_length_and_checksum(self) -> None:
         """Sanity check the length and checksum of the pack index and data."""
@@ -4436,24 +4436,22 @@ class Pack:
 
     def iterobjects(self) -> Iterator[ShaFile]:
         """Iterate over the objects in this pack."""
-        return iter(
-            PackInflater.for_pack_data(self.data, resolve_ext_ref=self.resolve_ext_ref)
+        yield from PackInflater.for_pack_data(
+            self.data, resolve_ext_ref=self.resolve_ext_ref
         )
 
     def iterobjects_subset(
         self, shas: Iterable[ObjectID], *, allow_missing: bool = False
     ) -> Iterator[ShaFile]:
         """Iterate over a subset of objects in this pack."""
-        return (
-            uo
-            for uo in PackInflater.for_pack_subset(
-                self,
-                shas,
-                allow_missing=allow_missing,
-                resolve_ext_ref=self.resolve_ext_ref,
-            )
-            if uo.id in shas
-        )
+        for uo in PackInflater.for_pack_subset(
+            self,
+            shas,
+            allow_missing=allow_missing,
+            resolve_ext_ref=self.resolve_ext_ref,
+        ):
+            if uo.id in shas:
+                yield uo
 
     def iter_unpacked_subset(
         self,
@@ -4640,7 +4638,7 @@ class Pack:
             object count.
         Returns: iterator of tuples with (sha, offset, crc32)
         """
-        return self.data.iterentries(
+        yield from self.data.iterentries(
             progress=progress, resolve_ext_ref=self.resolve_ext_ref
         )
 
@@ -4654,10 +4652,8 @@ class Pack:
             object count
         Returns: Iterator of tuples with (sha, offset, crc32)
         """
-        return iter(
-            self.data.sorted_entries(
-                progress=progress, resolve_ext_ref=self.resolve_ext_ref
-            )
+        yield from self.data.sorted_entries(
+            progress=progress, resolve_ext_ref=self.resolve_ext_ref
         )
 
     def get_unpacked_object(

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -1085,6 +1085,55 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         # accessible because _update_pack_cache will re-open it if needed
         self.assertEqual((Blob.type_num, b"data for pack two"), store.get_raw(b2.id))
 
+    def test_packed_git_limit_does_not_close_pack_in_use(self) -> None:
+        store = DiskObjectStore(self.store_dir)
+        self.addCleanup(store.close)
+
+        b1 = make_object(Blob, data=b"first object in pack one")
+        b2 = make_object(Blob, data=b"second object in pack one")
+        f, commit, abort = store.add_pack()
+        try:
+            write_pack_objects(
+                f.write,
+                [(b1, None), (b2, None)],
+                object_format=DEFAULT_OBJECT_FORMAT,
+            )
+        except BaseException:
+            abort()
+            raise
+        pack_one = commit()
+        self.assertIsNotNone(pack_one)
+
+        b3 = make_object(Blob, data=b"object in pack two")
+        f, commit, abort = store.add_pack()
+        try:
+            write_pack_objects(
+                f.write, [(b3, None)], object_format=DEFAULT_OBJECT_FORMAT
+            )
+        except BaseException:
+            abort()
+            raise
+        pack_two = commit()
+        self.assertIsNotNone(pack_two)
+
+        assert pack_one is not None
+        assert pack_two is not None
+        # Load both packs, then make pack one the least recently used.
+        pack_one.data
+        pack_two.data
+        store.get_raw(b3.id)
+        store.get_raw(b1.id)
+        store.packed_git_limit = store._total_pack_mmap_size() - 1
+
+        unpacked = pack_one.iter_unpacked()
+        next(unpacked)
+        store.get_raw(b3.id)
+
+        self.assertNotIn(pack_one, store._pack_cache.values())
+        self.assertIsNotNone(pack_one._data)
+        self.assertEqual(1, len(list(unpacked)))
+        pack_one.close()
+
     def test_packed_git_limit_no_limit(self) -> None:
         store = DiskObjectStore(self.store_dir)
         self.addCleanup(store.close)

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -22,6 +22,7 @@
 
 """Tests for Dulwich packs."""
 
+import gc
 import os
 import platform
 import shutil
@@ -753,6 +754,29 @@ class TestPack(PackTests):
         with self.get_pack(pack1_sha) as p:
             expected = {p[s] for s in [commit_sha, tree_sha, a_sha]}
             self.assertEqual(expected, set(list(p.iterobjects())))
+
+    def test_iterators_keep_released_pack_alive(self) -> None:
+        iterator_factories = {
+            "iter": iter,
+            "iterobjects": lambda pack: pack.iterobjects(),
+            "iterobjects_subset": lambda pack: pack.iterobjects_subset([commit_sha]),
+            "entries": lambda pack: pack.entries(),
+            "sorted_entries": lambda pack: pack.sorted_entries(),
+        }
+
+        for name, factory in iterator_factories.items():
+            with self.subTest(name=name):
+                pack = self.get_pack(pack1_sha)
+                iterator = factory(pack)
+                pack._release_from_cache()
+                pack_ref = weakref.ref(pack)
+                del pack
+                gc.collect()
+
+                self.assertIsNotNone(pack_ref())
+                self.assertTrue(list(iterator))
+                gc.collect()
+                self.assertIsNone(pack_ref())
 
     def test_pack_tuples(self) -> None:
         with self.get_pack(pack1_sha) as p:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -23,11 +23,13 @@
 """Tests for Dulwich packs."""
 
 import os
+import platform
 import shutil
 import sys
 import tempfile
 import tracemalloc
 import types
+import weakref
 import zlib
 from hashlib import sha1
 from io import BytesIO
@@ -717,6 +719,20 @@ class TestPackData(PackTests):
 
 
 class TestPack(PackTests):
+    def test_no_reference_cycle(self) -> None:
+        # A Pack must be freeable by reference counting alone. If it is part
+        # of a reference cycle, __del__ (and with it the file close) waits
+        # for a cycle-collector pass, and a pack released from the object
+        # store cache keeps its files open past close() — which breaks
+        # directory removal on Windows.
+        pack = self.get_pack(pack1_sha)
+        self.assertEqual(3, len(pack))
+        pack.close()
+        ref = weakref.ref(pack)
+        del pack
+        if platform.python_implementation() == "CPython":
+            self.assertIsNone(ref())
+
     def test_len(self) -> None:
         with self.get_pack(pack1_sha) as p:
             self.assertEqual(3, len(p))


### PR DESCRIPTION
Several code paths close a `Pack` at the moment it leaves the object-store cache: `_add_cached_pack` closes the pack it replaces, `_enforce_packed_git_limit` closes the least-recently-used pack, `_remove_pack` closes on removal, and `_update_pack_cache` closes packs whose files disappeared.

Closing at eviction time is unsafe when the store is shared: `packs` and `get_raw` hand out references to cached `Pack` objects, so another consumer — a concurrent request in a threaded/greenlet server, or an iterator like `iter_unpacked` that is still mid-pack — may be reading from the pack when eviction closes it under its feet. The reader then fails on a closed file even though the pack file itself is still perfectly valid on disk.

This changes eviction to release ownership instead of closing: the pack is dropped from the cache, and the underlying files are closed by `Pack.__del__` once the last borrower is done with it. Since that hand-off is intentional, `__del__` no longer emits the "unclosed Pack" `ResourceWarning` for packs released this way — explicit leaks still warn as before.

The new test exercises the LRU-limit path: a pack evicted by `packed_git_limit` while an `iter_unpacked` iterator is mid-stream stays readable until the iterator completes.