### PR TITLE
Add --author option to dulwich commit

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 1.2.15	UNRELEASED
 
+ * Add ``dulwich commit --author="Name <email>"`` to override the author
+   of a new or amended commit. (kudala-bharani, #1845)
+
  * Set ``branch.<name>.remote`` and ``branch.<name>.merge`` for the branch
    checked out by a clone, so that a subsequent ``git pull`` with no arguments
    has tracking information. (Jelmer Vernooĳ, #2376)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -2358,6 +2358,7 @@ class cmd_commit(Command):
         """
         parser = argparse.ArgumentParser()
         parser.add_argument("--message", "-m", help="Commit message")
+        parser.add_argument("--author", help="Override commit author (Name <email>)")
         parser.add_argument(
             "-a",
             "--all",
@@ -2400,7 +2401,13 @@ class cmd_commit(Command):
 
         try:
             porcelain.commit(
-                ".", message=message, all=parsed_args.all, amend=parsed_args.amend
+                ".",
+                message=message,
+                author=parsed_args.author.encode("utf-8")
+                if parsed_args.author is not None
+                else None,
+                all=parsed_args.all,
+                amend=parsed_args.amend,
             )
         except CommitMessageError as e:
             logger.exception(e)

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -289,6 +289,52 @@ class CommitCommandTest(DulwichCliTestCase):
         # Check that HEAD points to a commit
         self.assertIsNotNone(self.repo.head())
 
+    def test_commit_author(self):
+        """Explicit authors, including Unicode names, do not change the committer."""
+        self.overrideEnv("GIT_COMMITTER_NAME", "Test Committer")
+        self.overrideEnv("GIT_COMMITTER_EMAIL", "committer@example.com")
+        for author in (
+            "Other Author <author@example.com>",
+            "Zoë Example <zoe@example.com>",
+        ):
+            with self.subTest(author=author):
+                result, _stdout, _stderr = self._run_cli(
+                    "commit", "-m", "Authored commit", "--author", author
+                )
+                self.assertIsNone(result)
+                commit = self.repo[self.repo.head()]
+                self.assertEqual(commit.author, author.encode("utf-8"))
+                self.assertEqual(
+                    commit.committer, b"Test Committer <committer@example.com>"
+                )
+
+    def test_commit_amend_author(self):
+        """Amend preserves the original author unless explicitly overridden."""
+        self.overrideEnv("GIT_COMMITTER_NAME", "Test Committer")
+        self.overrideEnv("GIT_COMMITTER_EMAIL", "committer@example.com")
+        original_author = b"Original Author <original@example.com>"
+        for author in (None, "Other Author <other@example.com>"):
+            with self.subTest(author=author):
+                original_id = porcelain.commit(
+                    self.repo, message=b"Original commit", author=original_author
+                )
+                original = self.repo[original_id]
+                args = ["commit", "--amend", "-m", "Amended commit"]
+                if author is not None:
+                    args.extend(["--author", author])
+                result, _stdout, _stderr = self._run_cli(*args)
+                self.assertIsNone(result)
+                commit = self.repo[self.repo.head()]
+                expected_author = (
+                    original_author if author is None else author.encode("utf-8")
+                )
+                self.assertEqual(commit.author, expected_author)
+                self.assertEqual(
+                    commit.committer, b"Test Committer <committer@example.com>"
+                )
+                self.assertEqual(commit.parents, original.parents)
+                self.assertEqual(commit.message, b"Amended commit")
+
     def test_commit_all_flag(self):
         # Create initial commit
         test_file = os.path.join(self.repo_path, "test.txt")


### PR DESCRIPTION
`dulwich commit --author="Name <email>"` currently exits with an unrecognized-argument error. This adds the option and passes the UTF-8 identity through `porcelain.commit`, preserving the committer and the existing author-preservation behavior when amending without an override.

Refs #1845. This covers explicit author identities; author-pattern lookup and the other commit options remain outside this change.

Added real-repository CLI tests for ASCII/Unicode authors and amend with/without an override, plus a NEWS entry.

Validation on Python 3.12 (pure Python build):

- CLI/porcelain suite: 881 tests run, 26 skipped, no failures.
- `ruff check .`, `ruff format --check .`, `mypy dulwich`, and `codespell --config .codespellrc .` passed.
- The broader `tests.nocompat_test_suite` ran 4,080 tests with 10 signature-test errors caused by missing `gpg`/`gpgsm`. The same 10 errors reproduce on unchanged base commit `3e79ea9`; it also reported 75 skips and one expected failure.
- The new author-option cases failed before the implementation because argparse rejected the flag.
