### PR TITLE
Make Pack.get_raw thread-safe

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.13	UNRELEASED
 
+ * Make concurrent ``Pack.get_raw`` calls thread-safe by synchronizing
+   ``PackData``'s resolved-object offset cache.
+   (Bojan Zivanovic)
+
  * Bound fetch negotiation the way C Git's ``MAX_IN_VAIN`` does: give up
    after 256 unacknowledged "have" lines instead of draining the whole
    graph walker into stateless (HTTP) requests. (Bojan Zivanovic, #2343)

--- a/contrib/swift.py
+++ b/contrib/swift.py
@@ -67,17 +67,16 @@ if TYPE_CHECKING:
 from geventhttpclient import HTTPClient
 
 from dulwich.file import _GitFile
-from dulwich.lru_cache import LRUSizeCache
 from dulwich.object_store import INFODIR, PACKDIR, PackBasedObjectStore
 from dulwich.objects import S_ISGITLINK, Blob, Commit, ObjectID, Tag, Tree
 from dulwich.pack import (
     ObjectContainer,
+    OldUnpackedObject,
     Pack,
     PackData,
     PackIndex,
     PackIndexer,
     PackStreamCopier,
-    _compute_object_size,
     compute_file_sha,
     iter_sha1,
     load_pack_index_file,
@@ -696,15 +695,10 @@ class SwiftPackData(PackData):
         self.pack_length = int(headers["content-length"])
         pack_reader = SwiftPackReader(self.scon, str(self._filename), self.pack_length)
         (_version, self._num_objects) = read_pack_header(pack_reader.read)
-        self._offset_cache = LRUSizeCache(
-            1024 * 1024 * self.scon.cache_length,
-            compute_size=_compute_object_size,
-        )
+        self._init_offset_cache(1024 * 1024 * self.scon.cache_length)
         self.pack = None
 
-    def get_object_at(
-        self, offset: int
-    ) -> tuple[int, tuple[bytes | int, list[bytes]] | list[bytes]]:
+    def get_object_at(self, offset: int) -> tuple[int, OldUnpackedObject]:
         """Get the object at a specific offset in the pack.
 
         Args:
@@ -713,8 +707,10 @@ class SwiftPackData(PackData):
         Returns:
           Tuple of (pack_type_num, object_data)
         """
-        if offset in self._offset_cache:
-            return self._offset_cache[offset]
+        try:
+            return self._get_cached_object_at(offset)
+        except KeyError:
+            pass
         assert offset >= self._header_size
         pack_reader = SwiftPackReader(self.scon, str(self._filename), self.pack_length)
         pack_reader.seek(offset)

--- a/contrib/test_swift.py
+++ b/contrib/test_swift.py
@@ -29,7 +29,10 @@ from io import BytesIO, StringIO
 from time import time
 from unittest import skipIf
 
+from dulwich.object_format import DEFAULT_OBJECT_FORMAT
 from dulwich.objects import Blob, Commit, Tag, Tree, parse_timezone
+from dulwich.pack import OFS_DELTA, MemoryPackIndex, Pack
+from dulwich.tests.utils import build_pack
 from tests import TestCase
 from tests.test_object_store import ObjectStoreTests
 
@@ -229,6 +232,36 @@ class FakeSwiftConnector:
         if name not in self.store:
             return None
         return {"content-length": len(self.store[name])}
+
+
+@skipIf(missing_libs, skipmsg)
+class TestSwiftPackData(TestCase):
+    def test_resolve_delta_uses_offset_cache(self) -> None:
+        pack_file = BytesIO()
+        entries = build_pack(
+            pack_file,
+            [
+                (Blob.type_num, b"blob"),
+                (OFS_DELTA, (0, b"blob1")),
+            ],
+        )
+        pack_bytes = pack_file.getvalue()
+        connector = FakeSwiftConnector(
+            "fakerepo", None, {"fakerepo/pack.pack": pack_bytes}
+        )
+        data = swift.SwiftPackData(
+            connector, "pack.pack", object_format=DEFAULT_OBJECT_FORMAT
+        )
+        index = MemoryPackIndex(
+            [(entry[3], entry[0], entry[4]) for entry in entries],
+            object_format=DEFAULT_OBJECT_FORMAT,
+            pack_checksum=pack_bytes[-DEFAULT_OBJECT_FORMAT.oid_length :],
+        )
+        pack = Pack.from_objects(data, index)
+        self.addCleanup(pack.close)
+
+        self.assertEqual((Blob.type_num, b"blob1"), pack.get_raw(entries[1][3]))
+        self.assertEqual((Blob.type_num, b"blob1"), pack.get_raw(entries[1][3]))
 
 
 @skipIf(missing_libs, skipmsg)

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -117,6 +117,7 @@ import logging
 import os
 import struct
 import sys
+import threading
 import warnings
 import zlib
 from collections.abc import Callable, Iterable, Iterator, Sequence, Set
@@ -2148,12 +2149,18 @@ class PackData:
                 or delta_cache_size
                 or DEFAULT_DELTA_BASE_CACHE_LIMIT
             )
-            self._offset_cache = LRUSizeCache[int, tuple[int, OldUnpackedObject]](
-                cache_size, compute_size=_compute_object_size
-            )
+            self._init_offset_cache(cache_size)
         except BaseException:
             self.close()
             raise
+
+    def _init_offset_cache(self, max_size: int) -> None:
+        """Initialize the resolved object cache."""
+        self._offset_cache = LRUSizeCache[int, tuple[int, OldUnpackedObject]](
+            max_size, compute_size=_compute_object_size
+        )
+        # Cache hits update the LRU linked list, so reads need locking too.
+        self._offset_cache_lock = threading.Lock()
 
     @property
     def filename(self) -> str:
@@ -2468,6 +2475,18 @@ class PackData:
         )
         return unpacked
 
+    def _get_cached_object_at(self, offset: int) -> tuple[int, OldUnpackedObject]:
+        """Return the cached object at offset, or raise KeyError."""
+        with self._offset_cache_lock:
+            return self._offset_cache[offset]
+
+    def _cache_object_at(
+        self, offset: int, type_num: int, chunks: OldUnpackedObject
+    ) -> None:
+        """Cache a resolved object at offset."""
+        with self._offset_cache_lock:
+            self._offset_cache[offset] = (type_num, chunks)
+
     def get_object_at(self, offset: int) -> tuple[int, OldUnpackedObject]:
         """Given an offset in to the packfile return the object that is there.
 
@@ -2476,7 +2495,7 @@ class PackData:
         function.
         """
         try:
-            return self._offset_cache[offset]
+            return self._get_cached_object_at(offset)
         except KeyError:
             pass
         unpacked = self.get_unpacked_object_at(offset, include_comp=False)
@@ -4893,7 +4912,7 @@ class Pack:
             chunks = apply_delta(chunks_bytes, delta)
 
             if prev_offset is not None:
-                self.data._offset_cache[prev_offset] = base_type, chunks
+                self.data._cache_object_at(prev_offset, base_type, chunks)
         return base_type, chunks
 
     def entries(

--- a/tests/test_pack.py
+++ b/tests/test_pack.py
@@ -812,6 +812,50 @@ class TestPack(PackTests):
             self.assertEqual(obj.type_name, b"commit")
             self.assertEqual(obj.sha().hexdigest().encode("ascii"), commit_sha)
 
+    def test_get_raw_concurrent(self) -> None:
+        """Concurrent delta reads must not corrupt the offset cache."""
+        f = BytesIO()
+        specs = [(Blob.type_num, b"blob-0")]
+        specs.extend((OFS_DELTA, (0, f"blob-{i}".encode())) for i in range(1, 32))
+        entries = build_pack(f, specs)
+        data = PackData("test.pack", file=f, object_format=DEFAULT_OBJECT_FORMAT)
+        index = MemoryPackIndex.for_pack(data)
+        pack = Pack.from_objects(data, index)
+        self.addCleanup(pack.close)
+
+        expected = {entry[3]: (Blob.type_num, entry[2]) for entry in entries}
+        for sha, result in expected.items():
+            self.assertEqual(result, pack.get_raw(sha))
+
+        errors: list[BaseException] = []
+
+        def read_repeatedly(start: int) -> None:
+            try:
+                for i in range(2000):
+                    entry = entries[1 + (start + i) % (len(entries) - 1)]
+                    self.assertEqual(expected[entry[3]], pack.get_raw(entry[3]))
+            except BaseException as exc:
+                errors.append(exc)
+
+        old_switch_interval = sys.getswitchinterval()
+        sys.setswitchinterval(1e-6)
+        try:
+            threads = [
+                threading.Thread(target=read_repeatedly, args=(i * 3,))
+                for i in range(8)
+            ]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        finally:
+            sys.setswitchinterval(old_switch_interval)
+
+        self.assertEqual([], errors)
+        self.assertEqual(
+            len(data._offset_cache), len(list(data._offset_cache._walk_lru()))
+        )
+
     def test_copy(self) -> None:
         with self.get_pack(pack1_sha) as origpack:
             self.assertSucceeds(origpack.index.check)


### PR DESCRIPTION
Protect PackData's offset cache with a lock. LRUSizeCache updates its linked list on reads, so concurrent cache accesses could corrupt it while resolving deltas.

The next (last?) part of https://github.com/jelmer/dulwich/issues/2350, now that https://github.com/jelmer/dulwich/pull/2365 is in.