### PR TITLE
collapse consecutive ** segments in wildmatch translation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,14 @@
 1.2.13	2026-08-24
 
+ * Collapse a run of consecutive ``**`` segments when translating a
+   wildmatch pattern (``dulwich.wildmatch``). Git treats a run of
+   directory-spanning ``**`` as a single ``**``, but each segment emitted
+   its own ``(?:[^/]+/)*``, so a short ``.gitignore``/``.gitattributes``
+   pattern such as ``a/**/**/**/z`` from an untrusted repository built a
+   regex with adjacent unbounded quantifiers that backtracked
+   catastrophically on non-matching paths during status/checkout.
+   (netliomax25-code)
+
  * Make concurrent ``Pack.get_raw`` calls thread-safe by synchronizing
    ``PackData``'s resolved-object offset cache.
    (Bojan Zivanovic)

--- a/NEWS
+++ b/NEWS
@@ -1,13 +1,8 @@
 1.2.13	2026-08-24
 
- * Collapse a run of consecutive ``**`` segments when translating a
-   wildmatch pattern (``dulwich.wildmatch``). Git treats a run of
-   directory-spanning ``**`` as a single ``**``, but each segment emitted
-   its own ``(?:[^/]+/)*``, so a short ``.gitignore``/``.gitattributes``
-   pattern such as ``a/**/**/**/z`` from an untrusted repository built a
-   regex with adjacent unbounded quantifiers that backtracked
-   catastrophically on non-matching paths during status/checkout.
-   (netliomax25-code)
+ * Collapse consecutive `**` segments in wildmatch translation, matching
+   git's behavior and avoiding catastrophic regex backtracking on patterns
+   like `a/**/**/**/z` from untrusted repositories. (netliomax25-code)
 
  * Make concurrent ``Pack.get_raw`` calls thread-safe by synchronizing
    ``PackData``'s resolved-object offset cache.

--- a/dulwich/wildmatch.py
+++ b/dulwich/wildmatch.py
@@ -237,8 +237,13 @@ def _split_segments(pat: bytes) -> list[bytes]:
     return segments
 
 
-def _translate_double_asterisk(segments: Sequence[bytes], i: int) -> tuple[bytes, bool]:
-    """Handle ** segment processing, returns (regex_part, skip_next)."""
+def _translate_double_asterisk(segments: Sequence[bytes], i: int) -> bytes:
+    """Handle ** segment processing, returns the regex part.
+
+    A run of consecutive ``**`` segments is collapsed to one by
+    :func:`_translate` before this is called, so each ``**`` is handled on
+    its own here.
+    """
     # Check if ** is at end
     remaining = segments[i + 1 :]
     if all(s == b"" for s in remaining):
@@ -247,40 +252,41 @@ def _translate_double_asterisk(segments: Sequence[bytes], i: int) -> tuple[bytes
             # least one directory and end in a slash. Without this, "abc/**/"
             # also matches "abc/" itself and every file directly inside it,
             # while Git only ignores the directories below "abc".
-            return b".*/", False
+            return b".*/"
         # ** at end - matches everything
-        return b".*", False
+        return b".*"
 
-    # Check if next segment is also **
-    if i + 1 < len(segments) and segments[i + 1] == b"**":
-        # Consecutive ** segments
-        # Check if this ends with a directory pattern (trailing /)
-        remaining_after_next = segments[i + 2 :]
-        is_dir_pattern = (
-            len(remaining_after_next) == 1 and remaining_after_next[0] == b""
-        )
+    # ** in middle - handle differently depending on what follows
+    if i == 0:
+        # ** at start - any prefix
+        return b"(?:.*/)??"
+    # ** in middle - match zero or more complete directory segments
+    return b"(?:[^/]+/)*"
 
-        if is_dir_pattern:
-            # Pattern like c/**/**/ - requires at least one intermediate directory
-            return b"[^/]+/(?:[^/]+/)*", True
-        else:
-            # Pattern like c/**/**/d - allows zero intermediate directories
-            return b"(?:[^/]+/)*", True
-    else:
-        # ** in middle - handle differently depending on what follows
-        if i == 0:
-            # ** at start - any prefix
-            return b"(?:.*/)??", False
-        else:
-            # ** in middle - match zero or more complete directory segments
-            return b"(?:[^/]+/)*", False
+
+def _collapse_double_asterisks(segments: list[bytes]) -> list[bytes]:
+    """Collapse a run of consecutive ``**`` segments into a single one.
+
+    In Git a run of directory-spanning ``**`` segments is equivalent to a
+    single ``**``. Emitting one quantifier per segment builds a regex with
+    adjacent unbounded quantifiers (e.g. ``(?:[^/]+/)*(?:[^/]+/)*``) that
+    backtracks catastrophically on non-matching input (ReDoS), so a pattern
+    such as ``a/**/**/**/z`` from an untrusted ``.gitignore`` or
+    ``.gitattributes`` must be normalized before translation.
+    """
+    collapsed: list[bytes] = []
+    for segment in segments:
+        if segment == b"**" and collapsed and collapsed[-1] == b"**":
+            continue
+        collapsed.append(segment)
+    return collapsed
 
 
 def _translate(pat: bytes) -> bytes:
     if pat == b"**":
         return b".*"
     res = b""
-    segments = _split_segments(pat)
+    segments = _collapse_double_asterisks(_split_segments(pat))
     i = 0
     while i < len(segments):
         segment = segments[i]
@@ -290,12 +296,10 @@ def _translate(pat: bytes) -> bytes:
             res += re.escape(b"/")
 
         if segment == b"**":
-            regex_part, skip_next = _translate_double_asterisk(segments, i)
+            regex_part = _translate_double_asterisk(segments, i)
             res += regex_part
             if regex_part == b".*":  # End of pattern
                 break
-            if skip_next:
-                i += 1
         else:
             res += _translate_segment(segment)
 

--- a/tests/test_wildmatch.py
+++ b/tests/test_wildmatch.py
@@ -117,6 +117,22 @@ class TranslateTests(TestCase):
         self.assertNotMatches(b"a/**/", b"a/")
         self.assertNotMatches(b"a/**/", b"a/f")
 
+    def test_consecutive_double_asterisks_collapse(self) -> None:
+        # A run of '**' segments is equivalent to a single '**' in Git, so it
+        # must translate to a single quantifier rather than one per segment.
+        self.assertEqual(translate(b"a/**/z"), translate(b"a/**/**/**/z"))
+        self.assertEqual(translate(b"**/z"), translate(b"**/**/z"))
+        self.assertEqual(translate(b"a/**/"), translate(b"a/**/**/"))
+        self.assertMatches(b"a/**/**/z", b"a/z")
+        self.assertMatches(b"a/**/**/z", b"a/b/c/z")
+
+    def test_consecutive_double_asterisks_no_redos(self) -> None:
+        # Adjacent unbounded quantifiers from a run of '**' segments used to
+        # backtrack exponentially on a long non-matching path; the collapsed
+        # form must return promptly.
+        regex = re.compile(rb"^" + translate(b"a/" + b"**/" * 25 + b"z") + rb"$")
+        self.assertIsNone(regex.match(b"a/" + b"x/" * 40 + b"y"))
+
     def test_bracket(self) -> None:
         self.assertMatches(b"a/[[:digit:]]", b"a/5")
         self.assertNotMatches(b"a/[[:digit:]]", b"a/x")


### PR DESCRIPTION
1. wildmatch translate emits one quantifier per `**` segment, so a run of consecutive `**` produces adjacent unbounded quantifiers like `(?:[^/]+/)*(?:[^/]+/)*`.
2. `dulwich.ignore` and `dulwich.attrs` compile that regex and run it against every working-tree path during status/checkout, so a short pattern such as `a/**/**/**/z` from a cloned repository's `.gitignore` or `.gitattributes` backtracks catastrophically on a long non-matching path (a 57-byte line took about 14s for a single path through `IgnoreFilter.is_ignored`).
3. Git treats a run of `**` as a single `**`, so collapsing consecutive `**` segments before translation is behavior-preserving; I checked that match results are unchanged across single vs repeated `**` and that the existing wildmatch/ignore/attrs suites pass, and added a regression test.
