### PR TITLE
Match git's path parsing in the smart-HTTP router

### DIFF
--- a/dulwich/web.py
+++ b/dulwich/web.py
@@ -724,14 +724,14 @@ class HTTPGitApplication:
             Callable[[HTTPGitRequest, Backend, re.Match[str]], Iterator[bytes]],
         ]
     ] = {
-        ("GET", re.compile("/HEAD$")): get_text_file,
-        ("GET", re.compile("/info/refs$")): get_info_refs,
-        ("GET", re.compile("/objects/info/alternates$")): get_text_file,
-        ("GET", re.compile("/objects/info/http-alternates$")): get_text_file,
-        ("GET", re.compile("/objects/info/packs$")): get_info_packs,
+        ("GET", re.compile("/HEAD\\Z")): get_text_file,
+        ("GET", re.compile("/info/refs\\Z")): get_info_refs,
+        ("GET", re.compile("/objects/info/alternates\\Z")): get_text_file,
+        ("GET", re.compile("/objects/info/http-alternates\\Z")): get_text_file,
+        ("GET", re.compile("/objects/info/packs\\Z")): get_info_packs,
         (
             "GET",
-            re.compile("/objects/([0-9a-f]{2})/([0-9a-f]{38})$"),
+            re.compile("/objects/([0-9a-f]{2})/([0-9a-f]{38})\\Z"),
         ): get_loose_object,
         # Match any "<prefix>-<hash>" pack basename, not just "pack-". ``git
         # maintenance`` writes "loose-<hash>" packs, which get_info_packs
@@ -740,14 +740,14 @@ class HTTPGitApplication:
         # (get_named_file joins it under the control dir unsanitised).
         (
             "GET",
-            re.compile("/objects/pack/\\w+-([0-9a-f]{40}|[0-9a-f]{64})\\.pack$"),
+            re.compile("/objects/pack/\\w+-([0-9a-f]{40}|[0-9a-f]{64})\\.pack\\Z"),
         ): get_pack_file,
         (
             "GET",
-            re.compile("/objects/pack/\\w+-([0-9a-f]{40}|[0-9a-f]{64})\\.idx$"),
+            re.compile("/objects/pack/\\w+-([0-9a-f]{40}|[0-9a-f]{64})\\.idx\\Z"),
         ): get_idx_file,
-        ("POST", re.compile("/git-upload-pack$")): handle_service_request,
-        ("POST", re.compile("/git-receive-pack$")): handle_service_request,
+        ("POST", re.compile("/git-upload-pack\\Z")): handle_service_request,
+        ("POST", re.compile("/git-receive-pack\\Z")): handle_service_request,
     }
 
     def __init__(
@@ -793,6 +793,13 @@ class HTTPGitApplication:
                 continue
             mat = spath.search(path)
             if mat:
+                # url_prefix() collapses slashes, so "/repo//git-receive-pack"
+                # would otherwise resolve to the same repository as the
+                # canonical spelling. Reject the redundant form rather than
+                # normalise it, so only one path reaches a given repository.
+                if mat.string[: mat.start()].endswith("/"):
+                    mat = None
+                    continue
                 handler = self.services[smethod, spath]
                 break
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -711,6 +711,42 @@ class HTTPGitApplicationTestCase(TestCase):
             self._route_handler("GET", f"/objects/pack/pack-{sha}.pack"),
         )
 
+    def test_route_rejects_trailing_newline(self) -> None:
+        """A trailing newline must not match a service route.
+
+        Python's "$" also matches just before a final newline, so
+        "/git-receive-pack\n" would otherwise reach the write handler while a
+        front-end proxy gating writes by request path does not recognise it.
+        git-http-backend returns 404 for this spelling.
+        """
+        self.assertIs(
+            handle_service_request, self._route_handler("POST", "/git-receive-pack")
+        )
+        self.assertIsNone(self._route_handler("POST", "/git-receive-pack\n"))
+        self.assertIsNone(self._route_handler("POST", "/git-upload-pack\n"))
+        self.assertIsNone(self._route_handler("GET", "/info/refs\n"))
+        self.assertIsNone(self._route_handler("GET", "/HEAD\n"))
+
+    def test_route_rejects_doubled_slash(self) -> None:
+        """A doubled slash must not resolve to the same repository.
+
+        url_prefix() strips slashes, so "/repo//git-receive-pack" would
+        otherwise reach the same repository as the canonical spelling.
+        """
+        app = HTTPGitApplication("backend")
+        status = []
+
+        def start_response(code, headers, exc=None):
+            status.append(code)
+            return lambda data: None
+
+        environ = {
+            "PATH_INFO": "//git-receive-pack",
+            "REQUEST_METHOD": "POST",
+        }
+        list(app(environ, start_response))
+        self.assertEqual(["404 Not Found"], status)
+
     def test_route_rejects_pack_path_traversal(self) -> None:
         # A name with a path separator must not match the pack routes.
         self.assertIsNone(self._route_handler("GET", "/objects/pack/../../config.pack"))


### PR DESCRIPTION
The route regexes were anchored with "$", which in Python also matches just before a single trailing newline, so "/repo/git-receive-pack\n" matched and dispatched the write handler. git-http-backend returns 404 for that path. Anchor with "\Z" instead.

Also reject paths that only reach a route after slash collapsing: url_prefix() strips slashes, so "/repo//git-receive-pack" resolved to the same repository as the canonical spelling.

Reported by Izzy Izzy.