### PR TITLE
Make concurrent ``PackData`` reads thread-safe by mmap-ing pack contents

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,8 +10,11 @@
    (Bojan Zivanovic, #2342)
 
  * Make concurrent ``PackData`` reads thread-safe by mmap-ing pack contents
-   and giving each operation an independent cursor instead of sharing the
-   file position. (Bojan Zivanovic)
+   and indexing the mapping at explicit offsets instead of sharing the file
+   position. New ``unpack_object_at``, ``read_pack_header_at``,
+   ``read_zlib_chunks_at``, ``take_msb_bytes_at`` and ``compute_buffer_sha``
+   read from a buffer; the existing read-callable variants remain for streams.
+   (Bojan Zivanovic, Jelmer Vernooĳ)
 
  * Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
    (``dulwich.object_store``). Both re-expanded a commit once per path that

--- a/NEWS
+++ b/NEWS
@@ -9,6 +9,10 @@
    callers who cannot reject invalid input via ``check_user_identity``.
    (Bojan Zivanovic, #2342)
 
+ * Make concurrent ``PackData`` reads thread-safe by mmap-ing pack contents
+   and giving each operation an independent cursor instead of sharing the
+   file position. (Bojan Zivanovic)
+
  * Deduplicate the commit walk in ``find_shallow`` and ``get_depth``
    (``dulwich.object_store``). Both re-expanded a commit once per path that
    reached it, so a merge-heavy history walked in exponential time.

--- a/dulwich/object_store.py
+++ b/dulwich/object_store.py
@@ -105,6 +105,7 @@ from .pack import (
     PackedObjectContainer,
     PackFileDisappeared,
     PackHint,
+    PackIndexEntry,
     PackIndexer,
     PackInflater,
     PackStreamCopier,
@@ -2113,12 +2114,35 @@ class DiskObjectStore(PackBasedObjectStore):
         suffix = suffix_bytes.decode("ascii")
         return os.path.join(self.pack_dir, "pack-" + suffix)
 
+    def _index_pack(
+        self,
+        indexer: PackIndexer,
+        num_objects: int,
+        progress: Callable[..., None] | None = None,
+    ) -> tuple[list[PackIndexEntry], set[RawObjectID]]:
+        """Drain an indexer into index entries and the external refs it needs.
+
+        Args:
+          indexer: A PackIndexer over the pack being completed.
+          num_objects: Number of objects in the pack, for progress reporting.
+          progress: Optional progress reporting function.
+
+        Returns: Tuple of (index entries, external refs). ext_refs() is only
+            populated once the indexer has been drained.
+        """
+        entries = []
+        for i, entry in enumerate(indexer):
+            if progress is not None:
+                progress(f"generating index: {i}/{num_objects}\r".encode("ascii"))
+            entries.append(entry)
+        return entries, set(indexer.ext_refs())
+
     def _complete_pack(
         self,
         f: BinaryIO,
         path: str,
-        num_objects: int,
-        indexer: PackIndexer,
+        entries: list[PackIndexEntry],
+        ext_refs: set[RawObjectID],
         progress: Callable[..., None] | None = None,
         refs: dict[Ref, ObjectID] | None = None,
     ) -> Pack:
@@ -2127,23 +2151,23 @@ class DiskObjectStore(PackBasedObjectStore):
         Note: The file should be on the same file system as the
             packs directory.
 
+        This takes ownership of ``f``: it appends any missing base objects,
+        closes the file and renames it into place. Callers must have finished
+        reading the pack (see :meth:`_index_pack`) before calling this; on
+        Windows a mapping left over the file blocks both the write and the
+        rename.
+
         Args:
           f: Open file object for the pack.
           path: Path to the pack file.
-          num_objects: Number of objects in the pack.
-          indexer: A PackIndexer for indexing the pack.
+          entries: Index entries for the objects already in the pack.
+          ext_refs: Objects the pack deltas against that it does not contain.
           progress: Optional progress reporting function.
           refs: Optional dictionary of refs for bitmap generation.
         """
-        entries = []
-        for i, entry in enumerate(indexer):
-            if progress is not None:
-                progress(f"generating index: {i}/{num_objects}\r".encode("ascii"))
-            entries.append(entry)
-
         pack_sha, extra_entries = extend_pack(
             f,
-            set(indexer.ext_refs()),
+            ext_refs,
             get_raw=self.get_raw,
             compression_level=self.pack_compression_level,
             progress=progress,
@@ -2323,7 +2347,10 @@ class DiskObjectStore(PackBasedObjectStore):
                 delta_iter=indexer,  # type: ignore[arg-type]
             )
             copier.verify(progress=progress)
-            return self._complete_pack(f, path, len(copier), indexer, progress=progress)
+            entries, ext_refs = self._index_pack(
+                indexer, len(copier), progress=progress
+            )
+            return self._complete_pack(f, path, entries, ext_refs, progress=progress)
 
     def add_pack(
         self,
@@ -2345,12 +2372,16 @@ class DiskObjectStore(PackBasedObjectStore):
             if f.tell() > 0:
                 f.seek(0)
 
+                # Scope the mapping to indexing: _complete_pack writes to and
+                # renames this same file, which a live mapping blocks on
+                # Windows. PackData.close() leaves f open for it to finish.
                 with PackData(path, file=f, object_format=self.object_format) as pd:
                     indexer = PackIndexer.for_pack_data(
                         pd,
                         resolve_ext_ref=self.get_raw,
                     )
-                    return self._complete_pack(f, path, len(pd), indexer)  # type: ignore[arg-type]
+                    entries, ext_refs = self._index_pack(indexer, len(pd))  # type: ignore[arg-type]
+                return self._complete_pack(f, path, entries, ext_refs)
             else:
                 f.close()
                 os.remove(path)

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2121,8 +2121,12 @@ class PackData:
 
         if file is None:
             self._file = GitFile(self._filename, "rb")
+            self._close_file = True
         else:
+            # A caller-supplied file stays the caller's to close; it may well
+            # keep writing to it after we are done reading.
             self._file = file
+            self._close_file = False
         try:
             # Map the pack once; every read indexes this buffer at an explicit
             # offset, so concurrent reads never contend on a file position.
@@ -2213,12 +2217,17 @@ class PackData:
         return contents
 
     def close(self) -> None:
-        """Close the underlying pack file."""
+        """Release the mapping, and the pack file if we opened it.
+
+        Callers must drop the mapping before writing to or renaming the pack:
+        on Windows a live mapping locks the file.
+        """
         contents = self._contents
         self._contents = None
         _close_file_contents(contents)
         if self._file is not None:
-            self._file.close()
+            if self._close_file:
+                self._file.close()
             self._file = None  # type: ignore
 
     def __del__(self) -> None:

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -653,13 +653,22 @@ def read_zlib_chunks_at(
     Like :func:`read_zlib_chunks`, but indexes the buffer directly instead of
     consuming a read callable, so concurrent readers do not share a position.
 
+    The buffer is fed to zlib in ``buffer_size`` slices rather than in one
+    piece. That bounds ``unused_data``, which zlib materialises as a copy of
+    everything it was handed past the end of the stream: passing the whole
+    mapping would copy the entire remainder of the pack for every object read.
+
+    Slices are taken as memoryviews, so the compressed data is decompressed
+    straight out of the mapping. With ``include_comp`` the chunks are kept on
+    ``unpacked`` and outlive the mapping, so those are copied.
+
     Args:
       contents: Buffer holding the compressed data.
       offset: Offset in contents at which the zlib stream starts.
       unpacked: An UnpackedObject to write result data to; see
         :func:`read_zlib_chunks` for the attributes set on it.
       include_comp: If True, include compressed data in the result.
-      buffer_size: Number of bytes to decompress at a time.
+      buffer_size: Number of bytes to feed to zlib at a time.
     Returns: Offset in contents just past the end of the zlib stream.
 
     Raises:
@@ -676,30 +685,30 @@ def read_zlib_chunks_at(
     max_decomp = unpacked.decomp_len
     pos = offset
 
-    while True:
-        add = contents[pos : pos + buffer_size]
-        if not add:
-            raise zlib.error("EOF before end of zlib stream")
-        pos += len(add)
-        comp_chunks.append(add)
-        # +1 so overrun surfaces as unconsumed_tail rather than being truncated.
-        remaining = max_decomp - decomp_len + 1
-        decomp = decomp_obj.decompress(add, remaining)
-        if decomp_obj.unconsumed_tail:
-            raise zlib.error("decompressed data exceeds expected size")
-        decomp_len += len(decomp)
-        decomp_chunks.append(decomp)
-        unused = decomp_obj.unused_data
-        if unused:
-            left = len(unused)
-            pos -= left
+    with memoryview(contents) as view:
+        while True:
+            add = view[pos : pos + buffer_size]
+            if not add:
+                raise zlib.error("EOF before end of zlib stream")
+            pos += len(add)
+            # +1 so overrun surfaces as unconsumed_tail rather than being truncated.
+            remaining = max_decomp - decomp_len + 1
+            decomp = decomp_obj.decompress(add, remaining)
+            if decomp_obj.unconsumed_tail:
+                raise zlib.error("decompressed data exceeds expected size")
+            decomp_len += len(decomp)
+            decomp_chunks.append(decomp)
+            unused = decomp_obj.unused_data
+            if unused:
+                left = len(unused)
+                pos -= left
+                add = add[:-left]
             if crc32 is not None:
-                crc32 = binascii.crc32(add[:-left], crc32)
+                crc32 = binascii.crc32(add, crc32)
             if include_comp:
-                comp_chunks[-1] = add[:-left]
-            break
-        elif crc32 is not None:
-            crc32 = binascii.crc32(add, crc32)
+                comp_chunks.append(bytes(add))
+            if unused:
+                break
     if crc32 is not None:
         crc32 &= 0xFFFFFFFF
 

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -660,10 +660,14 @@ def _load_file_contents(
       size: Expected size, or None to determine from file
     Returns: Tuple of (contents, size)
     """
-    try:
-        fd = f.fileno()
-    except (UnsupportedOperation, AttributeError):
+    # Avoid rolling a SpooledTemporaryFile to disk just to get a descriptor.
+    if getattr(f, "_rolled", True) is False:
         fd = None
+    else:
+        try:
+            fd = f.fileno()
+        except (UnsupportedOperation, AttributeError):
+            fd = None
     # Attempt to use mmap if possible
     if fd is not None:
         if size is None:
@@ -679,6 +683,18 @@ def _load_file_contents(
     contents_bytes = f.read()
     size = len(contents_bytes)
     return contents_bytes, size
+
+
+def _close_file_contents(contents: "bytes | mmap.mmap | None") -> None:
+    """Close contents returned by _load_file_contents, if closeable.
+
+    Callers must close the mapping before the file it maps: on Windows the
+    mapping holds a lock on the file, so the handle cannot be released while
+    it is alive.
+    """
+    close_fn = getattr(contents, "close", None)
+    if close_fn is not None:
+        close_fn()
 
 
 def load_pack_index_file(
@@ -980,11 +996,7 @@ class FilePackIndex(PackIndex):
 
     def close(self) -> None:
         """Close the underlying file and any mmap."""
-        # Close the mmap before the file: on Windows the mapping holds a lock
-        # on the file, so the handle cannot be released while it is alive.
-        close_fn = getattr(self._contents, "close", None)
-        if close_fn is not None:
-            close_fn()
+        _close_file_contents(self._contents)
         self._file.close()
 
     def __del__(self) -> None:
@@ -1775,7 +1787,7 @@ def obj_sha(
 
 
 def compute_file_sha(
-    f: IO[bytes],
+    f: "IO[bytes] | _ContentsReader",
     hash_func: Callable[[], "HashObject"],
     start_ofs: int = 0,
     end_ofs: int = 0,
@@ -1810,6 +1822,44 @@ def compute_file_sha(
     return sha
 
 
+class _ContentsReader:
+    """Stateful read interface over an in-memory pack buffer.
+
+    Every reader tracks its own position, so any number of them can read
+    from the same buffer concurrently. Calling the reader reads from it, so
+    it can be passed directly wherever a read callable is expected.
+    """
+
+    __slots__ = ("_contents", "pos")
+
+    def __init__(self, contents: "bytes | mmap.mmap", offset: int) -> None:
+        self._contents = contents
+        self.pos = offset
+
+    def read(self, size: int = -1) -> bytes:
+        """Read up to size bytes from the current position, or all if -1."""
+        end = None if size < 0 else self.pos + size
+        chunk = self._contents[self.pos : end]
+        self.pos += len(chunk)
+        return chunk
+
+    __call__ = read
+
+    def seek(self, offset: int, whence: int = 0) -> int:
+        """Move the read position, following the io.IOBase convention."""
+        if whence == SEEK_END:
+            self.pos = len(self._contents) + offset
+        elif whence == SEEK_CUR:
+            self.pos += offset
+        else:
+            self.pos = offset
+        return self.pos
+
+    def tell(self) -> int:
+        """Return the current read position."""
+        return self.pos
+
+
 class PackData:
     """The data contained in a packfile.
 
@@ -1828,9 +1878,8 @@ class PackData:
     For the complete objects the data is stored as zlib deflated data.
     The size in the header is the uncompressed object size, so to uncompress
     you need to just keep feeding data to zlib until you get an object back,
-    or it errors on bad data. This is done here by just giving the complete
-    buffer from the start of the deflated object on. This is bad, but until I
-    get mmap sorted out it will have to do.
+    or it errors on bad data. This is done here by reading from the mapped
+    pack contents starting at the deflated object.
 
     Currently there are no integrity checks done. Also no attempt is made to
     try and detect the delta case, or a request for an object at the wrong
@@ -1855,14 +1904,15 @@ class PackData:
         """Create a PackData object representing the pack in the given filename.
 
         The file must exist and stay readable until the object is disposed of.
-        It must also stay the same size. It will be mapped whenever needed.
+        It must also stay the same size. It is mapped into memory on open, so
+        reads never contend on a shared file position.
 
-        Currently there is a restriction on the size of the pack as the python
-        mmap implementation is flawed.
+        The size argument is accepted for backward compatibility and ignored:
+        checksum offsets are derived from the size, so it is measured when the
+        pack is mapped rather than trusted from the caller.
         """
         self._filename = filename
         self.object_format = object_format
-        self._size = size
         self._header_size = 12
         self.delta_window_size = delta_window_size
         self.window_memory = window_memory
@@ -1872,20 +1922,34 @@ class PackData:
         self.big_file_threshold = big_file_threshold
         self.delta_base_cache_limit = delta_base_cache_limit
         self._file: IO[bytes]
+        self._contents: bytes | mmap.mmap | None = None
 
         if file is None:
             self._file = GitFile(self._filename, "rb")
         else:
             self._file = file
-        (_version, self._num_objects) = read_pack_header(self._file.read)
+        try:
+            # Keep one copy of the pack so each reader can track its own position.
+            self._contents, self._size = _load_file_contents(self._file)
+            minimum_size = self._header_size + self.object_format.oid_length
+            if self._size < minimum_size:
+                raise AssertionError(
+                    f"{self._filename} is too small for a packfile ({self._size} < {minimum_size})"
+                )
+            (_version, self._num_objects) = read_pack_header(self._reader())
 
-        # Use delta_base_cache_limit, then delta_cache_size, then default
-        cache_size = (
-            delta_base_cache_limit or delta_cache_size or DEFAULT_DELTA_BASE_CACHE_LIMIT
-        )
-        self._offset_cache = LRUSizeCache[int, tuple[int, OldUnpackedObject]](
-            cache_size, compute_size=_compute_object_size
-        )
+            # Use delta_base_cache_limit, then delta_cache_size, then default
+            cache_size = (
+                delta_base_cache_limit
+                or delta_cache_size
+                or DEFAULT_DELTA_BASE_CACHE_LIMIT
+            )
+            self._offset_cache = LRUSizeCache[int, tuple[int, OldUnpackedObject]](
+                cache_size, compute_size=_compute_object_size
+            )
+        except BaseException:
+            self.close()
+            raise
 
     @property
     def filename(self) -> str:
@@ -1917,7 +1981,7 @@ class PackData:
         Args:
           file: Open file object
           object_format: Object format
-          size: Optional file size
+          size: Ignored; the pack is measured when it is mapped
 
         Returns:
           PackData instance
@@ -1941,8 +2005,18 @@ class PackData:
         """
         return cls(filename=path, object_format=object_format)
 
+    def _reader(self, offset: int = 0) -> _ContentsReader:
+        """Return a reader over the pack contents positioned at offset."""
+        contents = self._contents
+        if contents is None:
+            raise ValueError(f"read from closed PackData: {self._filename}")
+        return _ContentsReader(contents, offset)
+
     def close(self) -> None:
         """Close the underlying pack file."""
+        contents = self._contents
+        self._contents = None
+        _close_file_contents(contents)
         if self._file is not None:
             self._file.close()
             self._file = None  # type: ignore
@@ -1984,12 +2058,6 @@ class PackData:
         return False
 
     def _get_size(self) -> int:
-        if self._size is not None:
-            return self._size
-        self._size = os.path.getsize(self._filename)
-        if self._size < self._header_size:
-            errmsg = f"{self._filename} is too small for a packfile ({self._size} < {self._header_size})"
-            raise AssertionError(errmsg)
         return self._size
 
     def __len__(self) -> int:
@@ -2002,22 +2070,21 @@ class PackData:
         Returns: Binary digest (size depends on hash algorithm)
         """
         return compute_file_sha(
-            self._file,
+            self._reader(),
             hash_func=self.object_format.hash_func,
             end_ofs=-self.object_format.oid_length,
         ).digest()
 
     def iter_unpacked(self, *, include_comp: bool = False) -> Iterator[UnpackedObject]:
         """Iterate over unpacked objects in the pack."""
-        self._file.seek(self._header_size)
-
         if self._num_objects is None:
             return
 
+        reader = self._reader(self._header_size)
         for _ in range(self._num_objects):
-            offset = self._file.tell()
+            offset = reader.pos
             unpacked, unused = unpack_object(
-                self._file.read,
+                reader,
                 self.object_format.hash_func,
                 compute_crc32=False,
                 include_comp=include_comp,
@@ -2025,7 +2092,7 @@ class PackData:
             unpacked.offset = offset
             yield unpacked
             # Back up over unused data.
-            self._file.seek(-len(unused), SEEK_CUR)
+            reader.pos -= len(unused)
 
     def iterentries(
         self,
@@ -2175,8 +2242,7 @@ class PackData:
     def get_stored_checksum(self) -> bytes:
         """Return the expected checksum stored in this pack."""
         checksum_size = self.object_format.oid_length
-        self._file.seek(-checksum_size, SEEK_END)
-        return self._file.read(checksum_size)
+        return self._reader(self._size - checksum_size).read(checksum_size)
 
     def check(self) -> None:
         """Check the consistency of this pack."""
@@ -2190,9 +2256,10 @@ class PackData:
     ) -> UnpackedObject:
         """Given offset in the packfile return a UnpackedObject."""
         assert offset >= self._header_size
-        self._file.seek(offset)
         unpacked, _ = unpack_object(
-            self._file.read, self.object_format.hash_func, include_comp=include_comp
+            self._reader(offset),
+            self.object_format.hash_func,
+            include_comp=include_comp,
         )
         unpacked.offset = offset
         return unpacked
@@ -2257,7 +2324,15 @@ class DeltaChainIterator(Generic[T]):
                 that materialise objects (e.g. PackInflater) when iterating
                 packs in a non-default hash algorithm such as SHA-256.
         """
-        self._file = file_obj
+        self._reader_at: Callable[[int], Callable[[int], bytes]] | None = None
+        if file_obj is not None:
+
+            def reader_at(offset: int) -> Callable[[int], bytes]:
+                # add_thin_pack may still be writing to this file, so read it directly.
+                file_obj.seek(offset)
+                return file_obj.read
+
+            self._reader_at = reader_at
         self.hash_func = hash_func
         self._object_format = object_format
         self._resolve_ext_ref = resolve_ext_ref
@@ -2374,7 +2449,7 @@ class DeltaChainIterator(Generic[T]):
         Args:
           pack_data: PackData object to use
         """
-        self._file = pack_data._file
+        self._reader_at = pack_data._reader
 
     def _walk_all_chains(self) -> Iterator[T]:
         for offset, type_num in self._full_ofs:
@@ -2419,10 +2494,9 @@ class DeltaChainIterator(Generic[T]):
         obj_type_num: int,
         base_chunks: bytes | list[bytes] | None,
     ) -> UnpackedObject:
-        assert self._file is not None
-        self._file.seek(offset)
+        assert self._reader_at is not None
         unpacked, _ = unpack_object(
-            self._file.read,
+            self._reader_at(offset),
             self.hash_func,
             read_some=None,
             compute_crc32=self._compute_crc32,

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -117,7 +117,7 @@ import zlib
 from collections.abc import Callable, Iterable, Iterator, Sequence, Set
 from hashlib import sha1, sha256
 from itertools import chain
-from os import SEEK_CUR, SEEK_END
+from os import SEEK_END
 from struct import unpack_from
 from types import TracebackType
 from typing import (
@@ -386,6 +386,32 @@ def take_msb_bytes(
     return ret, crc32
 
 
+def take_msb_bytes_at(
+    contents: "bytes | mmap.mmap", offset: int, crc32: int | None = None
+) -> tuple[list[int], int, int | None]:
+    """Read bytes marked with most significant bit from a buffer at an offset.
+
+    Args:
+      contents: Buffer to read from
+      offset: Offset in contents to start reading at
+      crc32: Optional CRC32 checksum to update
+
+    Returns:
+      Tuple of (list of bytes read, offset just past them, updated CRC32 or None)
+    """
+    ret: list[int] = []
+    pos = offset
+    while len(ret) == 0 or ret[-1] & 0x80:
+        b = contents[pos : pos + 1]
+        if not b:
+            raise AssertionError(f"unexpected end of pack data at {pos}")
+        pos += 1
+        if crc32 is not None:
+            crc32 = binascii.crc32(b, crc32)
+        ret.append(ord(b))
+    return ret, pos, crc32
+
+
 class PackFileDisappeared(Exception):
     """Raised when a pack file unexpectedly disappears.
 
@@ -613,6 +639,77 @@ def read_zlib_chunks(
     if include_comp:
         unpacked.comp_chunks = comp_chunks
     return unused
+
+
+def read_zlib_chunks_at(
+    contents: "bytes | mmap.mmap",
+    offset: int,
+    unpacked: UnpackedObject,
+    include_comp: bool = False,
+    buffer_size: int = _ZLIB_BUFSIZE,
+) -> int:
+    """Read zlib data from a buffer at a given offset.
+
+    Like :func:`read_zlib_chunks`, but indexes the buffer directly instead of
+    consuming a read callable, so concurrent readers do not share a position.
+
+    Args:
+      contents: Buffer holding the compressed data.
+      offset: Offset in contents at which the zlib stream starts.
+      unpacked: An UnpackedObject to write result data to; see
+        :func:`read_zlib_chunks` for the attributes set on it.
+      include_comp: If True, include compressed data in the result.
+      buffer_size: Number of bytes to decompress at a time.
+    Returns: Offset in contents just past the end of the zlib stream.
+
+    Raises:
+      zlib.error: if a decompression error occurred.
+    """
+    if unpacked.decomp_len is None or unpacked.decomp_len <= -1:
+        raise ValueError("non-negative zlib data stream size expected")
+    decomp_obj = zlib.decompressobj()
+
+    comp_chunks = []
+    decomp_chunks = unpacked.decomp_chunks
+    decomp_len = 0
+    crc32 = unpacked.crc32
+    max_decomp = unpacked.decomp_len
+    pos = offset
+
+    while True:
+        add = contents[pos : pos + buffer_size]
+        if not add:
+            raise zlib.error("EOF before end of zlib stream")
+        pos += len(add)
+        comp_chunks.append(add)
+        # +1 so overrun surfaces as unconsumed_tail rather than being truncated.
+        remaining = max_decomp - decomp_len + 1
+        decomp = decomp_obj.decompress(add, remaining)
+        if decomp_obj.unconsumed_tail:
+            raise zlib.error("decompressed data exceeds expected size")
+        decomp_len += len(decomp)
+        decomp_chunks.append(decomp)
+        unused = decomp_obj.unused_data
+        if unused:
+            left = len(unused)
+            pos -= left
+            if crc32 is not None:
+                crc32 = binascii.crc32(add[:-left], crc32)
+            if include_comp:
+                comp_chunks[-1] = add[:-left]
+            break
+        elif crc32 is not None:
+            crc32 = binascii.crc32(add, crc32)
+    if crc32 is not None:
+        crc32 &= 0xFFFFFFFF
+
+    if decomp_len != unpacked.decomp_len:
+        raise zlib.error("decompressed data does not match expected size")
+
+    unpacked.crc32 = crc32
+    if include_comp:
+        unpacked.comp_chunks = comp_chunks
+    return pos
 
 
 def iter_sha1(iter: Iterable[bytes]) -> bytes:
@@ -1435,6 +1532,28 @@ def read_pack_header(read: Callable[[int], bytes]) -> tuple[int, int]:
     return (version, num_objects)
 
 
+def read_pack_header_at(
+    contents: "bytes | mmap.mmap", offset: int = 0
+) -> tuple[int, int]:
+    """Read the header of a pack file from a buffer.
+
+    Args:
+      contents: Buffer holding the pack
+      offset: Offset in contents at which the header starts
+    Returns: Tuple of (pack version, number of objects).
+    """
+    header = contents[offset : offset + 12]
+    if not header:
+        raise AssertionError("file too short to contain pack")
+    if header[:4] != b"PACK":
+        raise AssertionError(f"Invalid pack header {bytes(header)!r}")
+    (version,) = unpack_from(b">L", header, 4)
+    if version not in (2, 3):
+        raise AssertionError(f"Version was {version}")
+    (num_objects,) = unpack_from(b">L", header, 8)
+    return (version, num_objects)
+
+
 def chunks_length(chunks: bytes | Iterable[bytes]) -> int:
     """Get the total length of a sequence of chunks.
 
@@ -1536,6 +1655,85 @@ def unpack_object(
         include_comp=include_comp,
     )
     return unpacked, unused
+
+
+def unpack_object_at(
+    contents: "bytes | mmap.mmap",
+    offset: int,
+    hash_func: Callable[[], "HashObject"],
+    compute_crc32: bool = False,
+    include_comp: bool = False,
+    zlib_bufsize: int = _ZLIB_BUFSIZE,
+) -> tuple[UnpackedObject, int]:
+    """Unpack a Git object from a buffer at a given offset.
+
+    Like :func:`unpack_object`, but indexes the buffer directly rather than
+    consuming a read callable, so any number of readers can work on the same
+    buffer concurrently.
+
+    Args:
+      contents: Buffer holding the pack.
+      offset: Offset in contents at which the object starts.
+      hash_func: Hash function to use for computing object IDs.
+      compute_crc32: If True, compute the CRC32 of the compressed data.
+      include_comp: If True, include compressed data in the result.
+      zlib_bufsize: An optional buffer size for zlib operations.
+    Returns: A tuple of (unpacked, end), where end is the offset just past
+        the object and unpacked is an UnpackedObject with its ``offset`` set;
+        see :func:`unpack_object` for the other attributes.
+    """
+    crc32: int | None = 0 if compute_crc32 else None
+
+    raw, pos, crc32 = take_msb_bytes_at(contents, offset, crc32=crc32)
+    type_num = (raw[0] >> 4) & 0x07
+    size = raw[0] & 0x0F
+    for i, byte in enumerate(raw[1:]):
+        size += (byte & 0x7F) << ((i * 7) + 4)
+
+    delta_base: int | bytes | None
+    if type_num == OFS_DELTA:
+        raw, pos, crc32 = take_msb_bytes_at(contents, pos, crc32=crc32)
+        if raw[-1] & 0x80:
+            raise AssertionError
+        delta_base_offset = raw[0] & 0x7F
+        for byte in raw[1:]:
+            delta_base_offset += 1
+            delta_base_offset <<= 7
+            delta_base_offset += byte & 0x7F
+        if delta_base_offset == 0:
+            # A zero offset makes the delta reference itself, which would
+            # loop forever in resolve_object. git's C client rejects this
+            # with "delta offset == 0 is invalid".
+            raise ApplyDeltaError("OFS_DELTA has delta_base_offset of 0")
+        delta_base = delta_base_offset
+    elif type_num == REF_DELTA:
+        hash_size = len(hash_func().digest())
+        delta_base_obj = bytes(contents[pos : pos + hash_size])
+        if len(delta_base_obj) != hash_size:
+            raise AssertionError(f"unexpected end of pack data at {pos}")
+        pos += hash_size
+        if crc32 is not None:
+            crc32 = binascii.crc32(delta_base_obj, crc32)
+        delta_base = delta_base_obj
+    else:
+        delta_base = None
+
+    unpacked = UnpackedObject(
+        type_num,
+        delta_base=delta_base,
+        decomp_len=size,
+        crc32=crc32,
+        hash_func=hash_func,
+    )
+    unpacked.offset = offset
+    end = read_zlib_chunks_at(
+        contents,
+        pos,
+        unpacked,
+        buffer_size=zlib_bufsize,
+        include_comp=include_comp,
+    )
+    return unpacked, end
 
 
 def _compute_object_size(value: tuple[int, Any]) -> int:
@@ -1787,7 +1985,7 @@ def obj_sha(
 
 
 def compute_file_sha(
-    f: "IO[bytes] | _ContentsReader",
+    f: IO[bytes],
     hash_func: Callable[[], "HashObject"],
     start_ofs: int = 0,
     end_ofs: int = 0,
@@ -1822,42 +2020,38 @@ def compute_file_sha(
     return sha
 
 
-class _ContentsReader:
-    """Stateful read interface over an in-memory pack buffer.
+def compute_buffer_sha(
+    contents: "bytes | mmap.mmap",
+    hash_func: Callable[[], "HashObject"],
+    start_ofs: int = 0,
+    end_ofs: int = 0,
+    buffer_size: int = 1 << 16,
+) -> "HashObject":
+    """Hash a portion of a buffer into a new SHA.
 
-    Every reader tracks its own position, so any number of them can read
-    from the same buffer concurrently. Calling the reader reads from it, so
-    it can be passed directly wherever a read callable is expected.
+    Args:
+      contents: Buffer to hash.
+      hash_func: A callable that returns a new HashObject.
+      start_ofs: The offset in the buffer to start hashing at.
+      end_ofs: The offset to end hashing at, relative to the end of the
+        buffer.
+      buffer_size: Number of bytes to hash at a time.
+    Returns: A new SHA object updated with data read from the buffer.
     """
-
-    __slots__ = ("_contents", "pos")
-
-    def __init__(self, contents: "bytes | mmap.mmap", offset: int) -> None:
-        self._contents = contents
-        self.pos = offset
-
-    def read(self, size: int = -1) -> bytes:
-        """Read up to size bytes from the current position, or all if -1."""
-        end = None if size < 0 else self.pos + size
-        chunk = self._contents[self.pos : end]
-        self.pos += len(chunk)
-        return chunk
-
-    __call__ = read
-
-    def seek(self, offset: int, whence: int = 0) -> int:
-        """Move the read position, following the io.IOBase convention."""
-        if whence == SEEK_END:
-            self.pos = len(self._contents) + offset
-        elif whence == SEEK_CUR:
-            self.pos += offset
-        else:
-            self.pos = offset
-        return self.pos
-
-    def tell(self) -> int:
-        """Return the current read position."""
-        return self.pos
+    sha = hash_func()
+    length = len(contents)
+    if start_ofs < 0:
+        raise AssertionError(f"start_ofs cannot be negative: {start_ofs}")
+    if (end_ofs < 0 and length + end_ofs < start_ofs) or end_ofs > length:
+        raise AssertionError(
+            f"Attempt to read beyond buffer length. start_ofs: {start_ofs}, end_ofs: {end_ofs}, buffer length: {length}"
+        )
+    pos = start_ofs
+    end = length + end_ofs
+    while pos < end:
+        sha.update(contents[pos : min(pos + buffer_size, end)])
+        pos += buffer_size
+    return sha
 
 
 class PackData:
@@ -1905,7 +2099,7 @@ class PackData:
 
         The file must exist and stay readable until the object is disposed of.
         It must also stay the same size. It is mapped into memory on open, so
-        reads never contend on a shared file position.
+        reads index the mapping directly rather than sharing a file position.
 
         The size argument is accepted for backward compatibility and ignored:
         checksum offsets are derived from the size, so it is measured when the
@@ -1929,14 +2123,15 @@ class PackData:
         else:
             self._file = file
         try:
-            # Keep one copy of the pack so each reader can track its own position.
+            # Map the pack once; every read indexes this buffer at an explicit
+            # offset, so concurrent reads never contend on a file position.
             self._contents, self._size = _load_file_contents(self._file)
             minimum_size = self._header_size + self.object_format.oid_length
             if self._size < minimum_size:
                 raise AssertionError(
                     f"{self._filename} is too small for a packfile ({self._size} < {minimum_size})"
                 )
-            (_version, self._num_objects) = read_pack_header(self._reader())
+            (_version, self._num_objects) = read_pack_header_at(self._contents)
 
             # Use delta_base_cache_limit, then delta_cache_size, then default
             cache_size = (
@@ -2005,12 +2200,12 @@ class PackData:
         """
         return cls(filename=path, object_format=object_format)
 
-    def _reader(self, offset: int = 0) -> _ContentsReader:
-        """Return a reader over the pack contents positioned at offset."""
+    def _buffer(self) -> "bytes | mmap.mmap":
+        """Return the mapped pack contents."""
         contents = self._contents
         if contents is None:
             raise ValueError(f"read from closed PackData: {self._filename}")
-        return _ContentsReader(contents, offset)
+        return contents
 
     def close(self) -> None:
         """Close the underlying pack file."""
@@ -2069,8 +2264,8 @@ class PackData:
 
         Returns: Binary digest (size depends on hash algorithm)
         """
-        return compute_file_sha(
-            self._reader(),
+        return compute_buffer_sha(
+            self._buffer(),
             hash_func=self.object_format.hash_func,
             end_ofs=-self.object_format.oid_length,
         ).digest()
@@ -2080,19 +2275,17 @@ class PackData:
         if self._num_objects is None:
             return
 
-        reader = self._reader(self._header_size)
+        contents = self._buffer()
+        offset = self._header_size
         for _ in range(self._num_objects):
-            offset = reader.pos
-            unpacked, unused = unpack_object(
-                reader,
+            unpacked, offset = unpack_object_at(
+                contents,
+                offset,
                 self.object_format.hash_func,
                 compute_crc32=False,
                 include_comp=include_comp,
             )
-            unpacked.offset = offset
             yield unpacked
-            # Back up over unused data.
-            reader.pos -= len(unused)
 
     def iterentries(
         self,
@@ -2242,7 +2435,7 @@ class PackData:
     def get_stored_checksum(self) -> bytes:
         """Return the expected checksum stored in this pack."""
         checksum_size = self.object_format.oid_length
-        return self._reader(self._size - checksum_size).read(checksum_size)
+        return bytes(self._buffer()[self._size - checksum_size :])
 
     def check(self) -> None:
         """Check the consistency of this pack."""
@@ -2256,12 +2449,12 @@ class PackData:
     ) -> UnpackedObject:
         """Given offset in the packfile return a UnpackedObject."""
         assert offset >= self._header_size
-        unpacked, _ = unpack_object(
-            self._reader(offset),
+        unpacked, _ = unpack_object_at(
+            self._buffer(),
+            offset,
             self.object_format.hash_func,
             include_comp=include_comp,
         )
-        unpacked.offset = offset
         return unpacked
 
     def get_object_at(self, offset: int) -> tuple[int, OldUnpackedObject]:
@@ -2324,15 +2517,8 @@ class DeltaChainIterator(Generic[T]):
                 that materialise objects (e.g. PackInflater) when iterating
                 packs in a non-default hash algorithm such as SHA-256.
         """
-        self._reader_at: Callable[[int], Callable[[int], bytes]] | None = None
-        if file_obj is not None:
-
-            def reader_at(offset: int) -> Callable[[int], bytes]:
-                # add_thin_pack may still be writing to this file, so read it directly.
-                file_obj.seek(offset)
-                return file_obj.read
-
-            self._reader_at = reader_at
+        self._file = file_obj
+        self._contents: bytes | mmap.mmap | None = None
         self.hash_func = hash_func
         self._object_format = object_format
         self._resolve_ext_ref = resolve_ext_ref
@@ -2449,7 +2635,8 @@ class DeltaChainIterator(Generic[T]):
         Args:
           pack_data: PackData object to use
         """
-        self._reader_at = pack_data._reader
+        self._file = None
+        self._contents = pack_data._buffer()
 
     def _walk_all_chains(self) -> Iterator[T]:
         for offset, type_num in self._full_ofs:
@@ -2494,15 +2681,27 @@ class DeltaChainIterator(Generic[T]):
         obj_type_num: int,
         base_chunks: bytes | list[bytes] | None,
     ) -> UnpackedObject:
-        assert self._reader_at is not None
-        unpacked, _ = unpack_object(
-            self._reader_at(offset),
-            self.hash_func,
-            read_some=None,
-            compute_crc32=self._compute_crc32,
-            include_comp=self._include_comp,
-        )
-        unpacked.offset = offset
+        if self._contents is not None:
+            unpacked, _ = unpack_object_at(
+                self._contents,
+                offset,
+                self.hash_func,
+                compute_crc32=self._compute_crc32,
+                include_comp=self._include_comp,
+            )
+        else:
+            # add_thin_pack may still be writing to this file, so it cannot be
+            # mapped up front; read through the file position instead.
+            assert self._file is not None
+            self._file.seek(offset)
+            unpacked, _ = unpack_object(
+                self._file.read,
+                self.hash_func,
+                read_some=None,
+                compute_crc32=self._compute_crc32,
+                include_comp=self._include_comp,
+            )
+            unpacked.offset = offset
         if base_chunks is None:
             assert unpacked.pack_type_num == obj_type_num
         else:

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -68,6 +68,7 @@ __all__ = [
     "apply_delta",
     "bisect_find_sha",
     "chunks_length",
+    "compute_buffer_sha",
     "compute_file_sha",
     "deltas_from_sorted_objects",
     "deltify_pack_objects",
@@ -84,10 +85,14 @@ __all__ = [
     "pack_object_header",
     "pack_objects_to_data",
     "read_pack_header",
+    "read_pack_header_at",
     "read_zlib_chunks",
+    "read_zlib_chunks_at",
     "sort_objects_for_delta",
     "take_msb_bytes",
+    "take_msb_bytes_at",
     "unpack_object",
+    "unpack_object_at",
     "verify_and_read",
     "write_pack",
     "write_pack_data",
@@ -2110,9 +2115,10 @@ class PackData:
         It must also stay the same size. It is mapped into memory on open, so
         reads index the mapping directly rather than sharing a file position.
 
-        The size argument is accepted for backward compatibility and ignored:
-        checksum offsets are derived from the size, so it is measured when the
-        pack is mapped rather than trusted from the caller.
+        The size argument is not trusted for checksum offsets, which are
+        derived from the mapped length instead. When given it is checked
+        against that length, so a caller passing a stale size gets an error
+        rather than silently wrong offsets.
         """
         self._filename = filename
         self.object_format = object_format
@@ -2135,6 +2141,10 @@ class PackData:
             # Map the pack once; every read indexes this buffer at an explicit
             # offset, so concurrent reads never contend on a file position.
             self._contents, self._size = _load_file_contents(self._file)
+            if size is not None and size != self._size:
+                raise AssertionError(
+                    f"{self._filename} is {self._size} bytes, but caller said {size}"
+                )
             minimum_size = self._header_size + self.object_format.oid_length
             if self._size < minimum_size:
                 raise AssertionError(
@@ -2185,7 +2195,7 @@ class PackData:
         Args:
           file: Open file object
           object_format: Object format
-          size: Ignored; the pack is measured when it is mapped
+          size: Optional expected file size, checked against the mapped length
 
         Returns:
           PackData instance
@@ -2260,9 +2270,6 @@ class PackData:
         if isinstance(other, PackData):
             return self.get_stored_checksum() == other.get_stored_checksum()
         return False
-
-    def _get_size(self) -> int:
-        return self._size
 
     def __len__(self) -> int:
         """Returns the number of objects in this pack."""
@@ -4583,7 +4590,7 @@ class Pack:
         """
         total = 0
         if self._data is not None:
-            total += self._data._get_size()
+            total += self._data._size
         if self._idx is not None and isinstance(self._idx, FilePackIndex):
             total += self._idx._size
         return total

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2025,9 +2025,13 @@ def compute_buffer_sha(
     hash_func: Callable[[], "HashObject"],
     start_ofs: int = 0,
     end_ofs: int = 0,
-    buffer_size: int = 1 << 16,
 ) -> "HashObject":
     """Hash a portion of a buffer into a new SHA.
+
+    The region is hashed in one pass through a memoryview, so a mapped pack
+    is never copied. The view is released before returning rather than left
+    to the garbage collector, since ``mmap.close()`` raises BufferError while
+    an export is alive.
 
     Args:
       contents: Buffer to hash.
@@ -2035,7 +2039,6 @@ def compute_buffer_sha(
       start_ofs: The offset in the buffer to start hashing at.
       end_ofs: The offset to end hashing at, relative to the end of the
         buffer.
-      buffer_size: Number of bytes to hash at a time.
     Returns: A new SHA object updated with data read from the buffer.
     """
     sha = hash_func()
@@ -2046,11 +2049,8 @@ def compute_buffer_sha(
         raise AssertionError(
             f"Attempt to read beyond buffer length. start_ofs: {start_ofs}, end_ofs: {end_ofs}, buffer length: {length}"
         )
-    pos = start_ofs
-    end = length + end_ofs
-    while pos < end:
-        sha.update(contents[pos : min(pos + buffer_size, end)])
-        pos += buffer_size
+    with memoryview(contents) as view:
+        sha.update(view[start_ofs : length + end_ofs])
     return sha
 
 

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -1526,26 +1526,6 @@ class PackIndex3(FilePackIndex):
         return result
 
 
-def read_pack_header(read: Callable[[int], bytes]) -> tuple[int, int]:
-    """Read the header of a pack file.
-
-    Args:
-      read: Read function
-    Returns: Tuple of (pack version, number of objects). If no data is
-        available to read, returns (None, None).
-    """
-    header = read(12)
-    if not header:
-        raise AssertionError("file too short to contain pack")
-    if header[:4] != b"PACK":
-        raise AssertionError(f"Invalid pack header {header!r}")
-    (version,) = unpack_from(b">L", header, 4)
-    if version not in (2, 3):
-        raise AssertionError(f"Version was {version}")
-    (num_objects,) = unpack_from(b">L", header, 8)
-    return (version, num_objects)
-
-
 def read_pack_header_at(
     contents: "bytes | mmap.mmap", offset: int = 0
 ) -> tuple[int, int]:
@@ -1568,6 +1548,16 @@ def read_pack_header_at(
     return (version, num_objects)
 
 
+def read_pack_header(read: Callable[[int], bytes]) -> tuple[int, int]:
+    """Read the header of a pack file.
+
+    Args:
+      read: Read function
+    Returns: Tuple of (pack version, number of objects).
+    """
+    return read_pack_header_at(read(12))
+
+
 def chunks_length(chunks: bytes | Iterable[bytes]) -> int:
     """Get the total length of a sequence of chunks.
 
@@ -1579,6 +1569,32 @@ def chunks_length(chunks: bytes | Iterable[bytes]) -> int:
         return len(chunks)
     else:
         return sum(map(len, chunks))
+
+
+def _decode_object_header(raw: list[int]) -> tuple[int, int]:
+    """Decode an object type and size from a pack object header."""
+    type_num = (raw[0] >> 4) & 0x07
+    size = raw[0] & 0x0F
+    for i, byte in enumerate(raw[1:]):
+        size += (byte & 0x7F) << ((i * 7) + 4)
+    return type_num, size
+
+
+def _decode_delta_base_offset(raw: list[int]) -> int:
+    """Decode an OFS_DELTA base offset from its variable-length encoding."""
+    if raw[-1] & 0x80:
+        raise AssertionError
+    delta_base_offset = raw[0] & 0x7F
+    for byte in raw[1:]:
+        delta_base_offset += 1
+        delta_base_offset <<= 7
+        delta_base_offset += byte & 0x7F
+    if delta_base_offset == 0:
+        # A zero offset makes the delta reference itself, which would
+        # loop forever in resolve_object. git's C client rejects this
+        # with "delta offset == 0 is invalid".
+        raise ApplyDeltaError("OFS_DELTA has delta_base_offset of 0")
+    return delta_base_offset
 
 
 def unpack_object(
@@ -1621,29 +1637,14 @@ def unpack_object(
         crc32 = None
 
     raw, crc32 = take_msb_bytes(read_all, crc32=crc32)
-    type_num = (raw[0] >> 4) & 0x07
-    size = raw[0] & 0x0F
-    for i, byte in enumerate(raw[1:]):
-        size += (byte & 0x7F) << ((i * 7) + 4)
+    type_num, size = _decode_object_header(raw)
 
     delta_base: int | bytes | None
     raw_base = len(raw)
     if type_num == OFS_DELTA:
         raw, crc32 = take_msb_bytes(read_all, crc32=crc32)
         raw_base += len(raw)
-        if raw[-1] & 0x80:
-            raise AssertionError
-        delta_base_offset = raw[0] & 0x7F
-        for byte in raw[1:]:
-            delta_base_offset += 1
-            delta_base_offset <<= 7
-            delta_base_offset += byte & 0x7F
-        if delta_base_offset == 0:
-            # A zero offset makes the delta reference itself, which would
-            # loop forever in resolve_object. git's C client rejects this
-            # with "delta offset == 0 is invalid".
-            raise ApplyDeltaError("OFS_DELTA has delta_base_offset of 0")
-        delta_base = delta_base_offset
+        delta_base = _decode_delta_base_offset(raw)
     elif type_num == REF_DELTA:
         # Determine hash size from hash_func
         hash_size = len(hash_func().digest())
@@ -1699,27 +1700,12 @@ def unpack_object_at(
     crc32: int | None = 0 if compute_crc32 else None
 
     raw, pos, crc32 = take_msb_bytes_at(contents, offset, crc32=crc32)
-    type_num = (raw[0] >> 4) & 0x07
-    size = raw[0] & 0x0F
-    for i, byte in enumerate(raw[1:]):
-        size += (byte & 0x7F) << ((i * 7) + 4)
+    type_num, size = _decode_object_header(raw)
 
     delta_base: int | bytes | None
     if type_num == OFS_DELTA:
         raw, pos, crc32 = take_msb_bytes_at(contents, pos, crc32=crc32)
-        if raw[-1] & 0x80:
-            raise AssertionError
-        delta_base_offset = raw[0] & 0x7F
-        for byte in raw[1:]:
-            delta_base_offset += 1
-            delta_base_offset <<= 7
-            delta_base_offset += byte & 0x7F
-        if delta_base_offset == 0:
-            # A zero offset makes the delta reference itself, which would
-            # loop forever in resolve_object. git's C client rejects this
-            # with "delta offset == 0 is invalid".
-            raise ApplyDeltaError("OFS_DELTA has delta_base_offset of 0")
-        delta_base = delta_base_offset
+        delta_base = _decode_delta_base_offset(raw)
     elif type_num == REF_DELTA:
         hash_size = len(hash_func().digest())
         delta_base_obj = bytes(contents[pos : pos + hash_size])

--- a/tests/test_object_store.py
+++ b/tests/test_object_store.py
@@ -21,6 +21,7 @@
 
 """Tests for the object store interface."""
 
+import mmap
 import os
 import shutil
 import stat
@@ -31,6 +32,7 @@ from contextlib import closing
 from io import BytesIO
 from unittest.mock import patch
 
+import dulwich.pack
 from dulwich.config import ConfigDict
 from dulwich.errors import ChecksumMismatch, NotTreeError, ObjectFormatException
 from dulwich.file import GitFile
@@ -464,6 +466,49 @@ class DiskObjectStoreTests(PackBasedObjectStoreTests, TestCase):
             raise
         else:
             commit()
+
+    def test_add_pack_unmaps_before_rename(self) -> None:
+        """The pack must not still be mapped when it is renamed into place.
+
+        commit() maps the temporary pack to index it, then hands the same
+        file to _complete_pack to append bases to and rename. Windows
+        refuses both while a mapping is alive.
+        """
+        o = DiskObjectStore(self.store_dir)
+        self.addCleanup(o.close)
+
+        mappings = []
+        real_load = dulwich.pack._load_file_contents
+
+        def tracking_load(f, size=None):
+            contents, size = real_load(f, size)
+            mappings.append(contents)
+            return contents, size
+
+        open_at_rename = []
+        real_rename = os.rename
+
+        def checking_rename(src, dst):
+            open_at_rename.extend(
+                m for m in mappings if isinstance(m, mmap.mmap) and not m.closed
+            )
+            return real_rename(src, dst)
+
+        f, commit, abort = o.add_pack()
+        try:
+            b = make_object(Blob, data=b"more yummy data")
+            write_pack_objects(
+                f.write, [(b, None)], object_format=DEFAULT_OBJECT_FORMAT
+            )
+        except BaseException:
+            abort()
+            raise
+        with (
+            patch.object(dulwich.pack, "_load_file_contents", tracking_load),
+            patch("dulwich.object_store.os.rename", checking_rename),
+        ):
+            commit()
+        self.assertEqual([], open_at_rename)
 
     def test_add_thin_pack(self) -> None:
         o = DiskObjectStore(self.store_dir)

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -544,7 +544,8 @@ class TestPackData(PackTests):
             PackData(
                 "truncated.pack", file=pack_file, object_format=DEFAULT_OBJECT_FORMAT
             )
-        self.assertTrue(pack_file.closed)
+        # The file was handed to us, so it stays the caller's to close.
+        self.assertFalse(pack_file.closed)
 
     def test_concurrent_reads(self) -> None:
         """Reads from several threads must not interfere with each other."""

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -573,6 +573,14 @@ class TestPackData(PackTests):
             self.assertEqual(8 * 50 * len(offsets), len(results))
             self.assertEqual([], [r for r in results if not r])
 
+    def test_rejects_wrong_size(self) -> None:
+        """A caller-supplied size that disagrees with the file is an error."""
+        with open(
+            os.path.join(self.datadir, f"pack-{pack1_sha.decode()}.pack"), "rb"
+        ) as f:
+            with self.assertRaisesRegex(AssertionError, "but caller said 42"):
+                PackData.from_file(f, DEFAULT_OBJECT_FORMAT, 42)
+
     def test_get_stored_checksum(self) -> None:
         """Test getting the stored checksum of the pack data."""
         with self.get_pack_data(pack1_sha) as p:
@@ -1981,8 +1989,8 @@ class DeltaChainIteratorTests(TestCase):
             ],
             store=self.store,
         )
-        fsize = f.tell()
-        f.seek(0)
+        # build_pack rewinds f, so measure the buffer rather than tell().
+        fsize = len(f.getvalue())
         packdata = PackData.from_file(f, DEFAULT_OBJECT_FORMAT, fsize)
         td = tempfile.mkdtemp()
         idx_path = os.path.join(td, "test.idx")

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -532,6 +532,18 @@ class TestPackData(PackTests):
         with self.get_pack_data(pack1_sha) as p:
             self.assertSucceeds(p.check)
 
+    def test_check_rejects_missing_checksum(self) -> None:
+        pack_file = BytesIO()
+        write_pack_header(pack_file.write, 0)
+        pack_file.seek(0)
+        with self.assertRaisesRegex(
+            AssertionError, "truncated.pack is too small for a packfile"
+        ):
+            PackData(
+                "truncated.pack", file=pack_file, object_format=DEFAULT_OBJECT_FORMAT
+            )
+        self.assertTrue(pack_file.closed)
+
     def test_get_stored_checksum(self) -> None:
         """Test getting the stored checksum of the pack data."""
         with self.get_pack_data(pack1_sha) as p:

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -26,6 +26,7 @@ import os
 import shutil
 import sys
 import tempfile
+import threading
 import tracemalloc
 import types
 import zlib
@@ -543,6 +544,34 @@ class TestPackData(PackTests):
                 "truncated.pack", file=pack_file, object_format=DEFAULT_OBJECT_FORMAT
             )
         self.assertTrue(pack_file.closed)
+
+    def test_concurrent_reads(self) -> None:
+        """Reads from several threads must not interfere with each other."""
+        with self.get_pack_data(pack1_sha) as p:
+            offsets = [unpacked.offset for unpacked in p.iter_unpacked()]
+            expected = {o: p.get_unpacked_object_at(o).sha() for o in offsets}
+            results: list[bool] = []
+            errors: list[BaseException] = []
+
+            def read_repeatedly() -> None:
+                try:
+                    for _ in range(50):
+                        for offset in offsets:
+                            results.append(
+                                p.get_unpacked_object_at(offset).sha()
+                                == expected[offset]
+                            )
+                except BaseException as e:
+                    errors.append(e)
+
+            threads = [threading.Thread(target=read_repeatedly) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            self.assertEqual([], errors)
+            self.assertEqual(8 * 50 * len(offsets), len(results))
+            self.assertEqual([], [r for r in results if not r])
 
     def test_get_stored_checksum(self) -> None:
         """Test getting the stored checksum of the pack data."""

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -62,6 +62,7 @@ from dulwich.pack import (
     load_pack_index,
     read_zlib_chunks,
     unpack_object,
+    unpack_object_at,
     write_pack,
     write_pack_header,
     write_pack_index,
@@ -1128,6 +1129,20 @@ class WritePackTests(TestCase):
             ApplyDeltaError,
             unpack_object,
             f.read,
+            DEFAULT_OBJECT_FORMAT.hash_func,
+        )
+
+    def test_unpack_object_at_rejects_zero_ofs_delta(self) -> None:
+        # Same guard as test_unpack_object_rejects_zero_ofs_delta, on the
+        # offset-based path.
+        header = bytes([(OFS_DELTA << 4) | 0])
+        ofs_bytes = bytes([0x00])
+        body = zlib.compress(b"")
+        self.assertRaises(
+            ApplyDeltaError,
+            unpack_object_at,
+            header + ofs_bytes + body,
+            0,
             DEFAULT_OBJECT_FORMAT.hash_func,
         )
 


### PR DESCRIPTION
Make concurrent ``PackData`` reads thread-safe by mmap-ing pack contents
and indexing the mapping at explicit offsets instead of sharing the file
position. New ``unpack_object_at``, ``read_pack_header_at``,
``read_zlib_chunks_at``, ``take_msb_bytes_at`` and ``compute_buffer_sha``
read from a buffer; the existing read-callable variants remain for streams.

based on #2362