### PR TITLE
test: fix typo in 'nonexistent' test method names

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -839,7 +839,7 @@ class ConfigDictTests(TestCase):
 
         self.assertEqual([(b"foo", b"bla")], list(cd.items((b"core",))))
 
-    def test_items_nonexistant(self) -> None:
+    def test_items_nonexistent(self) -> None:
         cd = ConfigDict()
         cd.set((b"core2",), b"foo", b"bloe")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1217,7 +1217,7 @@ class FileSystemBackendTests(TestCase):
         else:
             self.backend = FileSystemBackend()
 
-    def test_nonexistant(self) -> None:
+    def test_nonexistent(self) -> None:
         self.assertRaises(
             NotGitRepository,
             self.backend.open_repository,
@@ -1257,7 +1257,7 @@ class FileSystemBackendTests(TestCase):
 class DictBackendTests(TestCase):
     """Tests for DictBackend."""
 
-    def test_nonexistant(self) -> None:
+    def test_nonexistent(self) -> None:
         repo = MemoryRepo.init_bare([], {})
         backend = DictBackend({b"/": repo})
         self.assertRaises(


### PR DESCRIPTION
Fix spelling from 'nonexistant' to 'nonexistent' in test_config.py and test_server.py.