### PR TITLE
Make concurrent PackData reads thread-safe

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.13	UNRELEASED
 
+ * Read packs via ``os.pread`` where available instead of seek+read on a
+   shared file position, so concurrent readers of the same ``PackData`` no
+   longer corrupt each other's reads. (Bojan Zivanovic, #2350)
+
  * SECURITY: Don't follow symlinks when writing messages in
    ``porcelain.format_patch``, ``mbox.split_mbox`` and ``mbox.split_maildir``.
    A symlink pre-planted at an output filename was followed, writing the

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1828,12 +1828,18 @@ class _PreadCursor:
     # ``unpack_object`` reads variable-length headers one byte at a time.
     # Reading a block in advance avoids a separate system call for each byte.
     _READAHEAD = 512
+    # Start small because most cursors only read one object. If a cursor keeps
+    # missing its buffer, grow the window so sequential scans need fewer reads.
+    _MAX_READAHEAD = 256 * 1024
+
+    __slots__ = ("_buf", "_buf_start", "_pack_data", "_readahead", "offset")
 
     def __init__(self, pack_data: "PackData", offset: int) -> None:
         self._pack_data = pack_data
         self.offset = offset
         self._buf = b""
         self._buf_start = 0
+        self._readahead = self._READAHEAD
 
     def read(self, size: int) -> bytes:
         """Read up to size bytes and advance the cursor.
@@ -1860,14 +1866,15 @@ class _PreadCursor:
             # close() wait until the descriptor is no longer in use.
             pack_data._active_preads += 1
         try:
-            # Read enough to satisfy the request and fill at least one
-            # readahead block. If pread returns early, continue until the
-            # request is complete or the end of the file is reached.
+            # Fetch some extra data for the next call. If pread returns a short
+            # result, keep going until this request is satisfied or we hit EOF.
+            want = size + self._readahead
+            self._readahead = min(self._readahead * 2, self._MAX_READAHEAD)
             chunks: list[bytes] = []
             have = 0
             while have < size:
                 chunk = os.pread(  # type: ignore[attr-defined,unused-ignore]
-                    fd, max(size - have, self._READAHEAD), self.offset + have
+                    fd, want - have, self.offset + have
                 )
                 if not chunk:
                     break
@@ -1897,6 +1904,9 @@ class _SeekCursor:
     """
 
     _READAHEAD = _PreadCursor._READAHEAD
+    _MAX_READAHEAD = _PreadCursor._MAX_READAHEAD
+
+    __slots__ = ("_buf", "_buf_start", "_file", "_lock", "_readahead", "offset")
 
     def __init__(self, file: IO[bytes], lock: threading.Condition, offset: int) -> None:
         self._file = file
@@ -1904,6 +1914,7 @@ class _SeekCursor:
         self.offset = offset
         self._buf = b""
         self._buf_start = 0
+        self._readahead = self._READAHEAD
 
     def read(self, size: int) -> bytes:
         """Read up to size bytes and advance the cursor.
@@ -1922,7 +1933,8 @@ class _SeekCursor:
             return self._buf[buffer_offset : buffer_offset + size]
         with self._lock:
             self._file.seek(self.offset)
-            buf = self._file.read(max(size, self._READAHEAD))
+            buf = self._file.read(size + self._readahead)
+        self._readahead = min(self._readahead * 2, self._MAX_READAHEAD)
         self._buf = buf
         self._buf_start = self.offset
         self.offset += min(size, len(buf))

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1811,136 +1811,6 @@ def compute_file_sha(
     return sha
 
 
-class _PreadCursor:
-    """Provide a stateful reader using the stateless ``os.pread`` function.
-
-    Each cursor maintains its own offset. This allows concurrent readers of
-    the same pack file to operate without sharing a file position, taking the
-    shared lock only briefly to register each read.
-
-    A cursor registers with its PackData before reading from the descriptor
-    and unregisters when the read is complete. PackData.close() waits for these
-    reads to finish before closing the descriptor. Once it is closed, further
-    reads raise an error rather than risk using a descriptor number that the OS
-    has reassigned to another file.
-    """
-
-    # ``unpack_object`` reads variable-length headers one byte at a time.
-    # Reading a block in advance avoids a separate system call for each byte.
-    _READAHEAD = 512
-    # Start small because most cursors only read one object. If a cursor keeps
-    # missing its buffer, grow the window so sequential scans need fewer reads.
-    _MAX_READAHEAD = 256 * 1024
-
-    __slots__ = ("_buf", "_buf_start", "_pack_data", "_readahead", "offset")
-
-    def __init__(self, pack_data: "PackData", offset: int) -> None:
-        self._pack_data = pack_data
-        self.offset = offset
-        self._buf = b""
-        self._buf_start = 0
-        self._readahead = self._READAHEAD
-
-    def read(self, size: int) -> bytes:
-        """Read up to size bytes and advance the cursor.
-
-        Fewer bytes are returned only when the end of the file is reached.
-        """
-        if size < 0:
-            raise ValueError("size must be non-negative")
-        pack_data = self._pack_data
-        if pack_data._file is None:
-            raise ValueError("read from closed PackData")
-        # Decompression may read past an object and then rewind the cursor, so
-        # reuse the buffer whenever it still covers the requested range.
-        buffer_offset = self.offset - self._buf_start
-        if 0 <= buffer_offset and buffer_offset + size <= len(self._buf):
-            self.offset += size
-            return self._buf[buffer_offset : buffer_offset + size]
-        with pack_data._read_condition:
-            file = pack_data._file
-            if file is None:
-                raise ValueError("read from closed PackData")
-            fd = file.fileno()
-            # Register the read before releasing the condition lock. This lets
-            # close() wait until the descriptor is no longer in use.
-            pack_data._active_preads += 1
-        try:
-            # Fetch some extra data for the next call. If pread returns a short
-            # result, keep going until this request is satisfied or we hit EOF.
-            want = size + self._readahead
-            self._readahead = min(self._readahead * 2, self._MAX_READAHEAD)
-            chunks: list[bytes] = []
-            have = 0
-            while have < size:
-                chunk = os.pread(  # type: ignore[attr-defined,unused-ignore]
-                    fd, want - have, self.offset + have
-                )
-                if not chunk:
-                    break
-                chunks.append(chunk)
-                have += len(chunk)
-        finally:
-            with pack_data._read_condition:
-                pack_data._active_preads -= 1
-                if not pack_data._active_preads:
-                    pack_data._read_condition.notify_all()
-        buf = b"".join(chunks)
-        self._buf = buf
-        self._buf_start = self.offset
-        self.offset += min(size, len(buf))
-        return buf[:size]
-
-
-class _SeekCursor:
-    """Provide a fallback cursor using seek and read on a shared file object.
-
-    This is used when ``os.pread`` is unavailable, as on Windows, or when the
-    file has no usable descriptor, such as ``BytesIO``. Seeking again before
-    every read prevents concurrent cursors from disturbing one another's
-    positions, while the lock keeps each seek-and-read operation atomic.
-    Each read also fills a small readahead window, avoiding another lock and
-    seek for the following header bytes.
-    """
-
-    _READAHEAD = _PreadCursor._READAHEAD
-    _MAX_READAHEAD = _PreadCursor._MAX_READAHEAD
-
-    __slots__ = ("_buf", "_buf_start", "_file", "_lock", "_readahead", "offset")
-
-    def __init__(self, file: IO[bytes], lock: threading.Condition, offset: int) -> None:
-        self._file = file
-        self._lock = lock
-        self.offset = offset
-        self._buf = b""
-        self._buf_start = 0
-        self._readahead = self._READAHEAD
-
-    def read(self, size: int) -> bytes:
-        """Read up to size bytes and advance the cursor.
-
-        Fewer bytes are returned only when the end of the file is reached.
-        """
-        if size < 0:
-            raise ValueError("size must be non-negative")
-        if self._file.closed:
-            raise ValueError("read from closed PackData")
-        # Decompression may read past an object and then rewind the cursor, so
-        # reuse the buffer whenever it still covers the requested range.
-        buffer_offset = self.offset - self._buf_start
-        if 0 <= buffer_offset and buffer_offset + size <= len(self._buf):
-            self.offset += size
-            return self._buf[buffer_offset : buffer_offset + size]
-        with self._lock:
-            self._file.seek(self.offset)
-            buf = self._file.read(size + self._readahead)
-        self._readahead = min(self._readahead * 2, self._MAX_READAHEAD)
-        self._buf = buf
-        self._buf_start = self.offset
-        self.offset += min(size, len(buf))
-        return buf[:size]
-
-
 class PackData:
     """The data contained in a packfile.
 
@@ -2089,7 +1959,7 @@ class PackData:
     def close(self) -> None:
         """Close the underlying pack file after any active reads finish.
 
-        Cursors used after the file is closed raise an error.
+        Reads issued after the file is closed raise an error.
         """
         with self._read_condition:
             if self._file is None:
@@ -2163,14 +2033,68 @@ class PackData:
                 raise ValueError("read from closed PackData")
             yield file
 
-    def _cursor(self, offset: int) -> _PreadCursor | _SeekCursor:
-        """Create a read cursor at offset with its own file position."""
-        file = self._file
-        if file is None:
+    def _pread(self, size: int, offset: int) -> bytes:
+        """Read up to size bytes at offset, like ``os.pread``.
+
+        Fewer bytes are returned only when the end of the file is reached.
+        The read is registered before the shared lock is released, so close()
+        can wait until the descriptor is no longer in use. Once the file is
+        closed, reads raise an error rather than risk using a descriptor
+        number that the OS has reassigned to another file.
+        """
+        if size < 0:
+            raise ValueError("size must be non-negative")
+        with self._read_condition:
+            file = self._file
+            if file is None:
+                raise ValueError("read from closed PackData")
+            if not self._use_pread:
+                # Seeking again before every read prevents concurrent readers
+                # from disturbing one another's positions, while the lock
+                # keeps each seek-and-read operation atomic.
+                file.seek(offset)
+                return file.read(size)
+            fd = file.fileno()
+            self._active_preads += 1
+        try:
+            # If pread returns a short result, keep going until the request
+            # is satisfied or we hit EOF.
+            chunks: list[bytes] = []
+            have = 0
+            while have < size:
+                chunk = os.pread(  # type: ignore[attr-defined,unused-ignore]
+                    fd, size - have, offset + have
+                )
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                have += len(chunk)
+        finally:
+            with self._read_condition:
+                self._active_preads -= 1
+                if not self._active_preads:
+                    self._read_condition.notify_all()
+        if len(chunks) == 1:
+            return chunks[0]
+        return b"".join(chunks)
+
+    def _reader(self, offset: int) -> Callable[[int], bytes]:
+        """Return a read function over the pack starting at offset.
+
+        Each function tracks its own position, so any number of them can read
+        concurrently; every call is a single positional read.
+        """
+        if self._file is None:
             raise ValueError("read from closed PackData")
-        if self._use_pread:
-            return _PreadCursor(self, offset)
-        return _SeekCursor(file, self._read_condition, offset)
+        pos = offset
+
+        def read(size: int) -> bytes:
+            nonlocal pos
+            data = self._pread(size, pos)
+            pos += len(data)
+            return data
+
+        return read
 
     def __len__(self) -> int:
         """Returns the number of objects in this pack."""
@@ -2189,19 +2113,21 @@ class PackData:
             with self._locked_file() as file:
                 file.seek(0, SEEK_END)
                 size = file.tell()
-        # A cursor lets other readers continue while the checksum is calculated.
+        # Positional reads let other readers continue while the checksum is
+        # calculated.
         sha = self.object_format.hash_func()
         remaining = size - self.object_format.oid_length
         if remaining < 0:
             raise AssertionError("file too short to contain pack checksum")
-        cursor = self._cursor(0)
+        offset = 0
         while remaining > 0:
-            data = cursor.read(min(remaining, 1 << 16))
+            data = self._pread(min(remaining, 1 << 16), offset)
             if not data:
                 raise AssertionError(
                     f"EOF in {self._filename} with {remaining} bytes left to hash"
                 )
             sha.update(data)
+            offset += len(data)
             remaining -= len(data)
         return sha.digest()
 
@@ -2210,11 +2136,27 @@ class PackData:
         if self._num_objects is None:
             return
 
-        cursor = self._cursor(self._header_size)
+        pos = self._header_size
+        buf = b""
+        buf_start = 0
+
+        def read(size: int) -> bytes:
+            # The objects are scanned in order, so fetch large blocks and
+            # serve the byte-at-a-time header reads from the current block.
+            nonlocal pos, buf, buf_start
+            start = pos - buf_start
+            if not 0 <= start <= len(buf) - size:
+                buf = self._pread(max(size, 256 * 1024), pos)
+                buf_start = pos
+                start = 0
+            data = buf[start : start + size]
+            pos += len(data)
+            return data
+
         for _ in range(self._num_objects):
-            offset = cursor.offset
+            offset = pos
             unpacked, unused = unpack_object(
-                cursor.read,
+                read,
                 self.object_format.hash_func,
                 compute_crc32=False,
                 include_comp=include_comp,
@@ -2222,7 +2164,7 @@ class PackData:
             unpacked.offset = offset
             yield unpacked
             # Back up over unused data.
-            cursor.offset -= len(unused)
+            pos -= len(unused)
 
     def iterentries(
         self,
@@ -2380,7 +2322,7 @@ class PackData:
                 return file.read(checksum_size)
         # PackData records the descriptor's size when it opens the file and
         # requires that size to remain unchanged while the file is open.
-        return self._cursor(self._get_size() - checksum_size).read(checksum_size)
+        return self._pread(checksum_size, self._get_size() - checksum_size)
 
     def check(self) -> None:
         """Check the consistency of this pack."""
@@ -2395,7 +2337,7 @@ class PackData:
         """Given offset in the packfile return a UnpackedObject."""
         assert offset >= self._header_size
         unpacked, _ = unpack_object(
-            self._cursor(offset).read,
+            self._reader(offset),
             self.object_format.hash_func,
             include_comp=include_comp,
         )
@@ -2587,7 +2529,7 @@ class DeltaChainIterator(Generic[T]):
         Args:
           pack_data: PackData object to use
         """
-        self._reader_at = lambda offset: pack_data._cursor(offset).read
+        self._reader_at = pack_data._reader
 
     def _walk_all_chains(self) -> Iterator[T]:
         for offset, type_num in self._full_ofs:

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -100,7 +100,7 @@ __all__ = [
 
 import binascii
 from collections import defaultdict, deque
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from io import BytesIO, UnsupportedOperation
 
 try:
@@ -1997,14 +1997,15 @@ class PackData:
         self._use_pread = file is None and hasattr(os, "pread")
         if file is None:
             self._file = GitFile(self._filename, "rb")
-            if self._use_pread and self._size is None:
+            if self._use_pread:
+                # Checksum offsets are derived from the size, so measure the
+                # opened descriptor rather than trusting a passed size.
                 self._size = os.fstat(self._file.fileno()).st_size
         else:
             self._file = file
         # The condition's lock protects the shared file position during
-        # fallback reads and whole-file checksum calculations. The condition
-        # itself allows close() to wait for active pread calls before closing
-        # the descriptor.
+        # fallback reads. The condition itself allows close() to wait for
+        # active pread calls before closing the descriptor.
         self._read_condition = threading.Condition(threading.Lock())
         self._active_preads = 0
         self._closing = False
@@ -2141,6 +2142,15 @@ class PackData:
             raise AssertionError(errmsg)
         return self._size
 
+    @contextmanager
+    def _locked_file(self) -> Iterator[IO[bytes]]:
+        """Yield the file with the lock protecting its position held."""
+        with self._read_condition:
+            file = self._file
+            if file is None:
+                raise ValueError("read from closed PackData")
+            yield file
+
     def _cursor(self, offset: int) -> _PreadCursor | _SeekCursor:
         """Create a read cursor at offset with its own file position."""
         file = self._file
@@ -2159,18 +2169,29 @@ class PackData:
 
         Returns: Binary digest (size depends on hash algorithm)
         """
-        # Calculating the checksum changes the shared file position. Keep the
-        # lock for the full calculation so concurrent callers and fallback
-        # cursors cannot change the position partway through it.
-        with self._read_condition:
-            file = self._file
-            if file is None:
-                raise ValueError("read from closed PackData")
-            return compute_file_sha(
-                file,
-                hash_func=self.object_format.hash_func,
-                end_ofs=-self.object_format.oid_length,
-            ).digest()
+        if self._use_pread:
+            size = self._get_size()
+        else:
+            # A supplied file object may not expose its size separately, so
+            # measure it relative to the end of the file.
+            with self._locked_file() as file:
+                file.seek(0, SEEK_END)
+                size = file.tell()
+        # A cursor lets other readers continue while the checksum is calculated.
+        sha = self.object_format.hash_func()
+        remaining = size - self.object_format.oid_length
+        if remaining < 0:
+            raise AssertionError("file too short to contain pack checksum")
+        cursor = self._cursor(0)
+        while remaining > 0:
+            data = cursor.read(min(remaining, 1 << 16))
+            if not data:
+                raise AssertionError(
+                    f"EOF in {self._filename} with {remaining} bytes left to hash"
+                )
+            sha.update(data)
+            remaining -= len(data)
+        return sha.digest()
 
     def iter_unpacked(self, *, include_comp: bool = False) -> Iterator[UnpackedObject]:
         """Iterate over unpacked objects in the pack."""
@@ -2342,10 +2363,7 @@ class PackData:
         if not self._use_pread:
             # A supplied file object may not expose its size separately, so
             # locate the checksum relative to the end of the file.
-            with self._read_condition:
-                file = self._file
-                if file is None:
-                    raise ValueError("read from closed PackData")
+            with self._locked_file() as file:
                 file.seek(-checksum_size, SEEK_END)
                 return file.read(checksum_size)
         # PackData records the descriptor's size when it opens the file and

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -112,12 +112,13 @@ import logging
 import os
 import struct
 import sys
+import threading
 import warnings
 import zlib
 from collections.abc import Callable, Iterable, Iterator, Sequence, Set
 from hashlib import sha1, sha256
 from itertools import chain
-from os import SEEK_CUR, SEEK_END
+from os import SEEK_END
 from struct import unpack_from
 from types import TracebackType
 from typing import (
@@ -1810,6 +1811,124 @@ def compute_file_sha(
     return sha
 
 
+class _PreadCursor:
+    """Provide a stateful reader using the stateless ``os.pread`` function.
+
+    Each cursor maintains its own offset. This allows concurrent readers of
+    the same pack file to operate without sharing a file position, taking the
+    shared lock only briefly to register each read.
+
+    A cursor registers with its PackData before reading from the descriptor
+    and unregisters when the read is complete. PackData.close() waits for these
+    reads to finish before closing the descriptor. Once it is closed, further
+    reads raise an error rather than risk using a descriptor number that the OS
+    has reassigned to another file.
+    """
+
+    # ``unpack_object`` reads variable-length headers one byte at a time.
+    # Reading a block in advance avoids a separate system call for each byte.
+    _READAHEAD = 512
+
+    def __init__(self, pack_data: "PackData", offset: int) -> None:
+        self._pack_data = pack_data
+        self.offset = offset
+        self._buf = b""
+        self._buf_start = 0
+
+    def read(self, size: int) -> bytes:
+        """Read up to size bytes and advance the cursor.
+
+        Fewer bytes are returned only when the end of the file is reached.
+        """
+        if size < 0:
+            raise ValueError("size must be non-negative")
+        pack_data = self._pack_data
+        if pack_data._file is None:
+            raise ValueError("read from closed PackData")
+        # Decompression may read past an object and then rewind the cursor, so
+        # reuse the buffer whenever it still covers the requested range.
+        buffer_offset = self.offset - self._buf_start
+        if 0 <= buffer_offset and buffer_offset + size <= len(self._buf):
+            self.offset += size
+            return self._buf[buffer_offset : buffer_offset + size]
+        with pack_data._read_condition:
+            file = pack_data._file
+            if file is None:
+                raise ValueError("read from closed PackData")
+            fd = file.fileno()
+            # Register the read before releasing the condition lock. This lets
+            # close() wait until the descriptor is no longer in use.
+            pack_data._active_preads += 1
+        try:
+            # Read enough to satisfy the request and fill at least one
+            # readahead block. If pread returns early, continue until the
+            # request is complete or the end of the file is reached.
+            chunks: list[bytes] = []
+            have = 0
+            while have < size:
+                chunk = os.pread(  # type: ignore[attr-defined,unused-ignore]
+                    fd, max(size - have, self._READAHEAD), self.offset + have
+                )
+                if not chunk:
+                    break
+                chunks.append(chunk)
+                have += len(chunk)
+        finally:
+            with pack_data._read_condition:
+                pack_data._active_preads -= 1
+                if not pack_data._active_preads:
+                    pack_data._read_condition.notify_all()
+        buf = b"".join(chunks)
+        self._buf = buf
+        self._buf_start = self.offset
+        self.offset += min(size, len(buf))
+        return buf[:size]
+
+
+class _SeekCursor:
+    """Provide a fallback cursor using seek and read on a shared file object.
+
+    This is used when ``os.pread`` is unavailable, as on Windows, or when the
+    file has no usable descriptor, such as ``BytesIO``. Seeking again before
+    every read prevents concurrent cursors from disturbing one another's
+    positions, while the lock keeps each seek-and-read operation atomic.
+    Each read also fills a small readahead window, avoiding another lock and
+    seek for the following header bytes.
+    """
+
+    _READAHEAD = _PreadCursor._READAHEAD
+
+    def __init__(self, file: IO[bytes], lock: threading.Condition, offset: int) -> None:
+        self._file = file
+        self._lock = lock
+        self.offset = offset
+        self._buf = b""
+        self._buf_start = 0
+
+    def read(self, size: int) -> bytes:
+        """Read up to size bytes and advance the cursor.
+
+        Fewer bytes are returned only when the end of the file is reached.
+        """
+        if size < 0:
+            raise ValueError("size must be non-negative")
+        if self._file.closed:
+            raise ValueError("read from closed PackData")
+        # Decompression may read past an object and then rewind the cursor, so
+        # reuse the buffer whenever it still covers the requested range.
+        buffer_offset = self.offset - self._buf_start
+        if 0 <= buffer_offset and buffer_offset + size <= len(self._buf):
+            self.offset += size
+            return self._buf[buffer_offset : buffer_offset + size]
+        with self._lock:
+            self._file.seek(self.offset)
+            buf = self._file.read(max(size, self._READAHEAD))
+        self._buf = buf
+        self._buf_start = self.offset
+        self.offset += min(size, len(buf))
+        return buf[:size]
+
+
 class PackData:
     """The data contained in a packfile.
 
@@ -1854,11 +1973,11 @@ class PackData:
     ) -> None:
         """Create a PackData object representing the pack in the given filename.
 
-        The file must exist and stay readable until the object is disposed of.
-        It must also stay the same size. It will be mapped whenever needed.
-
-        Currently there is a restriction on the size of the pack as the python
-        mmap implementation is flawed.
+        The file must exist and remain readable until PackData is closed, and
+        its size must not change. When PackData opens the file and ``os.pread``
+        is available, readers can access it without changing a shared file
+        position. Supplied file objects instead use seek and read operations
+        protected by a lock.
         """
         self._filename = filename
         self.object_format = object_format
@@ -1871,12 +1990,25 @@ class PackData:
         self.threads = threads
         self.big_file_threshold = big_file_threshold
         self.delta_base_cache_limit = delta_base_cache_limit
-        self._file: IO[bytes]
+        self._file: IO[bytes] | None
 
+        # Use ``pread`` only for files opened here. Supplied file objects use
+        # the fallback to preserve their buffering and other read behavior.
+        self._use_pread = file is None and hasattr(os, "pread")
         if file is None:
             self._file = GitFile(self._filename, "rb")
+            if self._use_pread and self._size is None:
+                self._size = os.fstat(self._file.fileno()).st_size
         else:
             self._file = file
+        # The condition's lock protects the shared file position during
+        # fallback reads and whole-file checksum calculations. The condition
+        # itself allows close() to wait for active pread calls before closing
+        # the descriptor.
+        self._read_condition = threading.Condition(threading.Lock())
+        self._active_preads = 0
+        self._closing = False
+
         (_version, self._num_objects) = read_pack_header(self._file.read)
 
         # Use delta_base_cache_limit, then delta_cache_size, then default
@@ -1942,10 +2074,27 @@ class PackData:
         return cls(filename=path, object_format=object_format)
 
     def close(self) -> None:
-        """Close the underlying pack file."""
-        if self._file is not None:
-            self._file.close()
-            self._file = None  # type: ignore
+        """Close the underlying pack file after any active reads finish.
+
+        Cursors used after the file is closed raise an error.
+        """
+        with self._read_condition:
+            if self._file is None:
+                while self._closing:
+                    self._read_condition.wait()
+                return
+            # Claim the file before waiting so concurrent close calls cannot
+            # attempt to close it again.
+            file = self._file
+            self._file = None
+            self._closing = True
+            try:
+                while self._active_preads:
+                    self._read_condition.wait()
+                file.close()
+            finally:
+                self._closing = False
+                self._read_condition.notify_all()
 
     def __del__(self) -> None:
         """Ensure pack file is closed when PackData is garbage collected."""
@@ -1992,6 +2141,15 @@ class PackData:
             raise AssertionError(errmsg)
         return self._size
 
+    def _cursor(self, offset: int) -> _PreadCursor | _SeekCursor:
+        """Create a read cursor at offset with its own file position."""
+        file = self._file
+        if file is None:
+            raise ValueError("read from closed PackData")
+        if self._use_pread:
+            return _PreadCursor(self, offset)
+        return _SeekCursor(file, self._read_condition, offset)
+
     def __len__(self) -> int:
         """Returns the number of objects in this pack."""
         return self._num_objects
@@ -2001,23 +2159,29 @@ class PackData:
 
         Returns: Binary digest (size depends on hash algorithm)
         """
-        return compute_file_sha(
-            self._file,
-            hash_func=self.object_format.hash_func,
-            end_ofs=-self.object_format.oid_length,
-        ).digest()
+        # Calculating the checksum changes the shared file position. Keep the
+        # lock for the full calculation so concurrent callers and fallback
+        # cursors cannot change the position partway through it.
+        with self._read_condition:
+            file = self._file
+            if file is None:
+                raise ValueError("read from closed PackData")
+            return compute_file_sha(
+                file,
+                hash_func=self.object_format.hash_func,
+                end_ofs=-self.object_format.oid_length,
+            ).digest()
 
     def iter_unpacked(self, *, include_comp: bool = False) -> Iterator[UnpackedObject]:
         """Iterate over unpacked objects in the pack."""
-        self._file.seek(self._header_size)
-
         if self._num_objects is None:
             return
 
+        cursor = self._cursor(self._header_size)
         for _ in range(self._num_objects):
-            offset = self._file.tell()
+            offset = cursor.offset
             unpacked, unused = unpack_object(
-                self._file.read,
+                cursor.read,
                 self.object_format.hash_func,
                 compute_crc32=False,
                 include_comp=include_comp,
@@ -2025,7 +2189,7 @@ class PackData:
             unpacked.offset = offset
             yield unpacked
             # Back up over unused data.
-            self._file.seek(-len(unused), SEEK_CUR)
+            cursor.offset -= len(unused)
 
     def iterentries(
         self,
@@ -2175,8 +2339,18 @@ class PackData:
     def get_stored_checksum(self) -> bytes:
         """Return the expected checksum stored in this pack."""
         checksum_size = self.object_format.oid_length
-        self._file.seek(-checksum_size, SEEK_END)
-        return self._file.read(checksum_size)
+        if not self._use_pread:
+            # A supplied file object may not expose its size separately, so
+            # locate the checksum relative to the end of the file.
+            with self._read_condition:
+                file = self._file
+                if file is None:
+                    raise ValueError("read from closed PackData")
+                file.seek(-checksum_size, SEEK_END)
+                return file.read(checksum_size)
+        # PackData records the descriptor's size when it opens the file and
+        # requires that size to remain unchanged while the file is open.
+        return self._cursor(self._get_size() - checksum_size).read(checksum_size)
 
     def check(self) -> None:
         """Check the consistency of this pack."""
@@ -2190,9 +2364,10 @@ class PackData:
     ) -> UnpackedObject:
         """Given offset in the packfile return a UnpackedObject."""
         assert offset >= self._header_size
-        self._file.seek(offset)
         unpacked, _ = unpack_object(
-            self._file.read, self.object_format.hash_func, include_comp=include_comp
+            self._cursor(offset).read,
+            self.object_format.hash_func,
+            include_comp=include_comp,
         )
         unpacked.offset = offset
         return unpacked
@@ -2257,7 +2432,15 @@ class DeltaChainIterator(Generic[T]):
                 that materialise objects (e.g. PackInflater) when iterating
                 packs in a non-default hash algorithm such as SHA-256.
         """
-        self._file = file_obj
+        self._reader_at: Callable[[int], Callable[[int], bytes]] | None = None
+        if file_obj is not None:
+
+            def reader_at(offset: int) -> Callable[[int], bytes]:
+                # The buffered file may still be written, as in add_thin_pack.
+                file_obj.seek(offset)
+                return file_obj.read
+
+            self._reader_at = reader_at
         self.hash_func = hash_func
         self._object_format = object_format
         self._resolve_ext_ref = resolve_ext_ref
@@ -2374,7 +2557,7 @@ class DeltaChainIterator(Generic[T]):
         Args:
           pack_data: PackData object to use
         """
-        self._file = pack_data._file
+        self._reader_at = lambda offset: pack_data._cursor(offset).read
 
     def _walk_all_chains(self) -> Iterator[T]:
         for offset, type_num in self._full_ofs:
@@ -2419,10 +2602,10 @@ class DeltaChainIterator(Generic[T]):
         obj_type_num: int,
         base_chunks: bytes | list[bytes] | None,
     ) -> UnpackedObject:
-        assert self._file is not None
-        self._file.seek(offset)
+        assert self._reader_at is not None
+        read = self._reader_at(offset)
         unpacked, _ = unpack_object(
-            self._file.read,
+            read,
             self.hash_func,
             read_some=None,
             compute_crc32=self._compute_crc32,

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -559,23 +559,44 @@ class TestPackData(PackTests):
             # Verify it's a valid SHA1 hash (20 bytes)
             self.assertIsInstance(checksum, bytes)
 
-    def test_get_stored_checksum_uses_open_file_size(self) -> None:
+    def test_calculate_checksum_rejects_missing_checksum(self) -> None:
+        path = os.path.join(self.tempdir, "truncated.pack")
+        with open(path, "wb") as f:
+            write_pack_header(f.write, 0)
+
+        with PackData(path, object_format=DEFAULT_OBJECT_FORMAT) as p:
+            self.assertRaises(AssertionError, p.calculate_checksum)
+
+    def test_path_checksums_use_open_file_size(self) -> None:
         contents = self.get_pack_bytes(pack1_sha)
         path = os.path.join(self.tempdir, "pack.pack")
         replacement = os.path.join(self.tempdir, "replacement.pack")
         with open(path, "wb") as f:
             f.write(contents)
 
-        with PackData(path, object_format=DEFAULT_OBJECT_FORMAT) as p:
+        wrong_size = len(contents) + 100
+        with PackData(path, object_format=DEFAULT_OBJECT_FORMAT, size=wrong_size) as p:
             if not p._use_pread:
                 self.skipTest("os.pread is unavailable")
-            self.assertEqual(len(contents), p._size)
+            self.assertSucceeds(p.check)
             with open(replacement, "wb") as f:
                 f.write(b"replacement")
             os.replace(replacement, path)
             self.assertEqual(
                 contents[-DEFAULT_OBJECT_FORMAT.oid_length :], p.get_stored_checksum()
             )
+
+    def test_calculate_checksum_rejects_truncation(self) -> None:
+        contents = self.get_pack_bytes(pack1_sha)
+        path = os.path.join(self.tempdir, "pack.pack")
+        with open(path, "wb") as f:
+            f.write(contents)
+
+        with PackData(path, object_format=DEFAULT_OBJECT_FORMAT) as p:
+            if not p._use_pread:
+                self.skipTest("os.pread is unavailable")
+            os.truncate(path, len(contents) // 2)
+            self.assertRaises(AssertionError, p.calculate_checksum)
 
     # Removed test_check_pack_data_size as it was accessing private attributes
 
@@ -874,6 +895,65 @@ class TestPackData(PackTests):
     def test_concurrent_reads_no_fileno(self) -> None:
         with self.get_memory_pack_data(pack1_sha) as p:
             self._do_test_concurrent_reads(p)
+
+    def test_calculate_checksum_releases_fallback_lock_between_reads(self) -> None:
+        f = BytesIO()
+        write_pack_header(f.write, 0)
+        f.write(b"x" * (1 << 16))
+        f.write(b"\0" * DEFAULT_OBJECT_FORMAT.oid_length)
+        f.seek(0)
+
+        first_chunk_hashed = threading.Event()
+        resume_checksum = threading.Event()
+        other_read_done = threading.Event()
+        failures = []
+        real_hash = sha1()
+        hash_obj = mock.Mock(wraps=real_hash)
+
+        def pause_after_first_update(data: bytes) -> None:
+            real_hash.update(data)
+            if not first_chunk_hashed.is_set():
+                first_chunk_hashed.set()
+                if not resume_checksum.wait(5):
+                    raise RuntimeError("timed out waiting to resume checksum")
+
+        hash_obj.update.side_effect = pause_after_first_update
+
+        with PackData.from_file(f, DEFAULT_OBJECT_FORMAT) as p:
+
+            def calculate_checksum() -> None:
+                try:
+                    p.calculate_checksum()
+                except Exception as e:
+                    failures.append(e)
+
+            def read_checksum() -> None:
+                try:
+                    p.get_stored_checksum()
+                except Exception as e:
+                    failures.append(e)
+                finally:
+                    other_read_done.set()
+
+            checksum_thread = threading.Thread(target=calculate_checksum, daemon=True)
+            reader_thread = threading.Thread(target=read_checksum, daemon=True)
+            with mock.patch.object(p.object_format, "hash_func", return_value=hash_obj):
+                checksum_thread.start()
+                self.assertTrue(first_chunk_hashed.wait(5))
+                reader_thread.start()
+                try:
+                    self.assertTrue(
+                        other_read_done.wait(1),
+                        "fallback read blocked while checksum data was hashed",
+                    )
+                finally:
+                    resume_checksum.set()
+                    checksum_thread.join(5)
+                    reader_thread.join(5)
+
+            self.assertFalse(checksum_thread.is_alive())
+            self.assertFalse(reader_thread.is_alive())
+            self.assertEqual([], failures)
 
     def test_iterentries(self) -> None:
         with self.get_pack_data(pack1_sha) as p:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -26,12 +26,15 @@ import os
 import shutil
 import sys
 import tempfile
+import threading
 import tracemalloc
 import types
 import zlib
+from functools import partial
 from hashlib import sha1
 from io import BytesIO
 from typing import NoReturn
+from unittest import mock
 
 from dulwich.errors import ApplyDeltaError, ChecksumMismatch
 from dulwich.file import GitFile
@@ -112,11 +115,26 @@ class PackTests(TestCase):
         self.addCleanup(idx.close)
         return idx
 
+    def get_pack_path(self, sha):
+        """Returns the path of the pack file in the datadir with the given sha."""
+        return os.path.join(self.datadir, "pack-{}.pack".format(sha.decode("ascii")))
+
+    def get_pack_bytes(self, sha):
+        """Return the contents of the pack file with the given SHA."""
+        with open(self.get_pack_path(sha), "rb") as f:
+            return f.read()
+
     def get_pack_data(self, sha):
         """Returns a PackData object from the datadir with the given sha."""
         return PackData(
-            os.path.join(self.datadir, "pack-{}.pack".format(sha.decode("ascii"))),
+            self.get_pack_path(sha),
             object_format=DEFAULT_OBJECT_FORMAT,
+        )
+
+    def get_memory_pack_data(self, sha):
+        """Return a PackData backed by BytesIO rather than a file descriptor."""
+        return PackData.from_file(
+            BytesIO(self.get_pack_bytes(sha)), DEFAULT_OBJECT_FORMAT
         )
 
     def get_pack(self, sha):
@@ -515,13 +533,14 @@ class TestPackData(PackTests):
         self.get_pack_data(pack1_sha).close()
 
     def test_from_file(self) -> None:
-        path = os.path.join(
-            self.datadir, "pack-{}.pack".format(pack1_sha.decode("ascii"))
-        )
+        path = self.get_pack_path(pack1_sha)
         with open(path, "rb") as f:
             pack_data = PackData.from_file(
                 f, DEFAULT_OBJECT_FORMAT, os.path.getsize(path)
             )
+            # Files supplied by the caller use the fallback reader rather than
+            # ``pread``.
+            self.assertFalse(pack_data._use_pread)
             pack_data.close()
 
     def test_pack_len(self) -> None:
@@ -539,6 +558,24 @@ class TestPackData(PackTests):
             self.assertEqual(20, len(checksum))
             # Verify it's a valid SHA1 hash (20 bytes)
             self.assertIsInstance(checksum, bytes)
+
+    def test_get_stored_checksum_uses_open_file_size(self) -> None:
+        contents = self.get_pack_bytes(pack1_sha)
+        path = os.path.join(self.tempdir, "pack.pack")
+        replacement = os.path.join(self.tempdir, "replacement.pack")
+        with open(path, "wb") as f:
+            f.write(contents)
+
+        with PackData(path, object_format=DEFAULT_OBJECT_FORMAT) as p:
+            if not p._use_pread:
+                self.skipTest("os.pread is unavailable")
+            self.assertEqual(len(contents), p._size)
+            with open(replacement, "wb") as f:
+                f.write(b"replacement")
+            os.replace(replacement, path)
+            self.assertEqual(
+                contents[-DEFAULT_OBJECT_FORMAT.oid_length :], p.get_stored_checksum()
+            )
 
     # Removed test_check_pack_data_size as it was accessing private attributes
 
@@ -586,6 +623,257 @@ class TestPackData(PackTests):
                 ],
                 actual,
             )
+
+    def test_from_file_spooled_stays_in_memory(self) -> None:
+        """Ensure checking for pread support keeps a spooled file in memory."""
+        contents = self.get_pack_bytes(pack1_sha)
+        with tempfile.SpooledTemporaryFile(max_size=len(contents) + 1024) as sf:
+            sf.write(contents)
+            sf.seek(0)
+            with PackData.from_file(sf, DEFAULT_OBJECT_FORMAT) as p:
+                self.assertEqual(3, len(list(p.iter_unpacked())))
+                self.assertFalse(sf._rolled)
+
+    def _do_test_iter_unpacked_interleaved(self, p) -> None:
+        expected = list(p.iter_unpacked())
+        actual = []
+        for unpacked in p.iter_unpacked():
+            actual.append(unpacked)
+            # Reading another object between yields should not affect the
+            # iterator's position.
+            p.get_unpacked_object_at(178)
+            p.get_stored_checksum()
+        self.assertEqual(expected, actual)
+
+        it1 = p.iter_unpacked()
+        it2 = p.iter_unpacked()
+        actual1 = [next(it1)]
+        # Likewise, completing a second iteration should not affect the first.
+        actual2 = list(it2)
+        actual1.extend(it1)
+        self.assertEqual(expected, actual1)
+        self.assertEqual(expected, actual2)
+
+    def test_iter_unpacked_interleaved(self) -> None:
+        with self.get_pack_data(pack1_sha) as p:
+            self._do_test_iter_unpacked_interleaved(p)
+
+    def test_iter_unpacked_interleaved_no_fileno(self) -> None:
+        with self.get_memory_pack_data(pack1_sha) as p:
+            self._do_test_iter_unpacked_interleaved(p)
+
+    def _do_test_stale_cursor_after_close(self, p) -> None:
+        it = p.iter_unpacked()
+        next(it)
+        p.close()
+        # The OS may have reassigned the descriptor number to another file. In
+        # that case, the cursor should report that PackData is closed rather
+        # than read from the new file.
+        self.assertRaises(ValueError, next, it)
+
+    def test_stale_cursor_after_close(self) -> None:
+        """An iterator used after close() should report that the file is closed."""
+        self._do_test_stale_cursor_after_close(self.get_pack_data(pack1_sha))
+
+    def test_buffered_cursor_after_close(self) -> None:
+        """A closed PackData should not serve data buffered by a cursor."""
+        p = self.get_pack_data(pack1_sha)
+        cursor = p._cursor(0)
+        if not p._use_pread:
+            p.close()
+            self.skipTest("os.pread is unavailable")
+        cursor.read(1)
+        p.close()
+        self.assertRaises(ValueError, cursor.read, 1)
+        self.assertRaises(ValueError, p._cursor, 0)
+
+    def test_buffered_cursor_after_close_no_fileno(self) -> None:
+        """Ensure the fallback cursor rejects buffered reads after close()."""
+        p = self.get_memory_pack_data(pack1_sha)
+        cursor = p._cursor(0)
+        cursor.read(1)
+        p.close()
+        self.assertRaises(ValueError, cursor.read, 1)
+        self.assertRaises(ValueError, p._cursor, 0)
+
+    def _do_test_cursor_rejects_negative_size(self, p) -> None:
+        cursor = p._cursor(0)
+        cursor.read(1)
+        offset = cursor.offset
+        self.assertRaises(ValueError, cursor.read, -1)
+        self.assertEqual(offset, cursor.offset)
+
+    def test_cursor_rejects_negative_size(self) -> None:
+        with self.get_pack_data(pack1_sha) as p:
+            self._do_test_cursor_rejects_negative_size(p)
+
+    def test_cursor_rejects_negative_size_no_fileno(self) -> None:
+        with self.get_memory_pack_data(pack1_sha) as p:
+            self._do_test_cursor_rejects_negative_size(p)
+
+    def test_pread_cursor_handles_short_reads_and_eof(self) -> None:
+        p = self.get_pack_data(pack1_sha)
+        if not p._use_pread:
+            p.close()
+            self.skipTest("os.pread is unavailable")
+        contents = self.get_pack_bytes(pack1_sha)
+        calls = []
+
+        def short_pread(fd, size, offset):
+            calls.append((size, offset))
+            return contents[offset : offset + min(size, 3)]
+
+        try:
+            with mock.patch("dulwich.pack.os.pread", side_effect=short_pread):
+                cursor = p._cursor(0)
+                self.assertEqual(contents[:10], cursor.read(10))
+                self.assertEqual(10, cursor.offset)
+
+                cursor = p._cursor(len(contents) - 2)
+                self.assertEqual(contents[-2:], cursor.read(10))
+                self.assertEqual(len(contents), cursor.offset)
+        finally:
+            p.close()
+        self.assertGreater(len(calls), 2)
+
+    def test_pread_cursor_reuses_large_read_after_rewind(self) -> None:
+        p = self.get_pack_data(pack1_sha)
+        if not p._use_pread:
+            p.close()
+            self.skipTest("os.pread is unavailable")
+        contents = bytes(range(256)) * 4
+        calls = []
+
+        def recording_pread(fd, size, offset):
+            calls.append((size, offset))
+            return contents[offset : offset + size]
+
+        try:
+            with mock.patch("dulwich.pack.os.pread", side_effect=recording_pread):
+                cursor = p._cursor(0)
+                self.assertEqual(contents[:600], cursor.read(600))
+                self.assertEqual(1, len(calls))
+                cursor.offset -= 100
+                self.assertEqual(contents[500:501], cursor.read(1))
+                self.assertEqual(1, len(calls))
+        finally:
+            p.close()
+
+    def test_stale_cursor_after_close_no_fileno(self) -> None:
+        self._do_test_stale_cursor_after_close(self.get_memory_pack_data(pack1_sha))
+
+    def test_close_waits_for_active_pread(self) -> None:
+        """Ensure close() waits for a pread before releasing the descriptor."""
+        p = self.get_pack_data(pack1_sha)
+        if not p._use_pread:
+            p.close()
+            self.skipTest("os.pread is unavailable")
+        cursor = p._cursor(0)
+        entered_pread = threading.Event()
+        resume_pread = threading.Event()
+        close_done_events = [threading.Event(), threading.Event()]
+        results = []
+        failures = []
+        original_pread = os.pread
+
+        def delayed_pread(fd, size, offset):
+            entered_pread.set()
+            if not resume_pread.wait(5):
+                raise RuntimeError("timed out waiting to resume pread")
+            return original_pread(fd, size, offset)
+
+        def read() -> None:
+            try:
+                results.append(cursor.read(4))
+            except Exception as e:
+                failures.append(e)
+
+        def close(done: threading.Event) -> None:
+            try:
+                p.close()
+            except Exception as e:
+                failures.append(e)
+            finally:
+                done.set()
+
+        reader = threading.Thread(target=read, daemon=True)
+        closers = [
+            threading.Thread(target=close, args=(done,), daemon=True)
+            for done in close_done_events
+        ]
+        with mock.patch("dulwich.pack.os.pread", side_effect=delayed_pread):
+            reader.start()
+            self.assertTrue(entered_pread.wait(5))
+            for closer in closers:
+                closer.start()
+            try:
+                # Both close calls should wait until the delayed pread is
+                # allowed to finish.
+                for done in close_done_events:
+                    self.assertFalse(done.wait(0.1))
+            finally:
+                resume_pread.set()
+                reader.join(5)
+                for closer in closers:
+                    closer.join(5)
+
+        self.assertFalse(reader.is_alive())
+        self.assertFalse(any(closer.is_alive() for closer in closers))
+        self.assertTrue(all(done.is_set() for done in close_done_events))
+        self.assertEqual([b"PACK"], results)
+        self.assertEqual([], failures)
+
+    def assertStableUnderConcurrency(self, jobs, iterations=100) -> None:
+        """Run (func, expected result) jobs in parallel threads.
+
+        Each call is expected to return its corresponding result without
+        raising an exception.
+        """
+        failures = []
+
+        def hammer(func, expected) -> None:
+            try:
+                for _ in range(iterations):
+                    result = func()
+                    if result != expected:
+                        failures.append(result)
+                        return
+            except Exception as e:
+                failures.append(e)
+
+        threads = [
+            threading.Thread(target=hammer, args=job, daemon=True) for job in jobs
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(5)
+        self.assertFalse(any(t.is_alive() for t in threads))
+        self.assertEqual([], failures)
+
+    def _do_test_concurrent_reads(self, p) -> None:
+        expected_checksum = p.calculate_checksum()
+        offsets = [12, 138, 178]
+        self.assertStableUnderConcurrency(
+            [(p.calculate_checksum, expected_checksum)] * 2
+            + [
+                (
+                    partial(p.get_unpacked_object_at, offset),
+                    p.get_unpacked_object_at(offset),
+                )
+                for offset in offsets * 2
+            ],
+            iterations=200,
+        )
+
+    def test_concurrent_reads(self) -> None:
+        """Verify concurrent reads from one PackData remain independent."""
+        with self.get_pack_data(pack1_sha) as p:
+            self._do_test_concurrent_reads(p)
+
+    def test_concurrent_reads_no_fileno(self) -> None:
+        with self.get_memory_pack_data(pack1_sha) as p:
+            self._do_test_concurrent_reads(p)
 
     def test_iterentries(self) -> None:
         with self.get_pack_data(pack1_sha) as p:
@@ -1658,6 +1946,21 @@ class DeltaChainIteratorTests(TestCase):
         return TestPackIterator.for_pack_subset(
             pack, subset, resolve_ext_ref=resolve_ext_ref
         )
+
+    def test_set_pack_data_replaces_file_source(self) -> None:
+        f = BytesIO()
+        entries = build_pack(f, [(Blob.type_num, b"blob")])
+        data = PackData("test.pack", file=f, object_format=DEFAULT_OBJECT_FORMAT)
+        self.addCleanup(data.close)
+        file_obj = mock.Mock()
+        pack_iter = TestPackIterator(file_obj, DEFAULT_OBJECT_FORMAT.hash_func)
+
+        pack_iter.set_pack_data(data)
+        for unpacked in data.iter_unpacked(include_comp=False):
+            pack_iter.record(unpacked)
+
+        self.assertEntriesMatch([0], entries, pack_iter)
+        file_obj.seek.assert_not_called()
 
     def assertEntriesMatch(self, expected_indexes, entries, pack_iter) -> None:
         expected = [entries[i] for i in expected_indexes]

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -683,56 +683,49 @@ class TestPackData(PackTests):
         with self.get_memory_pack_data(pack1_sha) as p:
             self._do_test_iter_unpacked_interleaved(p)
 
-    def _do_test_stale_cursor_after_close(self, p) -> None:
+    def _do_test_stale_iterator_after_close(self, p) -> None:
         it = p.iter_unpacked()
         next(it)
         p.close()
         # The OS may have reassigned the descriptor number to another file. In
-        # that case, the cursor should report that PackData is closed rather
+        # that case, the read should report that PackData is closed rather
         # than read from the new file.
         self.assertRaises(ValueError, next, it)
 
-    def test_stale_cursor_after_close(self) -> None:
+    def test_stale_iterator_after_close(self) -> None:
         """An iterator used after close() should report that the file is closed."""
-        self._do_test_stale_cursor_after_close(self.get_pack_data(pack1_sha))
+        self._do_test_stale_iterator_after_close(self.get_pack_data(pack1_sha))
 
-    def test_buffered_cursor_after_close(self) -> None:
-        """A closed PackData should not serve data buffered by a cursor."""
-        p = self.get_pack_data(pack1_sha)
-        cursor = p._cursor(0)
-        if not p._use_pread:
-            p.close()
-            self.skipTest("os.pread is unavailable")
-        cursor.read(1)
+    def _do_test_reader_after_close(self, p) -> None:
+        read = p._reader(0)
+        read(1)
         p.close()
-        self.assertRaises(ValueError, cursor.read, 1)
-        self.assertRaises(ValueError, p._cursor, 0)
+        self.assertRaises(ValueError, read, 1)
+        self.assertRaises(ValueError, p._reader, 0)
 
-    def test_buffered_cursor_after_close_no_fileno(self) -> None:
-        """Ensure the fallback cursor rejects buffered reads after close()."""
-        p = self.get_memory_pack_data(pack1_sha)
-        cursor = p._cursor(0)
-        cursor.read(1)
-        p.close()
-        self.assertRaises(ValueError, cursor.read, 1)
-        self.assertRaises(ValueError, p._cursor, 0)
+    def test_reader_after_close(self) -> None:
+        """A closed PackData should reject further reads."""
+        self._do_test_reader_after_close(self.get_pack_data(pack1_sha))
 
-    def _do_test_cursor_rejects_negative_size(self, p) -> None:
-        cursor = p._cursor(0)
-        cursor.read(1)
-        offset = cursor.offset
-        self.assertRaises(ValueError, cursor.read, -1)
-        self.assertEqual(offset, cursor.offset)
+    def test_reader_after_close_no_fileno(self) -> None:
+        self._do_test_reader_after_close(self.get_memory_pack_data(pack1_sha))
 
-    def test_cursor_rejects_negative_size(self) -> None:
+    def _do_test_reader_rejects_negative_size(self, p) -> None:
+        read = p._reader(0)
+        read(1)
+        self.assertRaises(ValueError, read, -1)
+        # The failed read should not have moved the position.
+        self.assertEqual(b"ACK", read(3))
+
+    def test_reader_rejects_negative_size(self) -> None:
         with self.get_pack_data(pack1_sha) as p:
-            self._do_test_cursor_rejects_negative_size(p)
+            self._do_test_reader_rejects_negative_size(p)
 
-    def test_cursor_rejects_negative_size_no_fileno(self) -> None:
+    def test_reader_rejects_negative_size_no_fileno(self) -> None:
         with self.get_memory_pack_data(pack1_sha) as p:
-            self._do_test_cursor_rejects_negative_size(p)
+            self._do_test_reader_rejects_negative_size(p)
 
-    def test_pread_cursor_handles_short_reads_and_eof(self) -> None:
+    def test_pread_handles_short_reads_and_eof(self) -> None:
         p = self.get_pack_data(pack1_sha)
         if not p._use_pread:
             p.close()
@@ -746,42 +739,19 @@ class TestPackData(PackTests):
 
         try:
             with mock.patch("dulwich.pack.os.pread", side_effect=short_pread):
-                cursor = p._cursor(0)
-                self.assertEqual(contents[:10], cursor.read(10))
-                self.assertEqual(10, cursor.offset)
+                read = p._reader(0)
+                self.assertEqual(contents[:10], read(10))
+                self.assertEqual(contents[10:12], read(2))
 
-                cursor = p._cursor(len(contents) - 2)
-                self.assertEqual(contents[-2:], cursor.read(10))
-                self.assertEqual(len(contents), cursor.offset)
+                read = p._reader(len(contents) - 2)
+                self.assertEqual(contents[-2:], read(10))
+                self.assertEqual(b"", read(1))
         finally:
             p.close()
         self.assertGreater(len(calls), 2)
 
-    def test_pread_cursor_reuses_large_read_after_rewind(self) -> None:
-        p = self.get_pack_data(pack1_sha)
-        if not p._use_pread:
-            p.close()
-            self.skipTest("os.pread is unavailable")
-        contents = bytes(range(256)) * 4
-        calls = []
-
-        def recording_pread(fd, size, offset):
-            calls.append((size, offset))
-            return contents[offset : offset + size]
-
-        try:
-            with mock.patch("dulwich.pack.os.pread", side_effect=recording_pread):
-                cursor = p._cursor(0)
-                self.assertEqual(contents[:600], cursor.read(600))
-                self.assertEqual(1, len(calls))
-                cursor.offset -= 100
-                self.assertEqual(contents[500:501], cursor.read(1))
-                self.assertEqual(1, len(calls))
-        finally:
-            p.close()
-
-    def test_stale_cursor_after_close_no_fileno(self) -> None:
-        self._do_test_stale_cursor_after_close(self.get_memory_pack_data(pack1_sha))
+    def test_stale_iterator_after_close_no_fileno(self) -> None:
+        self._do_test_stale_iterator_after_close(self.get_memory_pack_data(pack1_sha))
 
     def test_close_waits_for_active_pread(self) -> None:
         """Ensure close() waits for a pread before releasing the descriptor."""
@@ -789,7 +759,7 @@ class TestPackData(PackTests):
         if not p._use_pread:
             p.close()
             self.skipTest("os.pread is unavailable")
-        cursor = p._cursor(0)
+        read_at_start = p._reader(0)
         entered_pread = threading.Event()
         resume_pread = threading.Event()
         close_done_events = [threading.Event(), threading.Event()]
@@ -805,7 +775,7 @@ class TestPackData(PackTests):
 
         def read() -> None:
             try:
-                results.append(cursor.read(4))
+                results.append(read_at_start(4))
             except Exception as e:
                 failures.append(e)
 


### PR DESCRIPTION
Use os.pread where available so concurrent pack readers no longer share a file position. Provide synchronized fallback reads for supplied file objects and systems without pread, coordinate reads with close operations, and protect the pack offset cache.

Add targeted coverage for concurrent reads, cursor behavior, checksum reads, and close races.

Issue: https://github.com/jelmer/dulwich/issues/2350
