### PR TITLE
Limit unanswered haves during fetch negotiation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.13	UNRELEASED
 
+ * Bound fetch negotiation the way C Git's ``MAX_IN_VAIN`` does: give up
+   after 256 unacknowledged "have" lines instead of draining the whole
+   graph walker into stateless (HTTP) requests. (Bojan Zivanovic, #2343)
+
  * Add ``repo.sanitize_user_identity``, which builds an identity from a
    name and an email sanitized the way git's ``fmt_ident`` does, for
    callers who cannot reject invalid input via ``check_user_identity``.

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -43,6 +43,7 @@ __all__ = [
     "COMMON_CAPABILITIES",
     "DEFAULT_GIT_CREDENTIALS_PATHS",
     "DEFAULT_REF_PREFIX",
+    "MAX_IN_VAIN",
     "RECEIVE_CAPABILITIES",
     "UPLOAD_CAPABILITIES",
     "AbstractHttpGitClient",
@@ -256,6 +257,10 @@ from .repo import BaseRepo, Repo
 # specified, so explicitly request all refs to match
 # behaviour with v1 when no ref-prefix is specified.
 DEFAULT_REF_PREFIX = [b"HEAD", b"refs/"]
+
+# Stop negotiation after this many "have" lines without an ACK. This matches
+# MAX_IN_VAIN in C Git's fetch-pack.c.
+MAX_IN_VAIN = 256
 
 
 logger = logging.getLogger(__name__)
@@ -968,14 +973,19 @@ def _handle_upload_pack_head(
         proto.write_pkt_line(None)
 
     have = next(graph_walker)
+    in_vain = 0
+    got_ack = False
     while have:
         proto.write_pkt_line(COMMAND_HAVE + b" " + have + b"\n")
+        in_vain += 1
         if can_read is not None and can_read():
             pkt = proto.read_pkt_line()
             assert pkt is not None
             parts = pkt.rstrip(b"\n").split(b" ")
             if parts[0] == b"ACK":
                 graph_walker.ack(ObjectID(parts[1]))
+                in_vain = 0
+                got_ack = True
                 if parts[2] in (b"continue", b"common"):
                     pass
                 elif parts[2] == b"ready":
@@ -984,6 +994,11 @@ def _handle_upload_pack_head(
                     raise AssertionError(
                         f"{parts[2]!r} not in ('continue', 'ready', 'common)"
                     )
+        # Once the server has ACKed something, stop if negotiation makes no
+        # progress for MAX_IN_VAIN haves. Stateless transports cannot read
+        # ACKs while building the request, so apply the limit from the start.
+        if in_vain >= MAX_IN_VAIN and (got_ack or can_read is None):
+            break
         have = next(graph_walker)
     proto.write_pkt_line(COMMAND_DONE + b"\n")
     if protocol_version == 2:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,6 +41,7 @@ import dulwich
 from dulwich import client, errors
 from dulwich.bundle import create_bundle_from_repo, write_bundle
 from dulwich.client import (
+    MAX_IN_VAIN,
     AuthCallbackPoolManager,
     BundleClient,
     FetchPackResult,
@@ -126,6 +127,28 @@ class DummyPopen:
 
     def wait(self, *args, **kwards) -> bool:
         return False
+
+
+class CountingGraphWalker:
+    """Graph walker yielding a bounded stream of synthetic shas."""
+
+    def __init__(self, limit=None) -> None:
+        self.count = 0
+        self.limit = limit
+        self.acked: list[bytes] = []
+
+    @staticmethod
+    def sha(count):
+        return f"{count:040x}".encode("ascii")
+
+    def __next__(self):
+        self.count += 1
+        if self.limit is not None and self.count > self.limit:
+            return None
+        return self.sha(self.count)
+
+    def ack(self, sha):
+        self.acked.append(sha)
 
 
 # TODO(durin42): add unit-level tests of GitClient
@@ -353,6 +376,63 @@ class GitClientTests(TestCase):
         output = self.rout.getvalue()
         self.assertIn(b"deepen-since 2023-01-01T00:00:00Z\n", output)
         self.assertIn(b"deepen-not refs/heads/excluded\n", output)
+
+    def test_handle_upload_pack_head_stateless_bounds_haves(self) -> None:
+        # Stateless transports cannot receive ACKs while building the request.
+        proto = Protocol(self.rin.read, self.rout.write)
+        _handle_upload_pack_head(
+            proto=proto,
+            capabilities=[b"multi_ack"],
+            graph_walker=CountingGraphWalker(),
+            wants=[b"55dcc6bf963f922e1ed5c4bbaaefcfacef57b1d7"],
+            can_read=None,
+            depth=None,
+            protocol_version=0,
+        )
+
+        output = self.rout.getvalue()
+        self.assertEqual(MAX_IN_VAIN, output.count(b"have "))
+        self.assertTrue(output.endswith(b"0009done\n"))
+
+    def test_handle_upload_pack_head_no_ack_sends_all_haves(self) -> None:
+        # A readable connection waits for the first ACK before applying the limit.
+        num_haves = MAX_IN_VAIN + 44
+        proto = Protocol(self.rin.read, self.rout.write)
+        _handle_upload_pack_head(
+            proto=proto,
+            capabilities=[b"multi_ack"],
+            graph_walker=CountingGraphWalker(limit=num_haves),
+            wants=[b"55dcc6bf963f922e1ed5c4bbaaefcfacef57b1d7"],
+            can_read=lambda: False,
+            depth=None,
+            protocol_version=0,
+        )
+
+        output = self.rout.getvalue()
+        self.assertEqual(num_haves, output.count(b"have "))
+
+    def test_handle_upload_pack_head_gives_up_after_ack(self) -> None:
+        # Stop after MAX_IN_VAIN more haves without an ACK.
+        first_sha = CountingGraphWalker.sha(1)
+        self.rin.write(pkt_line(b"ACK " + first_sha + b" continue\n"))
+        self.rin.seek(0)
+
+        reads = iter([True])
+        proto = Protocol(self.rin.read, self.rout.write)
+        graph_walker = CountingGraphWalker()
+        _handle_upload_pack_head(
+            proto=proto,
+            capabilities=[b"multi_ack"],
+            graph_walker=graph_walker,
+            wants=[b"55dcc6bf963f922e1ed5c4bbaaefcfacef57b1d7"],
+            can_read=lambda: next(reads, False),
+            depth=None,
+            protocol_version=0,
+        )
+
+        self.assertEqual([first_sha], graph_walker.acked)
+        output = self.rout.getvalue()
+        self.assertEqual(1 + MAX_IN_VAIN, output.count(b"have "))
 
     def test_send_pack_no_sideband64k_with_update_ref_error(self) -> None:
         # No side-bank-64k reported by server shouldn't try to parse


### PR DESCRIPTION
Stop sending haves after 256 go unanswered following an ACK, matching Git's MAX_IN_VAIN behavior.

For stateless transports such as HTTP, apply the limit from the start because ACKs are not read while building the request.

Fixes #2343.