### PR TITLE
Set up branch tracking on clone

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+ * Set ``branch.<name>.remote`` and ``branch.<name>.merge`` for the branch
+   checked out by a clone, so that a subsequent ``git pull`` with no arguments
+   has tracking information. (Jelmer Vernooĳ, #2376)
+
 1.2.14	2026-08-28
 
  * Collapse consecutive `**` segments in wildmatch translation, matching

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -244,6 +244,7 @@ from .refs import (
     SYMREF,
     Ref,
     _import_remote_refs,
+    _set_branch_tracking,
     _set_default_branch,
     _set_head,
     _set_origin_head,
@@ -1597,6 +1598,10 @@ class GitClient:
                 # Update target head
                 if head_ref:
                     head = _set_head(target.refs, head_ref, ref_message)
+                    if not bare:
+                        _set_branch_tracking(
+                            target.get_config(), head_ref, origin.encode("utf-8")
+                        )
                 else:
                     head = None
 
@@ -3323,6 +3328,10 @@ class LocalGitClient(GitClient):
                 # Update target head
                 if head_ref:
                     head = _set_head(target.refs, head_ref, ref_message)
+                    if not bare:
+                        _set_branch_tracking(
+                            target.get_config(), head_ref, origin.encode("utf-8")
+                        )
                 else:
                     head = None
 

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -76,6 +76,7 @@ else:
     from typing_extensions import Self
 
 if TYPE_CHECKING:
+    from .config import ConfigFile
     from .file import _GitFile
 
 from .errors import PackedRefsException, RefFormatError
@@ -1791,6 +1792,26 @@ def _set_head(
         except KeyError:
             head = None
     return head
+
+
+def _set_branch_tracking(config: "ConfigFile", head_ref: bytes, remote: bytes) -> None:
+    """Point the branch a clone checked out at its counterpart on the remote.
+
+    This is what lets a subsequent "git pull" with no arguments know what to
+    merge. Like git clone, nothing is written when HEAD ended up detached at a
+    tag rather than on a branch.
+
+    Args:
+      config: Config of the freshly cloned repository
+      head_ref: Local ref HEAD was pointed at, e.g. refs/heads/master
+      remote: Name of the remote the clone came from
+    """
+    if not head_ref.startswith(LOCAL_BRANCH_PREFIX):
+        return
+    branch = extract_branch_name(Ref(head_ref))
+    config.set((b"branch", branch), b"remote", remote)
+    config.set((b"branch", branch), b"merge", head_ref)
+    config.write_to_path()
 
 
 def _import_remote_refs(

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -153,6 +153,7 @@ from .refs import (
     DiskRefsContainer,
     Ref,
     RefsContainer,
+    _set_branch_tracking,
     _set_default_branch,
     _set_head,
     _set_origin_head,
@@ -2158,6 +2159,8 @@ class Repo(BaseRepo):
                     # Update target head
                     if head_ref:
                         head = _set_head(target.refs, head_ref, ref_message)
+                        if not bare:
+                            _set_branch_tracking(target.get_config(), head_ref, origin)
                     else:
                         head = None
 

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -1408,6 +1408,54 @@ class CloneTests(PorcelainTestCase):
             b"+refs/heads/*:refs/remotes/origin/*",
             c.get((b"remote", b"origin"), b"fetch"),
         )
+        self.assertEqual(b"origin", c.get((b"branch", b"master"), b"remote"))
+        self.assertEqual(b"refs/heads/master", c.get((b"branch", b"master"), b"merge"))
+
+    def test_branch_tracking(self) -> None:
+        """A cloned branch tracks its remote counterpart, so "git pull" works."""
+        f1_1 = make_object(Blob, data=b"f1")
+        (c1,) = build_commit_graph(self.repo.object_store, [[1]], {1: [(b"f1", f1_1)]})
+        self.repo.refs[b"refs/heads/master"] = c1.id
+        self.repo.refs[b"refs/heads/other"] = c1.id
+        self.repo.refs[b"refs/tags/v1"] = c1.id
+
+        for kwargs, expected in [
+            ({}, (b"master", b"origin", b"refs/heads/master")),
+            ({"branch": b"other"}, (b"other", b"origin", b"refs/heads/other")),
+            ({"origin": "upstream"}, (b"master", b"upstream", b"refs/heads/master")),
+        ]:
+            target_path = tempfile.mkdtemp()
+            self.addCleanup(shutil.rmtree, target_path)
+            branch, remote, merge = expected
+            with porcelain.clone(
+                self.repo.path,
+                target_path,
+                checkout=False,
+                errstream=BytesIO(),
+                **kwargs,
+            ) as r:
+                c = r.get_config()
+                self.assertEqual(remote, c.get((b"branch", branch), b"remote"))
+                self.assertEqual(merge, c.get((b"branch", branch), b"merge"))
+
+    def test_no_branch_tracking_for_tag(self) -> None:
+        """Cloning a tag leaves HEAD detached, so there is nothing to track."""
+        f1_1 = make_object(Blob, data=b"f1")
+        (c1,) = build_commit_graph(self.repo.object_store, [[1]], {1: [(b"f1", f1_1)]})
+        self.repo.refs[b"refs/heads/master"] = c1.id
+        self.repo.refs[b"refs/tags/v1"] = c1.id
+        target_path = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, target_path)
+        with porcelain.clone(
+            self.repo.path,
+            target_path,
+            checkout=False,
+            branch=b"v1",
+            errstream=BytesIO(),
+        ) as r:
+            c = r.get_config()
+            self.assertRaises(KeyError, c.get, (b"branch", b"v1"), b"remote")
+            self.assertRaises(KeyError, c.get, (b"branch", b"master"), b"remote")
 
     def test_simple_local_with_checkout(self) -> None:
         f1_1 = make_object(Blob, data=b"f1")

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -598,6 +598,10 @@ class RepositoryRootTests(TestCase):
                 b"+refs/heads/*:refs/remotes/origin/*",
                 c.get((b"remote", b"origin"), b"fetch"),
             )
+            self.assertEqual(b"origin", c.get((b"branch", b"master"), b"remote"))
+            self.assertEqual(
+                b"refs/heads/master", c.get((b"branch", b"master"), b"merge")
+            )
 
     def test_clone_no_head(self) -> None:
         temp_dir = self.mkdtemp()
@@ -730,6 +734,31 @@ class RepositoryRootTests(TestCase):
                 t.refs[b"refs/remotes/origin/HEAD"],
                 b"a90fa2d900a17e99b433217e988c4eb4a2e9a097",
             )
+            c = t.get_config()
+            self.assertEqual(b"origin", c.get((b"branch", b"mybranch"), b"remote"))
+            self.assertEqual(
+                b"refs/heads/mybranch", c.get((b"branch", b"mybranch"), b"merge")
+            )
+
+    def test_clone_custom_origin_name(self) -> None:
+        r = self.open_repo("a.git")
+        tmp_dir = self.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+        with r.clone(tmp_dir, mkdir=False, origin=b"upstream") as t:
+            c = t.get_config()
+            self.assertEqual(b"upstream", c.get((b"branch", b"master"), b"remote"))
+            self.assertEqual(
+                b"refs/heads/master", c.get((b"branch", b"master"), b"merge")
+            )
+
+    def test_clone_bare_no_tracking(self) -> None:
+        r = self.open_repo("a.git")
+        tmp_dir = self.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp_dir)
+        with r.clone(tmp_dir, mkdir=False, bare=True) as t:
+            c = t.get_config()
+            self.assertRaises(KeyError, c.get, (b"branch", b"master"), b"remote")
+            self.assertRaises(KeyError, c.get, (b"branch", b"master"), b"merge")
 
     def test_clone_tag(self) -> None:
         r = self.open_repo("a.git")
@@ -745,6 +774,9 @@ class RepositoryRootTests(TestCase):
                 t.refs[b"refs/remotes/origin/HEAD"],
                 b"a90fa2d900a17e99b433217e988c4eb4a2e9a097",
             )
+            # A detached HEAD has no branch to track, as with git clone
+            c = t.get_config()
+            self.assertRaises(KeyError, c.get, (b"branch", b"mytag"), b"remote")
 
     def test_clone_invalid_branch(self) -> None:
         r = self.open_repo("a.git")


### PR DESCRIPTION
git clone writes branch.<name>.remote and branch.<name>.merge for the branch it checks out; without them a plain "git pull" in the new repository has no tracking information.

Fixes #2376