### PR TITLE
Add sanitize_user_identity, mirroring git's fmt_ident sanitization

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.2.13	UNRELEASED
 
+ * Add ``repo.sanitize_user_identity``, which builds an identity from a
+   name and an email sanitized the way git's ``fmt_ident`` does, for
+   callers who cannot reject invalid input via ``check_user_identity``.
+   (Bojan Zivanovic, #2342)
+
  * Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
    (``dulwich.object_store``). Both re-expanded a commit once per path that
    reached it, so a merge-heavy history walked in exponential time.

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -55,6 +55,7 @@ __all__ = [
     "parse_graftpoints",
     "parse_shared_repository",
     "read_gitfile",
+    "sanitize_user_identity",
     "serialize_graftpoints",
 ]
 
@@ -312,6 +313,44 @@ def check_user_identity(identity: bytes) -> None:
         raise InvalidUserIdentity(identity.decode("utf-8", "replace"))
     if b"\0" in identity or b"\n" in identity:
         raise InvalidUserIdentity(identity.decode("utf-8", "replace"))
+
+
+_IDENTITY_CRUD = bytes(range(33)) + b",:;<>\"\\'"
+
+
+def _strip_identity_crud(value: bytes) -> bytes:
+    r"""Strip characters using git's ``strbuf_addstr_without_crud`` rules.
+
+    Leading and trailing "crud" (bytes <= 32 as well as ``,:;<>"\'``) is
+    stripped, and the delimiter characters ``\n``, ``<`` and ``>`` are
+    dropped from the rest of the value.
+    """
+    # Git does not handle embedded NUL bytes here, but check_user_identity
+    # rejects them.
+    return value.strip(_IDENTITY_CRUD).translate(None, b"\0\n<>")
+
+
+def sanitize_user_identity(name: bytes, email: bytes) -> bytes:
+    r"""Build a user identity with a sanitized name and email.
+
+    Matches git's ``fmt_ident`` behavior: the name and the email are each
+    stripped of leading and trailing "crud" (bytes <= 32 as well as
+    ``,:;<>"\'``), and the delimiter characters ``\n``, ``<`` and ``>``
+    are dropped from the middle.
+
+    Unlike ``check_user_identity``, this function never rejects its input. It
+    is intended for identities outside the caller's control, such as those
+    used by an importer to build commits. The result always passes
+    ``check_user_identity``.
+
+    Args:
+      name: User name bytestring
+      email: Email bytestring
+
+    Returns:
+      Identity bytestring of the format ``name <email>``
+    """
+    return _strip_identity_crud(name) + b" <" + _strip_identity_crud(email) + b">"
 
 
 def parse_graftpoints(

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -51,6 +51,7 @@ from dulwich.repo import (
     UnsupportedVersion,
     check_user_identity,
     parse_shared_repository,
+    sanitize_user_identity,
 )
 from dulwich.tests.utils import open_repo, setup_warning_catcher, tear_down_repo
 
@@ -2011,6 +2012,38 @@ class CheckUserIdentityTests(TestCase):
         self.assertRaises(
             InvalidUserIdentity, check_user_identity, b"Contains\nnewline byte <>"
         )
+
+
+class SanitizeUserIdentityTests(TestCase):
+    def test_clean(self) -> None:
+        self.assertEqual(
+            b"Me <me@example.com>", sanitize_user_identity(b"Me", b"me@example.com")
+        )
+
+    def test_strips_leading_and_trailing_crud(self) -> None:
+        self.assertEqual(
+            b"Full Name <me@example.com>",
+            sanitize_user_identity(b" ,:;<Full Name>'\"\\ ", b"<me@example.com>"),
+        )
+        self.assertEqual(
+            b"Me <me@example.com>",
+            sanitize_user_identity(b"\x01\x1fMe\t\n", b"\x00me@example.com\x20"),
+        )
+
+    def test_drops_delimiters_from_middle(self) -> None:
+        self.assertEqual(
+            b"FullName <mee@xample.com>",
+            sanitize_user_identity(b"Full<>\nName", b"me\ne@<x>\0ample.com"),
+        )
+
+    def test_keeps_inner_crud(self) -> None:
+        self.assertEqual(
+            b"Name, Full: yes <m,e@example.com>",
+            sanitize_user_identity(b"Name, Full: yes", b"m,e@example.com"),
+        )
+
+    def test_empty(self) -> None:
+        self.assertEqual(b" <>", sanitize_user_identity(b"<>", b" ,;"))
 
 
 class RepoConfigIncludeIfTests(TestCase):


### PR DESCRIPTION
check_user_identity validates and raises, which is no help when the identity is not under the caller's control (a hosted git service, an importer). Git does not reject in fmt_ident, it strips leading and trailing crud from the name and the email separately and drops the line delimiters from the middle, via strbuf_addstr_without_crud. Ported that as a standalone helper next to check_user_identity.

Fixes #2342