### PR TITLE
Speed up cached PackData.get_object_at lookups

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@
    ``PackData``'s resolved-object offset cache.
    (Bojan Zivanovic)
 
+ * Speed up cached `PackData.get_object_at` lookups by acquiring the
+   offset-cache lock directly instead of through a `with` statement.
+   (Bojan Zivanovic)
+
  * Bound fetch negotiation the way C Git's ``MAX_IN_VAIN`` does: give up
    after 256 unacknowledged "have" lines instead of draining the whole
    graph walker into stateless (HTTP) requests. (Bojan Zivanovic, #2343)

--- a/dulwich/pack.py
+++ b/dulwich/pack.py
@@ -2477,8 +2477,13 @@ class PackData:
 
     def _get_cached_object_at(self, offset: int) -> tuple[int, OldUnpackedObject]:
         """Return the cached object at offset, or raise KeyError."""
-        with self._offset_cache_lock:
+        # Hot path: acquire/release directly rather than using the context
+        # manager, which measurably speeds up cache hits on get_object_at.
+        self._offset_cache_lock.acquire()
+        try:
             return self._offset_cache[offset]
+        finally:
+            self._offset_cache_lock.release()
 
     def _cache_object_at(
         self, offset: int, type_num: int, chunks: OldUnpackedObject


### PR DESCRIPTION
Acquire the offset-cache lock via acquire/release directly rather than through the with statement, which measurably speeds up cache hits on this hot path.

Follow-up to 3d270b19.