### PR TITLE
Honor GIT_REF_PARANOIA during ref iteration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.15	UNRELEASED
 
+ * Honor ``GIT_REF_PARANOIA`` in ``for-each-ref`` and ``show-ref``. Ref
+   containers can now explicitly include badly named refs during iteration
+   without reading the process environment themselves. (eunwoo song, #1819)
+
  * Support ``dulwich commit -C/--reuse-message`` and ``-c/--reedit-message``
    to reuse a commit's message, author and author date, optionally editing
    the message. The committer and new commit ancestry remain independent.

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -893,6 +893,19 @@ def _parse_env_bool(env: Mapping[str, str], name: str) -> bool:
         ) from None
 
 
+def _include_broken_refs(env: Mapping[str, str] | None) -> bool:
+    """Return whether ref iteration should include badly named refs.
+
+    Git enables ref paranoia by default. Setting ``GIT_REF_PARANOIA`` to a
+    false value opts into silently skipping broken refs.
+    """
+    if env is None:
+        env = os.environ
+    if "GIT_REF_PARANOIA" not in env:
+        return True
+    return _parse_env_bool(env, "GIT_REF_PARANOIA")
+
+
 def _repo_from_env(
     path_or_repo: str | bytes | os.PathLike[str] | None,
     env: Mapping[str, str] | None,
@@ -5078,19 +5091,21 @@ def fetch(
 def for_each_ref(
     repo: Repo | str | None = None,
     pattern: str | bytes | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> list[tuple[bytes, bytes, bytes]]:
     """Iterate over all refs that match the (optional) pattern.
 
     Args:
       repo: Path to the repository
       pattern: Optional glob (7) patterns to filter the refs with
+      env: Environment to read ``GIT_REF_PARANOIA`` from (defaults to os.environ)
     Returns: List of bytes tuples with: (sha, object_type, ref_name)
     """
     if isinstance(pattern, str):
         pattern = os.fsencode(pattern)
 
     with open_repo_closing(repo) as r:
-        refs = r.get_refs()
+        refs = r.get_refs(include_broken=_include_broken_refs(env))
 
     if pattern:
         matching_refs: dict[Ref, ObjectID] = {}
@@ -5136,6 +5151,7 @@ def show_ref(
     tags: bool = False,
     dereference: bool = False,
     verify: bool = False,
+    env: Mapping[str, str] | None = None,
 ) -> list[tuple[bytes, bytes]]:
     """List references in a local repository.
 
@@ -5147,6 +5163,7 @@ def show_ref(
       tags: Limit to local tags (refs/tags/)
       dereference: Dereference tags into object IDs
       verify: Enable stricter reference checking (exact path match)
+      env: Environment to read ``GIT_REF_PARANOIA`` from (defaults to os.environ)
     Returns: List of tuples with (sha, ref_name) or (sha, ref_name^{}) for dereferenced tags
     """
     # Convert string patterns to bytes
@@ -5155,7 +5172,7 @@ def show_ref(
         byte_patterns = [os.fsencode(p) if isinstance(p, str) else p for p in patterns]
 
     with open_repo_closing(repo) as r:
-        refs = r.get_refs()
+        refs = r.get_refs(include_broken=_include_broken_refs(env))
 
         # Filter by branches/tags if specified
         if branches or tags:

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -870,7 +870,9 @@ def _parse_ceiling_dirs(env: Mapping[str, str]) -> list[str] | None:
     return result
 
 
-def _parse_env_bool(env: Mapping[str, str], name: str) -> bool:
+def _parse_env_bool(
+    env: Mapping[str, str], name: str, *, default: bool = False
+) -> bool:
     """Parse a boolean Git environment variable.
 
     Follows git's rules: ``true``/``yes``/``on`` and any non-zero integer
@@ -879,7 +881,7 @@ def _parse_env_bool(env: Mapping[str, str], name: str) -> bool:
     """
     raw = env.get(name)
     if raw is None:
-        return False
+        return default
     value = raw.strip().lower()
     if value in ("true", "yes", "on"):
         return True
@@ -899,11 +901,9 @@ def _include_broken_refs(env: Mapping[str, str] | None) -> bool:
     Git enables ref paranoia by default. Setting ``GIT_REF_PARANOIA`` to a
     false value opts into silently skipping broken refs.
     """
-    if env is None:
-        env = os.environ
-    if "GIT_REF_PARANOIA" not in env:
-        return True
-    return _parse_env_bool(env, "GIT_REF_PARANOIA")
+    return _parse_env_bool(
+        os.environ if env is None else env, "GIT_REF_PARANOIA", default=True
+    )
 
 
 def _repo_from_env(

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -1153,8 +1153,10 @@ class DiskRefsContainer(RefsContainer):
             except RefFormatError:
                 return None
         # Broken names may bypass ref-format validation, but never the refs tree.
-        if include_broken and name != HEADREF and (
-            not name.startswith(b"refs/") or b".." in name.split(b"/")
+        if (
+            include_broken
+            and name != HEADREF
+            and (not name.startswith(b"refs/") or b".." in name.split(b"/"))
         ):
             return None
         filename = self.refpath(name)

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -357,13 +357,8 @@ class RefsContainer:
             packed refs.
         """
         if base is not None:
-            if include_broken:
-                return self.subkeys(base, include_broken=True)
-            return self.subkeys(base)
-        else:
-            if include_broken:
-                return self.allkeys(include_broken=True)
-            return self.allkeys()
+            return self.subkeys(base, include_broken=include_broken)
+        return self.allkeys(include_broken=include_broken)
 
     def subkeys(self, base: Ref, include_broken: bool = False) -> set[Ref]:
         """Refs present in this container under a base.
@@ -376,8 +371,7 @@ class RefsContainer:
         """
         keys: set[Ref] = set()
         base_len = len(base) + 1
-        refs = self.allkeys(include_broken=True) if include_broken else self.allkeys()
-        for refname in refs:
+        for refname in self.allkeys(include_broken=include_broken):
             if refname.startswith(base):
                 keys.add(Ref(refname[base_len:]))
         return keys
@@ -392,9 +386,7 @@ class RefsContainer:
           include_broken: Include refs whose names fail ref-format validation.
         """
         ret: dict[Ref, ObjectID] = {}
-        keys = (
-            self.keys(base, include_broken=True) if include_broken else self.keys(base)
-        )
+        keys = self.keys(base, include_broken=include_broken)
         base_bytes: bytes
         if base is None:
             base_bytes = b""
@@ -403,10 +395,7 @@ class RefsContainer:
         for key in keys:
             refname = Ref((base_bytes + b"/" + key).strip(b"/"))
             try:
-                if include_broken:
-                    _chain, sha = self.follow(refname, include_broken=True)
-                else:
-                    _chain, sha = self.follow(refname)
+                _chain, sha = self.follow(refname, include_broken=include_broken)
             except (SymrefLoop, KeyError):
                 continue  # Unable to resolve
             if sha is not None and (include_broken or valid_hexsha(sha)):
@@ -474,10 +463,7 @@ class RefsContainer:
         Returns: The contents of the ref file, or None if it does
             not exist.
         """
-        if include_broken:
-            contents = self.read_loose_ref(refname, include_broken=True)
-        else:
-            contents = self.read_loose_ref(refname)
+        contents = self.read_loose_ref(refname, include_broken=include_broken)
         if not contents:
             contents = self.get_packed_refs().get(refname, None)
         return contents
@@ -507,10 +493,7 @@ class RefsContainer:
         while contents and contents.startswith(SYMREF):
             refname = Ref(contents[len(SYMREF) :])
             refnames.append(refname)
-            if include_broken:
-                contents = self.read_ref(refname, include_broken=True)
-            else:
-                contents = self.read_ref(refname)
+            contents = self.read_ref(refname, include_broken=include_broken)
             if not contents:
                 break
             depth += 1
@@ -1169,18 +1152,12 @@ class DiskRefsContainer(RefsContainer):
                 self._check_refname(name)
             except RefFormatError:
                 return None
+        # Broken names may bypass ref-format validation, but never the refs tree.
+        if include_broken and (
+            not name.startswith(b"refs/") or b".." in name.split(b"/")
+        ):
+            return None
         filename = self.refpath(name)
-        if include_broken and name != HEADREF:
-            root_dir = self.worktree_path if is_per_worktree_ref(name) else self.path
-            refs_root = os.path.abspath(os.path.join(root_dir, b"refs"))
-            try:
-                if (
-                    os.path.commonpath((refs_root, os.path.abspath(filename)))
-                    != refs_root
-                ):
-                    return None
-            except ValueError:
-                return None
         try:
             with GitFile(filename, "rb") as f:
                 header = f.read(len(SYMREF))
@@ -2084,12 +2061,7 @@ class NamespacedRefsContainer(RefsContainer):
     def allkeys(self, include_broken: bool = False) -> set[Ref]:
         """Return all reference keys in this namespace."""
         keys: set[Ref] = set()
-        underlying_keys = (
-            self._refs.allkeys(include_broken=True)
-            if include_broken
-            else self._refs.allkeys()
-        )
-        for key in underlying_keys:
+        for key in self._refs.allkeys(include_broken=include_broken):
             stripped = self._strip_namespace(key)
             if stripped is not None:
                 keys.add(Ref(stripped))
@@ -2097,10 +2069,9 @@ class NamespacedRefsContainer(RefsContainer):
 
     def read_loose_ref(self, name: Ref, include_broken: bool = False) -> bytes | None:
         """Read a loose reference."""
-        namespaced_name = Ref(self._apply_namespace(name))
-        if include_broken:
-            return self._refs.read_loose_ref(namespaced_name, include_broken=True)
-        return self._refs.read_loose_ref(namespaced_name)
+        return self._refs.read_loose_ref(
+            Ref(self._apply_namespace(name)), include_broken=include_broken
+        )
 
     def get_packed_refs(self) -> dict[Ref, ObjectID]:
         """Get packed refs within this namespace."""

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -1153,7 +1153,7 @@ class DiskRefsContainer(RefsContainer):
             except RefFormatError:
                 return None
         # Broken names may bypass ref-format validation, but never the refs tree.
-        if include_broken and (
+        if include_broken and name != HEADREF and (
             not name.startswith(b"refs/") or b".." in name.split(b"/")
         ):
             return None

--- a/dulwich/refs.py
+++ b/dulwich/refs.py
@@ -335,56 +335,82 @@ class RefsContainer:
         for ref in to_delete:
             self.remove_if_equals(Ref(b"/".join((base, ref))), None, message=message)
 
-    def allkeys(self) -> set[Ref]:
-        """All refs present in this container."""
+    def allkeys(self, include_broken: bool = False) -> set[Ref]:
+        """All refs present in this container.
+
+        Args:
+          include_broken: Include refs whose names fail ref-format validation.
+        """
         raise NotImplementedError(self.allkeys)
 
     def __iter__(self) -> Iterator[Ref]:
         """Iterate over all reference keys."""
         return iter(self.allkeys())
 
-    def keys(self, base: Ref | None = None) -> set[Ref]:
+    def keys(self, base: Ref | None = None, include_broken: bool = False) -> set[Ref]:
         """Refs present in this container.
 
         Args:
           base: An optional base to return refs under.
+          include_broken: Include refs whose names fail ref-format validation.
         Returns: An unsorted set of valid refs in this container, including
             packed refs.
         """
         if base is not None:
+            if include_broken:
+                return self.subkeys(base, include_broken=True)
             return self.subkeys(base)
         else:
+            if include_broken:
+                return self.allkeys(include_broken=True)
             return self.allkeys()
 
-    def subkeys(self, base: Ref) -> set[Ref]:
+    def subkeys(self, base: Ref, include_broken: bool = False) -> set[Ref]:
         """Refs present in this container under a base.
 
         Args:
           base: The base to return refs under.
+          include_broken: Include refs whose names fail ref-format validation.
         Returns: A set of valid refs in this container under the base; the base
             prefix is stripped from the ref names returned.
         """
         keys: set[Ref] = set()
         base_len = len(base) + 1
-        for refname in self.allkeys():
+        refs = self.allkeys(include_broken=True) if include_broken else self.allkeys()
+        for refname in refs:
             if refname.startswith(base):
                 keys.add(Ref(refname[base_len:]))
         return keys
 
-    def as_dict(self, base: Ref | None = None) -> dict[Ref, ObjectID]:
-        """Return the contents of this container as a dictionary."""
+    def as_dict(
+        self, base: Ref | None = None, include_broken: bool = False
+    ) -> dict[Ref, ObjectID]:
+        """Return the contents of this container as a dictionary.
+
+        Args:
+          base: Optional base to return refs under.
+          include_broken: Include refs whose names fail ref-format validation.
+        """
         ret: dict[Ref, ObjectID] = {}
-        keys = self.keys(base)
+        keys = (
+            self.keys(base, include_broken=True) if include_broken else self.keys(base)
+        )
         base_bytes: bytes
         if base is None:
             base_bytes = b""
         else:
             base_bytes = base.rstrip(b"/")
         for key in keys:
+            refname = Ref((base_bytes + b"/" + key).strip(b"/"))
             try:
-                ret[key] = self[Ref((base_bytes + b"/" + key).strip(b"/"))]
+                if include_broken:
+                    _chain, sha = self.follow(refname, include_broken=True)
+                else:
+                    _chain, sha = self.follow(refname)
             except (SymrefLoop, KeyError):
                 continue  # Unable to resolve
+            if sha is not None and (include_broken or valid_hexsha(sha)):
+                ret[key] = sha
 
         return ret
 
@@ -439,30 +465,37 @@ class RefsContainer:
         if not (valid_hexsha(ref) or ref.startswith(SYMREF)):
             raise ValueError(f"{ref!r} must be a valid sha or a symref")
 
-    def read_ref(self, refname: Ref) -> bytes | None:
+    def read_ref(self, refname: Ref, include_broken: bool = False) -> bytes | None:
         """Read a reference without following any references.
 
         Args:
           refname: The name of the reference
+          include_broken: Allow a badly formatted ref name to be read.
         Returns: The contents of the ref file, or None if it does
             not exist.
         """
-        contents = self.read_loose_ref(refname)
+        if include_broken:
+            contents = self.read_loose_ref(refname, include_broken=True)
+        else:
+            contents = self.read_loose_ref(refname)
         if not contents:
             contents = self.get_packed_refs().get(refname, None)
         return contents
 
-    def read_loose_ref(self, name: Ref) -> bytes | None:
+    def read_loose_ref(self, name: Ref, include_broken: bool = False) -> bytes | None:
         """Read a loose reference and return its contents.
 
         Args:
           name: the refname to read
+          include_broken: Allow a badly formatted ref name to be read.
         Returns: The contents of the ref file, or None if it does
             not exist.
         """
         raise NotImplementedError(self.read_loose_ref)
 
-    def follow(self, name: Ref) -> tuple[list[Ref], ObjectID | None]:
+    def follow(
+        self, name: Ref, include_broken: bool = False
+    ) -> tuple[list[Ref], ObjectID | None]:
         """Follow a reference name.
 
         Returns: a tuple of (refnames, sha), wheres refnames are the names of
@@ -474,7 +507,10 @@ class RefsContainer:
         while contents and contents.startswith(SYMREF):
             refname = Ref(contents[len(SYMREF) :])
             refnames.append(refname)
-            contents = self.read_ref(refname)
+            if include_broken:
+                contents = self.read_ref(refname, include_broken=True)
+            else:
+                contents = self.read_ref(refname)
             if not contents:
                 break
             depth += 1
@@ -663,11 +699,11 @@ class DictRefsContainer(RefsContainer):
         self._peeled: dict[Ref, ObjectID] = {}
         self._watchers: set[Any] = set()
 
-    def allkeys(self) -> set[Ref]:
+    def allkeys(self, include_broken: bool = False) -> set[Ref]:
         """Return all reference keys."""
         return set(self._refs.keys())
 
-    def read_loose_ref(self, name: Ref) -> bytes | None:
+    def read_loose_ref(self, name: Ref, include_broken: bool = False) -> bytes | None:
         """Read a loose reference."""
         return self._refs.get(name, None)
 
@@ -911,6 +947,7 @@ class DiskRefsContainer(RefsContainer):
         path: bytes,
         base: bytes,
         dir_filter: Callable[[bytes], bool] | None = None,
+        include_broken: bool = False,
     ) -> Iterator[Ref]:
         refspath = os.path.join(path, base.rstrip(b"/"))
         prefix_len = len(os.path.join(path, b""))
@@ -926,10 +963,12 @@ class DiskRefsContainer(RefsContainer):
 
             for filename in files:
                 refname = b"/".join([directory, filename])
-                if check_ref_format(Ref(refname)):
+                if include_broken or check_ref_format(Ref(refname)):
                     yield Ref(refname)
 
-    def _iter_loose_refs(self, base: bytes = b"refs/") -> Iterator[Ref]:
+    def _iter_loose_refs(
+        self, base: bytes = b"refs/", include_broken: bool = False
+    ) -> Iterator[Ref]:
         base = base.rstrip(b"/") + b"/"
         search_paths: list[tuple[bytes, Callable[[bytes], bool] | None]] = []
         if base != b"refs/":
@@ -945,13 +984,15 @@ class DiskRefsContainer(RefsContainer):
             search_paths.append((self.worktree_path, is_per_worktree_ref))
 
         for path, dir_filter in search_paths:
-            yield from self._iter_dir(path, base, dir_filter=dir_filter)
+            yield from self._iter_dir(
+                path, base, dir_filter=dir_filter, include_broken=include_broken
+            )
 
-    def subkeys(self, base: Ref) -> set[Ref]:
+    def subkeys(self, base: Ref, include_broken: bool = False) -> set[Ref]:
         """Return subkeys under a given base reference path."""
         subkeys: set[Ref] = set()
 
-        for key in self._iter_loose_refs(base):
+        for key in self._iter_loose_refs(base, include_broken=include_broken):
             if key.startswith(base):
                 subkeys.add(Ref(key[len(base) :].strip(b"/")))
 
@@ -960,13 +1001,13 @@ class DiskRefsContainer(RefsContainer):
                 subkeys.add(Ref(key[len(base) :].strip(b"/")))
         return subkeys
 
-    def allkeys(self) -> set[Ref]:
+    def allkeys(self, include_broken: bool = False) -> set[Ref]:
         """Return all reference keys."""
         allkeys: set[Ref] = set()
         if os.path.exists(self.refpath(HEADREF)):
             allkeys.add(Ref(HEADREF))
 
-        allkeys.update(self._iter_loose_refs())
+        allkeys.update(self._iter_loose_refs(include_broken=include_broken))
         allkeys.update(self.get_packed_refs())
         return allkeys
 
@@ -1107,7 +1148,7 @@ class DiskRefsContainer(RefsContainer):
             # Known not peelable
             return self[name]
 
-    def read_loose_ref(self, name: Ref) -> bytes | None:
+    def read_loose_ref(self, name: Ref, include_broken: bool = False) -> bytes | None:
         """Read a reference file and return its contents.
 
         If the reference file a symbolic reference, only read the first line of
@@ -1115,6 +1156,7 @@ class DiskRefsContainer(RefsContainer):
 
         Args:
           name: the refname to read, relative to refpath
+          include_broken: Allow a badly formatted ref name to be read.
         Returns: The contents of the ref file, or None if the file does not
             exist.
 
@@ -1122,11 +1164,23 @@ class DiskRefsContainer(RefsContainer):
           IOError: if any other error occurs
         """
         # Validate the name before turning it into a path.
-        try:
-            self._check_refname(name)
-        except RefFormatError:
-            return None
+        if not include_broken:
+            try:
+                self._check_refname(name)
+            except RefFormatError:
+                return None
         filename = self.refpath(name)
+        if include_broken and name != HEADREF:
+            root_dir = self.worktree_path if is_per_worktree_ref(name) else self.path
+            refs_root = os.path.abspath(os.path.join(root_dir, b"refs"))
+            try:
+                if (
+                    os.path.commonpath((refs_root, os.path.abspath(filename)))
+                    != refs_root
+                ):
+                    return None
+            except ValueError:
+                return None
         try:
             with GitFile(filename, "rb") as f:
                 header = f.read(len(SYMREF))
@@ -2027,18 +2081,26 @@ class NamespacedRefsContainer(RefsContainer):
             return name[len(self._namespace_prefix) :]
         return None
 
-    def allkeys(self) -> set[Ref]:
+    def allkeys(self, include_broken: bool = False) -> set[Ref]:
         """Return all reference keys in this namespace."""
         keys: set[Ref] = set()
-        for key in self._refs.allkeys():
+        underlying_keys = (
+            self._refs.allkeys(include_broken=True)
+            if include_broken
+            else self._refs.allkeys()
+        )
+        for key in underlying_keys:
             stripped = self._strip_namespace(key)
             if stripped is not None:
                 keys.add(Ref(stripped))
         return keys
 
-    def read_loose_ref(self, name: Ref) -> bytes | None:
+    def read_loose_ref(self, name: Ref, include_broken: bool = False) -> bytes | None:
         """Read a loose reference."""
-        return self._refs.read_loose_ref(Ref(self._apply_namespace(name)))
+        namespaced_name = Ref(self._apply_namespace(name))
+        if include_broken:
+            return self._refs.read_loose_ref(namespaced_name, include_broken=True)
+        return self._refs.read_loose_ref(namespaced_name)
 
     def get_packed_refs(self) -> dict[Ref, ObjectID]:
         """Get packed refs within this namespace."""

--- a/dulwich/reftable.py
+++ b/dulwich/reftable.py
@@ -993,7 +993,7 @@ class ReftableRefsContainer(RefsContainer):
                     all_refs[ref] = (value_type, value)
         return all_refs
 
-    def allkeys(self) -> set[Ref]:
+    def allkeys(self, include_broken: bool = False) -> set[Ref]:
         """Return set of all ref names."""
         refs = self._read_all_tables()
         result = set(refs.keys())
@@ -1007,7 +1007,9 @@ class ReftableRefsContainer(RefsContainer):
 
         return result
 
-    def follow(self, name: Ref) -> tuple[list[Ref], ObjectID | None]:
+    def follow(
+        self, name: Ref, include_broken: bool = False
+    ) -> tuple[list[Ref], ObjectID | None]:
         """Follow a reference name.
 
         Returns: a tuple of (refnames, sha), where refnames are the names of
@@ -1050,11 +1052,12 @@ class ReftableRefsContainer(RefsContainer):
             raise KeyError(name)
         return sha
 
-    def read_loose_ref(self, name: Ref) -> bytes:
+    def read_loose_ref(self, name: Ref, include_broken: bool = False) -> bytes:
         """Read a reference value without following symbolic refs.
 
         Args:
             name: the refname to read
+            include_broken: Accepted for compatibility with ref containers.
         Returns: The contents of the ref file.
                  For symbolic refs, returns b"ref: <target>"
         Raises:

--- a/dulwich/repo.py
+++ b/dulwich/repo.py
@@ -1018,12 +1018,14 @@ class BaseRepo:
             update_shallow=self.update_shallow,
         )
 
-    def get_refs(self) -> dict[Ref, ObjectID]:
+    def get_refs(self, include_broken: bool = False) -> dict[Ref, ObjectID]:
         """Get dictionary with all refs.
 
+        Args:
+          include_broken: Include refs whose names fail ref-format validation.
         Returns: A ``dict`` mapping ref names to SHA1s
         """
-        return self.refs.as_dict()
+        return self.refs.as_dict(include_broken=include_broken)
 
     def head(self) -> ObjectID:
         """Return the SHA1 pointed at by HEAD."""

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -10101,6 +10101,28 @@ class ForEachTests(PorcelainTestCase):
             ],
         )
 
+    def test_for_each_ref_honors_git_ref_paranoia(self) -> None:
+        ref = b"refs/heads/bad..name"
+        with open(self.repo.refs.refpath(ref), "wb") as f:
+            f.write(self.repo.refs[b"HEAD"] + b"\n")
+
+        hidden = porcelain.for_each_ref(self.repo, env={"GIT_REF_PARANOIA": "0"})
+        visible = porcelain.for_each_ref(self.repo, env={"GIT_REF_PARANOIA": "1"})
+
+        self.assertNotIn(ref, {name for _sha, _type, name in hidden})
+        self.assertIn(ref, {name for _sha, _type, name in visible})
+
+    def test_show_ref_honors_git_ref_paranoia(self) -> None:
+        ref = b"refs/heads/bad..name"
+        with open(self.repo.refs.refpath(ref), "wb") as f:
+            f.write(self.repo.refs[b"HEAD"] + b"\n")
+
+        hidden = porcelain.show_ref(self.repo, env={"GIT_REF_PARANOIA": "false"})
+        visible = porcelain.show_ref(self.repo, env={})
+
+        self.assertNotIn(ref, {name for _sha, name in hidden})
+        self.assertIn(ref, {name for _sha, name in visible})
+
 
 class SparseCheckoutTests(PorcelainTestCase):
     """Integration tests for Dulwich's sparse checkout feature."""

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -38,7 +38,6 @@ from dulwich.refs import (
     DictRefsContainer,
     DiskRefsContainer,
     NamespacedRefsContainer,
-    Ref,
     SymrefLoop,
     _split_ref_line,
     check_ref_format,
@@ -444,17 +443,6 @@ class DictRefsContainerTests(RefsContainerTests, TestCase):
         del expected_refs[b"refs/heads/loop"]
         expected_refs[b"refs/stash"] = b"00" * 20
         self.assertEqual(expected_refs, self._refs.as_dict())
-
-    def test_default_iteration_supports_legacy_subclass_signatures(self) -> None:
-        class LegacyRefsContainer(DictRefsContainer):
-            def allkeys(self) -> set[Ref]:
-                return super().allkeys()
-
-            def read_loose_ref(self, name: Ref) -> bytes | None:
-                return super().read_loose_ref(name)
-
-        refs = LegacyRefsContainer({Ref(b"refs/heads/main"): ONES})
-        self.assertEqual({Ref(b"refs/heads/main"): ONES}, refs.as_dict())
 
     def test_set_if_equals_with_symbolic_ref(self) -> None:
         # Test that set_if_equals only updates the requested ref,

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -520,6 +520,9 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
     def test_include_broken_cannot_escape_refs_directory(self) -> None:
         self.assertIsNone(self._refs.read_ref(b"refs/../config", include_broken=True))
 
+    def test_as_dict_with_broken_refs_keeps_head(self) -> None:
+        self.assertEqual(self._refs[b"HEAD"], self._refs.as_dict(include_broken=True)[b"HEAD"])
+
     def test_remove_packed_ref_with_unread_packed_refs(self) -> None:
         # An unconditional delete never reads packed-refs on the way in, so
         # _remove_packed_ref() is reached without the cache being populated.

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -521,7 +521,9 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
         self.assertIsNone(self._refs.read_ref(b"refs/../config", include_broken=True))
 
     def test_as_dict_with_broken_refs_keeps_head(self) -> None:
-        self.assertEqual(self._refs[b"HEAD"], self._refs.as_dict(include_broken=True)[b"HEAD"])
+        self.assertEqual(
+            self._refs[b"HEAD"], self._refs.as_dict(include_broken=True)[b"HEAD"]
+        )
 
     def test_remove_packed_ref_with_unread_packed_refs(self) -> None:
         # An unconditional delete never reads packed-refs on the way in, so

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -38,6 +38,7 @@ from dulwich.refs import (
     DictRefsContainer,
     DiskRefsContainer,
     NamespacedRefsContainer,
+    Ref,
     SymrefLoop,
     _split_ref_line,
     check_ref_format,
@@ -444,6 +445,17 @@ class DictRefsContainerTests(RefsContainerTests, TestCase):
         expected_refs[b"refs/stash"] = b"00" * 20
         self.assertEqual(expected_refs, self._refs.as_dict())
 
+    def test_default_iteration_supports_legacy_subclass_signatures(self) -> None:
+        class LegacyRefsContainer(DictRefsContainer):
+            def allkeys(self) -> set[Ref]:
+                return super().allkeys()
+
+            def read_loose_ref(self, name: Ref) -> bytes | None:
+                return super().read_loose_ref(name)
+
+        refs = LegacyRefsContainer({Ref(b"refs/heads/main"): ONES})
+        self.assertEqual({Ref(b"refs/heads/main"): ONES}, refs.as_dict())
+
     def test_set_if_equals_with_symbolic_ref(self) -> None:
         # Test that set_if_equals only updates the requested ref,
         # not all refs in a symbolic reference chain
@@ -497,6 +509,28 @@ class DiskRefsContainerTests(RefsContainerTests, TestCase):
             },
             self._refs.get_packed_refs(),
         )
+
+    def test_allkeys_can_include_badly_named_refs(self) -> None:
+        ref = b"refs/heads/bad..name"
+        path = self._refs.refpath(ref)
+        with open(path, "wb") as f:
+            f.write(ONES + b"\n")
+
+        self.assertNotIn(ref, self._refs.allkeys())
+        self.assertIn(ref, self._refs.allkeys(include_broken=True))
+
+    def test_as_dict_can_include_broken_ref_values(self) -> None:
+        ref = b"refs/heads/broken"
+        with open(self._refs.refpath(ref), "wb") as f:
+            f.write(b"not-an-object-id\n")
+
+        self.assertNotIn(ref, self._refs.as_dict())
+        self.assertEqual(
+            b"not-an-object-id", self._refs.as_dict(include_broken=True)[ref]
+        )
+
+    def test_include_broken_cannot_escape_refs_directory(self) -> None:
+        self.assertIsNone(self._refs.read_ref(b"refs/../config", include_broken=True))
 
     def test_remove_packed_ref_with_unread_packed_refs(self) -> None:
         # An unconditional delete never reads packed-refs on the way in, so


### PR DESCRIPTION
Fixes #1819. `for-each-ref` and `show-ref` now honor `GIT_REF_PARANOIA`, exposing malformed ref names for repository recovery and debugging unless the variable is explicitly false. Regular ref iteration continues to filter malformed names.