### PR TITLE
Keep scp-style relative paths relative in SSHGitClient.get_url

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,14 @@
+1.2.15	UNRELEASED
+
  * Set ``branch.<name>.remote`` and ``branch.<name>.merge`` for the branch
    checked out by a clone, so that a subsequent ``git pull`` with no arguments
    has tracking information. (Jelmer Vernooĳ, #2376)
+
+ * Keep relative paths relative in ``SSHGitClient.get_url``, emitting git's
+   ``ssh://host/~/path`` form. Cloning from an scp-style URL like
+   ``user@host:git/repo.git`` previously stored
+   ``ssh://user@host/git/repo.git`` as the remote URL, which points at a
+   different repository. (Jelmer Vernooĳ, #2375)
 
 1.2.14	2026-08-28
 

--- a/dulwich/client.py
+++ b/dulwich/client.py
@@ -3973,6 +3973,14 @@ class SSHGitClient(TraditionalGitClient):
         if self.username is not None:
             netloc = urlquote(self.username, "@/:") + "@" + netloc
 
+        if not path.startswith("/"):
+            # Paths in ssh:// URLs are absolute, but scp-style URLs take a
+            # path relative to the home directory. Use git's /~/ form so the
+            # URL still refers to the same repository.
+            if not path.startswith("~"):
+                path = "~/" + path
+            path = "/" + path
+
         return urlunsplit(("ssh", netloc, path, "", ""))
 
     @classmethod

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1194,6 +1194,26 @@ class SSHGitClientTests(TestCase):
         url = c.get_url(path)
         self.assertEqual("ssh://user@git.samba.org:2222/tmp/repo.git", url)
 
+    def test_get_url_relative_path(self) -> None:
+        # Relative paths, as used in scp-style URLs, are home directory
+        # relative and must not be turned into absolute paths.
+        c = SSHGitClient("git.samba.org", username="user")
+
+        self.assertEqual(
+            "ssh://user@git.samba.org/~/git/repo.git", c.get_url("git/repo.git")
+        )
+
+    def test_get_url_tilde_path(self) -> None:
+        c = SSHGitClient("git.samba.org", username="user")
+
+        self.assertEqual(
+            "ssh://user@git.samba.org/~/git/repo.git", c.get_url("~/git/repo.git")
+        )
+        self.assertEqual(
+            "ssh://user@git.samba.org/~other/git/repo.git",
+            c.get_url("~other/git/repo.git"),
+        )
+
     def test_default_command(self) -> None:
         self.assertEqual(b"git-upload-pack", self.client._get_cmd_path(b"upload-pack"))
 


### PR DESCRIPTION
urlunsplit prepends a slash to a path that lacks one, so a clone from user@host:git/repo.git recorded ssh://user@host/git/repo.git as the remote URL, pointing at /git/repo.git on the server rather than the home-relative path the clone actually used. Emit git's ssh://host/~/path form instead, which _connect already normalises back.

Fixes #2375