### PR TITLE
Add bugreport command for diagnostic report templates

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.2.15	UNRELEASED
 
+ * Add ``dulwich bugreport`` to write an editable report template with system
+   metadata and executable hook filenames. Supports output directories, timestamp
+   suffixes and noninteractive ``--no-edit`` operation, including outside a
+   repository. Existing reports are never overwritten. (eunwoo song, #1836)
+
  * Support ``dulwich commit -C/--reuse-message`` and ``-c/--reedit-message``
    to reuse a commit's message, author and author date, optionally editing
    the message. The committer and new commit ancestry remain independent.

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -5073,6 +5073,88 @@ class cmd_describe(Command):
         logger.info(porcelain.describe(None))
 
 
+class cmd_bugreport(Command):
+    """Write a bug report template with system and repository information."""
+
+    def run(self, args: Sequence[str]) -> None:
+        """Collect a report and optionally open it in an editor.
+
+        Args:
+            args: Command line arguments
+        """
+        import platform
+        from datetime import datetime
+
+        from dulwich import __version__
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-o", "--output-directory", default=".")
+        suffix_group = parser.add_mutually_exclusive_group()
+        suffix_group.add_argument("-s", "--suffix", default="%Y-%m-%d-%H%M")
+        suffix_group.add_argument("--no-suffix", action="store_true")
+        parser.add_argument(
+            "--no-edit", action="store_true", help="Do not open an editor"
+        )
+        options = parser.parse_args(args)
+        suffix = "" if options.no_suffix else datetime.now().strftime(options.suffix)
+        if any(char in suffix for char in ("/", "\\", "\0")):
+            parser.error("suffix must not contain path separators or NUL")
+        name = "dulwich-bugreport" + ("-" + suffix if suffix else "") + ".txt"
+        report_path = Path(options.output_directory) / name
+
+        lines = [
+            "Please describe the problem before sharing this report.",
+            "Review the collected information before sending it.",
+            "",
+            "What did you do? (Include steps to reproduce.)",
+            "",
+            "What did you expect to happen?",
+            "",
+            "What happened instead?",
+            "",
+            "[System information]",
+            "Dulwich version: " + ".".join(str(part) for part in __version__),
+            "Python version: " + sys.version,
+            "Python implementation: " + platform.python_implementation(),
+            "System: " + platform.system(),
+            "Release: " + platform.release(),
+            "Machine: " + platform.machine(),
+            "Python compiler: " + platform.python_compiler(),
+            "Shell: " + os.environ.get("SHELL", "(not set)"),
+            "",
+            "[Repository information]",
+        ]
+        try:
+            repo = Repo.discover()
+        except NotGitRepository:
+            lines.append("Repository: (not found)")
+        else:
+            with repo:
+                lines.append(f"Bare: {repo.bare}")
+                config = repo.get_config_stack()
+                try:
+                    hooks_path = Path(os.fsdecode(config.get((b"core",), b"hooksPath")))
+                    if not hooks_path.is_absolute():
+                        hooks_path = Path(repo.path) / hooks_path
+                except KeyError:
+                    hooks_path = Path(repo.commondir()) / "hooks"
+                lines.append("Executable hook files:")
+                if hooks_path.is_dir():
+                    lines.extend(
+                        "  " + hook.name
+                        for hook in sorted(hooks_path.iterdir())
+                        if hook.is_file() and os.access(hook, os.X_OK)
+                    )
+        content = ("\n".join(lines) + "\n").encode("utf-8", "replace")
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        # Reserve the filename before editing and preserve the template on failure.
+        with report_path.open("xb") as report:
+            report.write(content)
+        if not options.no_edit:
+            report_path.write_bytes(launch_editor(content))
+        sys.stdout.write(f"Created bug report: {report_path}\n")
+
+
 class cmd_diagnose(Command):
     """Display diagnostic information about the Python environment."""
 
@@ -7779,6 +7861,7 @@ commands = {
     "blame": cmd_blame,
     "branch": cmd_branch,
     "bundle": cmd_bundle,
+    "bugreport": cmd_bugreport,
     "cat-file": cmd_cat_file,
     "check-ignore": cmd_check_ignore,
     "check-mailmap": cmd_check_mailmap,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -34,6 +34,7 @@ import sys
 import tempfile
 import time
 import unittest
+from pathlib import Path
 from unittest import skipIf
 from unittest.mock import MagicMock, patch
 
@@ -188,6 +189,113 @@ class InitCommandTest(DulwichCliTestCase):
         self.addCleanup(repo.close)
         config = repo.get_config()
         self.assertEqual(b"sha256", config.get((b"extensions",), b"objectformat"))
+
+
+class BugreportCommandTest(DulwichCliTestCase):
+    """Tests for collecting bug report templates."""
+
+    def test_bugreport_outside_repository(self):
+        """A report can be generated even when repository discovery fails."""
+        self.repo_path = self.test_dir
+        result, _, _ = self._run_cli("bugreport", "--no-edit", "--no-suffix")
+        self.assertIsNone(result)
+        report = Path(self.test_dir, "dulwich-bugreport.txt").read_text()
+        self.assertIn("What happened instead?", report)
+        self.assertIn("Dulwich version:", report)
+        self.assertIn("Python version:", report)
+        self.assertIn("Repository: (not found)", report)
+
+    def test_bugreport_repository_and_output_directory(self):
+        """Report metadata does not include config values or hook contents."""
+        hook = Path(self.repo.controldir(), "hooks", "pre-commit")
+        hook.write_text("#!/bin/sh\n# private-hook-content\n")
+        hook.chmod(0o755)
+        config = self.repo.get_config()
+        config.set((b"remote", b"origin"), b"url", b"https://private-token@example.com")
+        config.write_to_path()
+        result, _, _ = self._run_cli(
+            "bugreport", "--no-edit", "-o", "reports/nested", "-s", "fixed"
+        )
+        self.assertIsNone(result)
+        report = Path(
+            self.repo_path, "reports/nested/dulwich-bugreport-fixed.txt"
+        ).read_text()
+        self.assertIn("Bare: False", report)
+        self.assertIn("pre-commit", report)
+        self.assertNotIn("private-token", report)
+        self.assertNotIn("private-hook-content", report)
+
+    def test_bugreport_does_not_overwrite(self):
+        """A repeated suffix must preserve the existing report."""
+        report = Path(self.repo_path, "dulwich-bugreport.txt")
+        report.write_text("existing report")
+        with self.assertRaises(FileExistsError):
+            self._run_cli("bugreport", "--no-edit", "--no-suffix")
+        self.assertEqual(report.read_text(), "existing report")
+
+    @patch("dulwich.cli.launch_editor", return_value=b"User report\n")
+    def test_bugreport_editor(self, editor):
+        """The generated template is editable before sharing."""
+        self._run_cli("bugreport", "--no-suffix")
+        self.assertIn(b"Dulwich version:", editor.call_args.args[0])
+        self.assertEqual(
+            Path(self.repo_path, "dulwich-bugreport.txt").read_text(), "User report\n"
+        )
+
+    def test_bugreport_suffix_cannot_escape_output_directory(self):
+        """Suffixes identify files, not paths."""
+        for suffix in ("../escape", "nested/name", "nested\\name"):
+            with self.subTest(suffix=suffix), self.assertRaises(SystemExit):
+                self._run_cli("bugreport", "--no-edit", "--suffix", suffix)
+
+    def test_bugreport_bare_repository(self):
+        """Bare repositories do not need a worktree to produce a report."""
+        bare_path = os.path.join(self.test_dir, "bare")
+        os.mkdir(bare_path)
+        with Repo.init_bare(bare_path):
+            self.repo_path = bare_path
+            self._run_cli("bugreport", "--no-edit", "--no-suffix")
+        self.assertIn(
+            "Bare: True", Path(bare_path, "dulwich-bugreport.txt").read_text()
+        )
+
+    @skipIf(os.name == "nt", "Windows does not use Unix executable permissions")
+    def test_bugreport_configured_hooks(self):
+        """Only executable files in the configured hook directory are listed."""
+        hooks = Path(self.repo_path, "custom-hooks")
+        hooks.mkdir()
+        for name, mode in (("pre-commit", 0o755), ("disabled", 0o644)):
+            hook = hooks / name
+            hook.write_text("#!/bin/sh\n")
+            hook.chmod(mode)
+        (hooks / "directory").mkdir()
+        config = self.repo.get_config()
+        config.set((b"core",), b"hooksPath", b"custom-hooks")
+        config.write_to_path()
+        self._run_cli("bugreport", "--no-edit", "--no-suffix")
+        report = Path(self.repo_path, "dulwich-bugreport.txt").read_text()
+        self.assertIn("  pre-commit\n", report)
+        self.assertNotIn("disabled", report)
+        self.assertNotIn("  directory\n", report)
+
+    @patch("dulwich.cli.launch_editor", side_effect=RuntimeError("editor failed"))
+    def test_bugreport_editor_failure_preserves_template(self, editor):
+        """The generated report remains available after editor failure."""
+        with self.assertRaisesRegex(RuntimeError, "editor failed"):
+            self._run_cli("bugreport", "--no-suffix")
+        self.assertIn(
+            "Dulwich version:",
+            Path(self.repo_path, "dulwich-bugreport.txt").read_text(),
+        )
+
+    def test_bugreport_default_suffix(self):
+        """The default name uses a local-time suffix."""
+        self._run_cli("bugreport", "--no-edit")
+        reports = list(Path(self.repo_path).glob("dulwich-bugreport-*.txt"))
+        self.assertEqual(len(reports), 1)
+        self.assertRegex(
+            reports[0].name, r"dulwich-bugreport-\d{4}-\d{2}-\d{2}-\d{4}\.txt"
+        )
 
 
 class HelperFunctionsTest(TestCase):


### PR DESCRIPTION
Fixes #1836.

Add `dulwich bugreport` to create an editable report template with Dulwich/Python/system metadata, repository type, and executable hook filenames. Supports `-o/--output-directory`, `-s/--suffix`, `--no-suffix`, and `--no-edit`; it also works outside a repository. Existing reports are preserved, and editor failure leaves the generated template available. Remote URLs, configuration values, and hook contents are not collected.

Validation: nine command tests cover these behaviors; full CLI suite passes (320 tests, four skipped), plus Ruff, formatting, mypy, codespell, and diff checks. Tested on Python 3.12/macOS. Diagnostic ZIP archives remain the separate, existing `diagnose` TODO.
