### PR TITLE
Fix standalone branch listing in the CLI

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.15	UNRELEASED
 
+ * List local branches for bare ``dulwich branch`` and standalone
+   ``dulwich branch --list [pattern]``. Listing empty repositories or patterns
+   with no matches succeeds without changing refs. (be-student, #1847)
+
  * Add ``dulwich commit --author="Name <email>"`` to override the author
    of a new or amended commit. (kudala-bharani, #1845)
 

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -4396,7 +4396,7 @@ class cmd_branch(Command):
         parser.add_argument(
             "--list",
             nargs="?",
-            const=None,
+            const="*",
             help="List branches matching a pattern",
         )
         parsed_args = parser.parse_args(args)
@@ -4412,7 +4412,7 @@ class cmd_branch(Command):
                 for branch in branches:
                     sys.stdout.write(f"{branch.decode()}\n")
 
-        branches: Iterator[bytes] | list[bytes] | None = None
+        branches: Iterator[bytes] | Sequence[bytes] | None = None
 
         try:
             if parsed_args.all:
@@ -4436,13 +4436,17 @@ class cmd_branch(Command):
                         f"error: object name {e.args[0].decode()} not found\n"
                     )
                     return 1
+            elif parsed_args.list is not None or (
+                parsed_args.branch is None and not parsed_args.delete
+            ):
+                branches = porcelain.branch_list(None)
 
         except porcelain.Error as e:
             sys.stderr.write(f"{e}")
             return 1
 
         pattern = parsed_args.list
-        if pattern is not None and branches:
+        if pattern is not None and branches is not None:
             branches = porcelain.filter_branches_by_pattern(branches, pattern)
 
         if branches is not None:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -591,6 +591,33 @@ class StatusCommandTest(DulwichCliTestCase):
 class BranchCommandTest(DulwichCliTestCase):
     """Tests for branch command."""
 
+    def test_branch_list_local_defaults(self) -> None:
+        self._run_cli("commit", "--message=Initial")
+        self._run_cli("branch", "feature-one")
+        self._run_cli("branch", "feature-two")
+        refs_before = self.repo.refs.as_dict()
+        local_names = {"master", "feature-one", "feature-two"}
+        cases = [
+            ((), local_names),
+            (("--list",), local_names),
+            (("--list", "feature-*"), {"feature-one", "feature-two"}),
+            (("--list", "missing-*"), set()),
+            (("--column",), local_names),
+        ]
+        for args, expected in cases:
+            with self.subTest(args=args):
+                result, stdout, _stderr = self._run_cli("branch", *args)
+                self.assertEqual(result, 0)
+                self.assertEqual(set(stdout.split()), expected)
+                self.assertEqual(self.repo.refs.as_dict(), refs_before)
+
+    def test_branch_list_empty_repository(self) -> None:
+        for args in [(), ("--list",), ("--list", "missing-*")]:
+            with self.subTest(args=args):
+                result, stdout, _stderr = self._run_cli("branch", *args)
+                self.assertEqual(result, 0)
+                self.assertEqual(stdout, "")
+
     def test_branch_create(self):
         # Create initial commit
         test_file = os.path.join(self.repo_path, "test.txt")


### PR DESCRIPTION
Bare `dulwich branch`, `dulwich branch --list`, and `dulwich branch --list "feature-*"` currently fall through to a usage error unless another listing option such as `--all` supplies the branches first.

Select local branches for those listing forms, distinguishing an omitted `--list` flag from one without a pattern. Filtering also handles an empty branch list. Branch creation and deletion keep their existing paths. Refs #1847; this repairs standalone listing after #1882, not the other missing branch options.

Regression tests exercise populated and unborn repositories, matching and nonmatching patterns, bare `--column`, and unchanged refs after listing. All eight new scenarios failed on the original code. NEWS records the behavior.

Validation:
- CLI suite: 292 tests run, one skipped, no failures (`python -m unittest tests.cli.test_cli`).
- All 11 branch tests passed again after the sequence-type annotation adjustment.
- Repository-wide `ruff check`, `ruff format --check`, `mypy dulwich` (85 files), and `codespell` passed.
- `git diff --check` passed.

The full non-CLI and C Git compatibility suites were not run locally. No changes to porcelain behavior, repository formats, or dependencies.
