### PR TITLE
avoid exponential commit walk in find_shallow and get_depth - #2352

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
 1.2.13	UNRELEASED
 
+ * SECURITY: Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
+   (``dulwich.object_store``). Both re-expanded a commit once per path that
+   reached it, so a small merge-heavy history walked in exponential time. A
+   ``deepen`` request on ``git-upload-pack`` reaches ``find_shallow`` before any
+   authentication, so a pushed ~100-commit repository could pin a server CPU for
+   hours per shallow clone. The traversal now skips already-visited
+   ``(sha, depth)`` states, which leaves the result unchanged.
+   (netliomax25-code)
+
  * SECURITY: Don't follow symlinks when writing messages in
    ``porcelain.format_patch``, ``mbox.split_mbox`` and ``mbox.split_maildir``.
    A symlink pre-planted at an output filename was followed, writing the

--- a/NEWS
+++ b/NEWS
@@ -1,12 +1,8 @@
 1.2.13	UNRELEASED
 
- * SECURITY: Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
+ * Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
    (``dulwich.object_store``). Both re-expanded a commit once per path that
-   reached it, so a small merge-heavy history walked in exponential time. A
-   ``deepen`` request on ``git-upload-pack`` reaches ``find_shallow`` before any
-   authentication, so a pushed ~100-commit repository could pin a server CPU for
-   hours per shallow clone. The traversal now skips already-visited
-   ``(sha, depth)`` states, which leaves the result unchanged.
+   reached it, so a merge-heavy history walked in exponential time.
    (netliomax25-code)
 
  * SECURITY: Don't follow symlinks when writing messages in

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -61,6 +61,7 @@ import stat
 import sys
 import time
 import warnings
+from collections import deque
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence, Set
 from contextlib import closing, suppress
 from io import BytesIO
@@ -336,8 +337,17 @@ def find_shallow(
 
     not_shallow = set()
     shallow = set()
+    # A commit reachable along N distinct paths was popped and re-expanded N
+    # times, so a merge-heavy history walked in exponential time. Deduplicate
+    # on the (sha, depth) state: re-processing a state adds to the same set and
+    # pushes the same parents, so skipping repeats leaves the result unchanged.
+    seen: set[tuple[ObjectID, int]] = set()
     while todo:
-        sha, cur_depth = todo.pop()
+        state = todo.pop()
+        if state in seen:
+            continue
+        seen.add(state)
+        sha, cur_depth = state
         if cur_depth < depth:
             not_shallow.add(sha)
             new_depth = cur_depth + 1
@@ -368,11 +378,20 @@ def get_depth(
     if head not in store:
         return 0
     current_depth = 1
-    queue = [(head, current_depth)]
+    queue = deque([(head, current_depth)])
     commit_graph = store.get_commit_graph()
 
+    # Without deduplication a commit reachable along several paths is expanded
+    # once per path, so a merge-heavy history is walked in exponential time.
+    # Track the (sha, depth) states already queued; re-visiting one only
+    # recomputes the same max and re-queues the same parents. deque.popleft()
+    # keeps the O(1) breadth-first order that list.pop(0) made O(n).
+    seen: set[tuple[ObjectID, int]] = set()
     while queue and (max_depth is None or current_depth < max_depth):
-        e, depth = queue.pop(0)
+        e, depth = queue.popleft()
+        if (e, depth) in seen:
+            continue
+        seen.add((e, depth))
         current_depth = max(current_depth, depth)
 
         # Try to use commit graph for parent lookup if available

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -973,6 +973,50 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
         depth_disabled = get_depth(self.store, c4.id)
         self.assertEqual(3, depth_disabled)
 
+    def test_find_shallow_merge_heavy_history(self) -> None:
+        # A "diamond" history: m_i has parents [a_i, b_i] and a_i/b_i both have
+        # parent m_{i+1}, so ~3*levels commits expose 2**levels distinct paths.
+        # Without state deduplication find_shallow/get_depth re-expand every
+        # path and hang here; the result is unchanged, only the walk is bounded.
+        ts = int(time.time())
+        seq = [0]
+
+        def commit(parents):
+            seq[0] += 1
+            c = make_object(
+                Commit,
+                message=b"c%d" % seq[0],
+                tree=b"1" * 40,
+                parents=parents,
+                author=b"Test <test@example.com>",
+                committer=b"Test <test@example.com>",
+                commit_time=ts,
+                commit_timezone=0,
+                author_time=ts,
+                author_timezone=0,
+            )
+            self.store.add_object(c)
+            return c.id
+
+        levels = 24
+        head = tail = commit([])
+        for _ in range(levels):
+            a = commit([head])
+            b = commit([head])
+            head = commit([a, b])
+
+        all_ids = set(self.store)
+        # Depth larger than the longest path: every commit is not_shallow.
+        shallow, not_shallow = find_shallow(self.store, [head], 10**9)
+        self.assertEqual(set(), shallow)
+        self.assertEqual(all_ids, not_shallow)
+        # Longest path head -> a/b -> m ... -> tail is 2*levels + 1 commits.
+        self.assertEqual(2 * levels + 1, get_depth(self.store, head))
+        # Boundary depth still marks the commit reached exactly at the boundary.
+        shallow, not_shallow = find_shallow(self.store, [tail], 1)
+        self.assertEqual({tail}, shallow)
+        self.assertEqual(set(), not_shallow)
+
     def test_fsync_object_files_disabled_by_default(self) -> None:
         """Test that fsync is disabled by default for object files."""
         config = ConfigDict()


### PR DESCRIPTION
`find_shallow` and `get_depth` in `dulwich.object_store` walk the commit DAG from a set of heads but never deduplicate the frontier, so a commit reachable along k distinct paths is expanded k times and a small merge-heavy history is walked in exponential time.

1. In `find_shallow` the `todo` stack pushes every parent once per visiting path. A diamond history of ~3n commits (each merge reachable through two sub-paths) exposes 2**n paths, and `find_shallow` runs pre-auth on `git-upload-pack`: a client `deepen` request reaches it through `ProtocolGraphWalker._handle_shallow_request` before any authentication.
2. `get_depth` has the same missing visited set, plus an O(n) `list.pop(0)` on each step.
3. Both now skip already-seen `(sha, depth)` states. Re-processing a state only re-adds to the same set and re-queues the same parents, so the returned sets/value are unchanged; `get_depth` also switches to a `deque`. This mirrors git, which marks commits SEEN and records the depth already assigned so each is visited once.

Measured on a diamond history, `find_shallow` at a depth beyond the longest path:

    commits    before        after
    31         0.007 s       ~0.0002 s
    37         0.040 s       ~0.0002 s
    43         0.143 s       ~0.0003 s
    49         0.832 s        0.0003 s
    73         >5,000,000 frontier pops (aborted)   0.0009 s

An anonymous `git clone --depth=N` of a pushed ~100-commit repository pins a server CPU for a long time per request before any pack is generated. Added a regression test and a NEWS entry.

(rebased and tweaked from https://github.com/jelmer/dulwich/pull/2352)