### PR TITLE
Support reusing and reediting commit messages

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.2.15	UNRELEASED
 
+ * Support ``dulwich commit -C/--reuse-message`` and ``-c/--reedit-message``
+   to reuse a commit's message, author and author date, optionally editing
+   the message. The committer and new commit ancestry remain independent.
+   (eunwoo song, #1845)
+
  * List local branches for bare ``dulwich branch`` and standalone
    ``dulwich branch --list [pattern]``. Listing empty repositories or patterns
    with no matches succeeds without changing refs. (be-student, #1847)

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -91,7 +91,7 @@ from .errors import (
 from .index import Index, InvalidPathError
 from .log_utils import _configure_logging_from_trace
 from .objects import Commit, ObjectID, RawObjectID, sha_to_hex, valid_hexsha
-from .objectspec import parse_commit_range
+from .objectspec import parse_commit, parse_commit_range
 from .pack import Pack
 from .patch import DiffAlgorithmNotAvailable
 from .repo import Repo
@@ -2358,7 +2358,20 @@ class cmd_commit(Command):
             args: Command line arguments
         """
         parser = argparse.ArgumentParser()
-        parser.add_argument("--message", "-m", help="Commit message")
+        messages = parser.add_mutually_exclusive_group()
+        messages.add_argument("--message", "-m", help="Commit message")
+        messages.add_argument(
+            "--reuse-message",
+            "-C",
+            metavar="COMMIT",
+            help="Reuse message and authorship from a commit",
+        )
+        messages.add_argument(
+            "--reedit-message",
+            "-c",
+            metavar="COMMIT",
+            help="Reuse authorship and edit a commit's message",
+        )
         parser.add_argument("--author", help="Override commit author (Name <email>)")
         parser.add_argument(
             "-a",
@@ -2374,8 +2387,34 @@ class cmd_commit(Command):
         parsed_args = parser.parse_args(args)
 
         message: bytes | str | Callable[[Repo | None, Commit | None], bytes]
+        reused_commit = None
+        source = (
+            parsed_args.reuse_message
+            if parsed_args.reuse_message is not None
+            else parsed_args.reedit_message
+        )
+        if source is not None:
+            try:
+                with porcelain.open_repo_closing(None) as repo:
+                    reused_commit = parse_commit(repo, source)
+            except (KeyError, ValueError) as e:
+                parser.error(str(e))
 
-        if parsed_args.message:
+        if reused_commit is not None:
+            if parsed_args.reedit_message is not None:
+                initial_message = reused_commit.message
+
+                def get_reused_message(
+                    repo: Repo | None, commit: Commit | None
+                ) -> bytes:
+                    return _get_commit_message_with_template(
+                        initial_message, repo, commit
+                    )
+
+                message = get_reused_message
+            else:
+                message = reused_commit.message
+        elif parsed_args.message:
             message = parsed_args.message
         elif parsed_args.amend:
             # For amend, create a callable that opens editor with original message pre-populated
@@ -2406,7 +2445,16 @@ class cmd_commit(Command):
                 message=message,
                 author=parsed_args.author.encode("utf-8")
                 if parsed_args.author is not None
+                else reused_commit.author
+                if reused_commit is not None
                 else None,
+                author_timestamp=reused_commit.author_time
+                if reused_commit is not None
+                else None,
+                author_timezone=reused_commit.author_timezone
+                if reused_commit is not None
+                else None,
+                encoding=reused_commit.encoding if reused_commit is not None else None,
                 all=parsed_args.all,
                 amend=parsed_args.amend,
             )

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -2394,11 +2394,8 @@ class cmd_commit(Command):
             else parsed_args.reedit_message
         )
         if source is not None:
-            try:
-                with porcelain.open_repo_closing(None) as repo:
-                    reused_commit = parse_commit(repo, source)
-            except (KeyError, ValueError) as e:
-                parser.error(str(e))
+            with porcelain.open_repo_closing(None) as repo:
+                reused_commit = parse_commit(repo, source)
 
         if reused_commit is not None:
             if parsed_args.reedit_message is not None:

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -392,11 +392,9 @@ class CommitCommandTest(DulwichCliTestCase):
         self.assertEqual(commit.parents, self.repo[head].parents)
 
     def test_commit_reuse_invalid_arguments(self):
-        """Invalid references and conflicting message flags leave HEAD unchanged."""
+        """Conflicting message flags leave HEAD unchanged."""
         head = porcelain.commit(self.repo, message=b"Original")
         for args in (
-            ("-C", "missing"),
-            ("-C", ""),
             ("-m", "new", "-C", "HEAD"),
             ("-C", "HEAD", "-c", "HEAD"),
         ):
@@ -405,6 +403,22 @@ class CommitCommandTest(DulwichCliTestCase):
                     self._run_cli("commit", *args)
                 self.assertEqual(error.exception.code, 2)
                 self.assertEqual(self.repo.head(), head)
+
+    def test_commit_reuse_invalid_source(self):
+        """Commit resolution errors propagate without changing HEAD."""
+        head = porcelain.commit(self.repo, message=b"Original")
+        blob = Blob.from_string(b"not a commit")
+        self.repo.object_store.add_object(blob)
+        for flag in ("-C", "--reuse-message", "-c", "--reedit-message"):
+            for source, error_type in (
+                ("missing", KeyError),
+                ("", KeyError),
+                (blob.id.decode(), ValueError),
+            ):
+                with self.subTest(flag=flag, source=source):
+                    with self.assertRaises(error_type):
+                        self._run_cli("commit", flag, source)
+                    self.assertEqual(self.repo.head(), head)
 
     @patch("dulwich.cli.launch_editor", return_value=b"")
     def test_commit_reedit_empty_message(self, editor):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -335,6 +335,86 @@ class CommitCommandTest(DulwichCliTestCase):
                 self.assertEqual(commit.parents, original.parents)
                 self.assertEqual(commit.message, b"Amended commit")
 
+    def test_commit_reuse_message(self):
+        """Reusing a message preserves authorship, not committer or parents."""
+        self.overrideEnv("GIT_COMMITTER_NAME", "New Committer")
+        self.overrideEnv("GIT_COMMITTER_EMAIL", "new@example.com")
+        for flag in ("-C", "--reuse-message", "-c", "--reedit-message"):
+            with self.subTest(flag=flag):
+                original_id = porcelain.commit(
+                    self.repo,
+                    message="Original café\n",
+                    author=b"Old <old@example.com>",
+                    author_timestamp=1234567890,
+                    author_timezone=19800,
+                    commit_timestamp=1234567890,
+                )
+                with patch(
+                    "dulwich.cli.launch_editor", return_value=b"Edited message\n"
+                ) as editor:
+                    result, _, _ = self._run_cli("commit", flag, original_id.decode())
+                self.assertIsNone(result)
+                commit = self.repo[self.repo.head()]
+                self.assertEqual(commit.author, b"Old <old@example.com>")
+                self.assertEqual(commit.author_time, 1234567890)
+                self.assertEqual(commit.author_timezone, 19800)
+                self.assertEqual(commit.committer, b"New Committer <new@example.com>")
+                self.assertNotEqual(commit.commit_time, 1234567890)
+                self.assertEqual(commit.parents, [original_id])
+                if flag in ("-c", "--reedit-message"):
+                    self.assertEqual(commit.message, b"Edited message\n")
+                    self.assertTrue(
+                        editor.call_args.args[0].startswith("Original café\n".encode())
+                    )
+                else:
+                    self.assertEqual(commit.message, "Original café\n".encode())
+                    editor.assert_not_called()
+
+    def test_commit_reuse_message_amend_author_override(self):
+        """An explicit author overrides reused authorship when amending."""
+        source = porcelain.commit(
+            self.repo, message=b"Source", author_timestamp=1234567890
+        )
+        head = porcelain.commit(self.repo, message=b"Head")
+        result, _, _ = self._run_cli(
+            "commit",
+            "--amend",
+            "-C",
+            source.decode(),
+            "--author",
+            "Other <other@example.com>",
+        )
+        self.assertIsNone(result)
+        commit = self.repo[self.repo.head()]
+        self.assertEqual(commit.message, b"Source")
+        self.assertEqual(commit.author, b"Other <other@example.com>")
+        self.assertEqual(commit.author_time, 1234567890)
+        self.assertEqual(commit.parents, self.repo[head].parents)
+
+    def test_commit_reuse_invalid_arguments(self):
+        """Invalid references and conflicting message flags leave HEAD unchanged."""
+        head = porcelain.commit(self.repo, message=b"Original")
+        for args in (
+            ("-C", "missing"),
+            ("-C", ""),
+            ("-m", "new", "-C", "HEAD"),
+            ("-C", "HEAD", "-c", "HEAD"),
+        ):
+            with self.subTest(args=args):
+                with self.assertRaises(SystemExit) as error:
+                    self._run_cli("commit", *args)
+                self.assertEqual(error.exception.code, 2)
+                self.assertEqual(self.repo.head(), head)
+
+    @patch("dulwich.cli.launch_editor", return_value=b"")
+    def test_commit_reedit_empty_message(self, editor):
+        """Cancelling the reused message editor leaves the existing commit intact."""
+        head = porcelain.commit(self.repo, message=b"Original")
+        result, _, _ = self._run_cli("commit", "-c", "HEAD")
+        self.assertEqual(result, 1)
+        self.assertEqual(self.repo.head(), head)
+        editor.assert_called_once()
+
     def test_commit_all_flag(self):
         # Create initial commit
         test_file = os.path.join(self.repo_path, "test.txt")


### PR DESCRIPTION
Add `dulwich commit -C/--reuse-message` to reuse a commit's message and authorship, and `-c/--reedit-message` to edit the reused message. Explicit `--author` still takes precedence.

Includes CLI regression tests and a NEWS entry. Refs #1845.