### PR TITLE
Add dulwich bugreport command

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,10 @@
 1.2.15	UNRELEASED
 
+ * Add ``dulwich bugreport`` to collect system info, the Dulwich version and
+   a repository's enabled hooks into a text file for filing bug reports,
+   matching the layout and ``-o``/``-s``/``--no-suffix`` options of C Git's
+   ``git bugreport``. (Prashant Koirala, #1836)
+
  * Support ``dulwich commit -C/--reuse-message`` and ``-c/--reedit-message``
    to reuse a commit's message, author and author date, optionally editing
    the message. The committer and new commit ancestry remain independent.

--- a/docs/c-git-compatibility.txt
+++ b/docs/c-git-compatibility.txt
@@ -148,7 +148,7 @@ Other
 * ✗ ``git web--browse`` - Launch web browser to view HTML documentation
 * ✗ ``git difftool`` - Show changes using external diff tool
 * ✓ ``git range-diff`` - Compare two commit ranges
-* ✗ ``git bugreport`` - Collect information for bug reports
+* ✓ ``git bugreport`` - Collect information for bug reports
 * ✓ ``git diagnose`` - Display diagnostic information about the environment
 * ✗ ``git fsmonitor--daemon`` - Filesystem monitor daemon
 * ✗ ``git scalar`` - Manage large Git repositories

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -5088,7 +5088,7 @@ def _bugreport_hooks_section() -> str:
             enabled = sorted(
                 name
                 for name, hook in r.hooks.items()
-                if os.path.exists(getattr(hook, "filepath", ""))
+                if os.access(getattr(hook, "filepath", ""), os.X_OK)
             )
     except NotGitRepository:
         return "not run from a git repository - no hooks to show"

--- a/dulwich/cli.py
+++ b/dulwich/cli.py
@@ -60,11 +60,13 @@ import contextlib
 import io
 import logging
 import os
+import platform
 import shutil
 import signal
 import subprocess
 import sys
 import tempfile
+import time
 import types
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from pathlib import Path
@@ -5073,6 +5075,124 @@ class cmd_describe(Command):
         logger.info(porcelain.describe(None))
 
 
+def _bugreport_hooks_section() -> str:
+    """Build the "[Enabled Hooks]" section of a bug report.
+
+    Returns:
+        The names of hooks enabled in the repository discovered from the
+        current directory, one per line, or an explanatory message if the
+        current directory is not inside a repository.
+    """
+    try:
+        with Repo.discover() as r:
+            enabled = sorted(
+                name
+                for name, hook in r.hooks.items()
+                if os.path.exists(getattr(hook, "filepath", ""))
+            )
+    except NotGitRepository:
+        return "not run from a git repository - no hooks to show"
+    return "\n".join(enabled)
+
+
+def _bugreport_text() -> str:
+    """Build the contents of a Dulwich bug report.
+
+    Returns:
+        The full text of the bug report, matching the layout of C Git's
+        ``git bugreport`` so it can be filed against either project.
+    """
+    import dulwich
+
+    version = ".".join(str(v) for v in dulwich.__version__)
+    lines = [
+        "Thank you for filling out a Git bug report!",
+        "Please answer the following questions to help us understand your issue.",
+        "",
+        "What did you do before the bug happened? (Steps to reproduce your issue)",
+        "",
+        "What did you expect to happen? (Expected behavior)",
+        "",
+        "What happened instead? (Actual behavior)",
+        "",
+        "What's different between what you expected and what actually happened?",
+        "",
+        "Anything else you want to add:",
+        "",
+        "Please review the rest of the bug report below.",
+        "You can delete any lines you don't wish to share.",
+        "",
+        "",
+        "[System Info]",
+        f"dulwich version: {version}",
+        f"python version: {sys.version}",
+        f"python executable: {sys.executable}",
+        f"platform: {platform.platform()}",
+        f"$SHELL (typically, interactive shell): {os.environ.get('SHELL', '(not set)')}",
+        "",
+        "",
+        "[Enabled Hooks]",
+        _bugreport_hooks_section(),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+class cmd_bugreport(Command):
+    """Collect information for a bug report."""
+
+    def run(self, args: Sequence[str]) -> int:
+        """Execute the bugreport command.
+
+        Args:
+            args: Command line arguments
+
+        Returns:
+            0 on success, 128 if the report file already exists
+        """
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "-o",
+            "--output-directory",
+            type=str,
+            default=".",
+            help="Place the resulting bug report file in this directory",
+        )
+        parser.add_argument(
+            "-s",
+            "--suffix",
+            type=str,
+            default="%Y-%m-%d-%H%M",
+            dest="suffix",
+            help="strftime(3) format string used to disambiguate the filename",
+        )
+        parser.add_argument(
+            "--no-suffix",
+            action="store_const",
+            const=None,
+            dest="suffix",
+            help="Do not disambiguate the filename with a suffix",
+        )
+        parsed_args = parser.parse_args(args)
+
+        if parsed_args.suffix is None:
+            filename = "git-bugreport.txt"
+        else:
+            filename = f"git-bugreport-{time.strftime(parsed_args.suffix)}.txt"
+
+        os.makedirs(parsed_args.output_directory, exist_ok=True)
+        path = os.path.join(parsed_args.output_directory, filename)
+
+        try:
+            with open(path, "x", encoding="utf-8") as f:
+                f.write(_bugreport_text())
+        except FileExistsError:
+            logger.error("fatal: unable to create '%s': File exists", path)
+            return 128
+
+        print(f"Created new report at '{path}'.")
+        return 0
+
+
 class cmd_diagnose(Command):
     """Display diagnostic information about the Python environment."""
 
@@ -7778,6 +7898,7 @@ commands = {
     "bisect": cmd_bisect,
     "blame": cmd_blame,
     "branch": cmd_branch,
+    "bugreport": cmd_bugreport,
     "bundle": cmd_bundle,
     "cat-file": cmd_cat_file,
     "check-ignore": cmd_check_ignore,

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -37,6 +37,7 @@ import unittest
 from unittest import skipIf
 from unittest.mock import MagicMock, patch
 
+import dulwich
 from dulwich import cli, porcelain
 from dulwich.cli import (
     AutoFlushBinaryIOWrapper,
@@ -5353,6 +5354,100 @@ class DiagnoseCommandTest(DulwichCliTestCase):
 
             # Check that at least core dependencies are listed
             self.assertIn("urllib3:", log_output)
+
+
+class BugreportCommandTest(DulwichCliTestCase):
+    """Tests for bugreport command."""
+
+    def test_bugreport_default_filename(self):
+        """Test that a timestamped report file is created by default."""
+        result, stdout, _stderr = self._run_cli("bugreport")
+        self.assertEqual(0, result)
+
+        matches = glob.glob(os.path.join(self.repo_path, "git-bugreport-*.txt"))
+        self.assertEqual(1, len(matches))
+        self.assertIn("Created new report at", stdout)
+        self.assertIn(os.path.basename(matches[0]), stdout)
+
+        with open(matches[0]) as f:
+            content = f.read()
+        self.assertIn("Thank you for filling out a Git bug report!", content)
+        self.assertIn("[System Info]", content)
+        self.assertIn(
+            f"dulwich version: {'.'.join(str(v) for v in dulwich.__version__)}", content
+        )
+        self.assertIn("[Enabled Hooks]", content)
+
+    def test_bugreport_no_suffix(self):
+        """Test that --no-suffix produces an unadorned filename."""
+        result, _stdout, _stderr = self._run_cli("bugreport", "--no-suffix")
+        self.assertEqual(0, result)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.repo_path, "git-bugreport.txt"))
+        )
+
+    def test_bugreport_custom_suffix(self):
+        """Test that -s controls the filename suffix."""
+        result, _stdout, _stderr = self._run_cli("bugreport", "-s", "custom")
+        self.assertEqual(0, result)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.repo_path, "git-bugreport-custom.txt"))
+        )
+
+    def test_bugreport_refuses_to_overwrite(self):
+        """Test that an existing report file is not clobbered."""
+        result, _stdout, _stderr = self._run_cli("bugreport", "--no-suffix")
+        self.assertEqual(0, result)
+
+        with self.assertLogs("dulwich.cli", level="ERROR"):
+            result, _stdout, _stderr = self._run_cli("bugreport", "--no-suffix")
+        self.assertEqual(128, result)
+
+    def test_bugreport_output_directory(self):
+        """Test that -o places the report in the given directory, creating it."""
+        result, _stdout, _stderr = self._run_cli(
+            "bugreport", "-o", "reports", "--no-suffix"
+        )
+        self.assertEqual(0, result)
+        self.assertTrue(
+            os.path.exists(os.path.join(self.repo_path, "reports", "git-bugreport.txt"))
+        )
+
+    def test_bugreport_lists_enabled_hooks(self):
+        """Test that an executable hook script is listed as enabled."""
+        hooks_dir = os.path.join(self.repo_path, ".git", "hooks")
+        os.makedirs(hooks_dir, exist_ok=True)
+        hook_path = os.path.join(hooks_dir, "pre-commit")
+        with open(hook_path, "w") as f:
+            f.write("#!/bin/sh\nexit 0\n")
+        os.chmod(hook_path, 0o755)
+
+        result, _stdout, _stderr = self._run_cli("bugreport", "--no-suffix")
+        self.assertEqual(0, result)
+
+        with open(os.path.join(self.repo_path, "git-bugreport.txt")) as f:
+            content = f.read()
+        self.assertIn("pre-commit", content.split("[Enabled Hooks]")[1])
+
+    def test_bugreport_outside_repository(self):
+        """Test the hooks section when run outside of any repository."""
+        old_cwd = os.getcwd()
+        old_stdout = sys.stdout
+        try:
+            os.chdir(self.test_dir)
+            sys.stdout = io.StringIO()
+            result = cli.main(["bugreport", "--no-suffix"])
+        finally:
+            os.chdir(old_cwd)
+            sys.stdout = old_stdout
+        self.assertEqual(0, result)
+
+        with open(os.path.join(self.test_dir, "git-bugreport.txt")) as f:
+            content = f.read()
+        self.assertIn(
+            "not run from a git repository - no hooks to show",
+            content,
+        )
 
 
 class RepoDiscoveryTest(DulwichCliTestCase):

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5429,6 +5429,26 @@ class BugreportCommandTest(DulwichCliTestCase):
             content = f.read()
         self.assertIn("pre-commit", content.split("[Enabled Hooks]")[1])
 
+    def test_bugreport_ignores_non_executable_hook(self):
+        """Test that a hook script without the executable bit is not listed.
+
+        Matches C Git, which ignores non-executable hook files (and warns
+        about them) rather than treating them as enabled.
+        """
+        hooks_dir = os.path.join(self.repo_path, ".git", "hooks")
+        os.makedirs(hooks_dir, exist_ok=True)
+        hook_path = os.path.join(hooks_dir, "pre-commit")
+        with open(hook_path, "w") as f:
+            f.write("#!/bin/sh\nexit 0\n")
+        os.chmod(hook_path, 0o644)
+
+        result, _stdout, _stderr = self._run_cli("bugreport", "--no-suffix")
+        self.assertEqual(0, result)
+
+        with open(os.path.join(self.repo_path, "git-bugreport.txt")) as f:
+            content = f.read()
+        self.assertNotIn("pre-commit", content.split("[Enabled Hooks]")[1])
+
     def test_bugreport_outside_repository(self):
         """Test the hooks section when run outside of any repository."""
         old_cwd = os.getcwd()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -28,6 +28,7 @@ import glob
 import io
 import logging
 import os
+import platform
 import re
 import shutil
 import sys
@@ -5356,11 +5357,34 @@ class DiagnoseCommandTest(DulwichCliTestCase):
             self.assertIn("urllib3:", log_output)
 
 
+def _parse_bugreport(content):
+    """Split bugreport text into its intro paragraph and named sections.
+
+    Returns a tuple ``(intro_lines, sections)`` where ``intro_lines`` is
+    the text before the first ``[Section Header]`` line and ``sections``
+    is an ordered dict mapping each header to its non-blank content
+    lines, so tests can assert on exact structure instead of doing
+    substring matches against the whole blob.
+    """
+    intro = []
+    sections: dict[str, list[str]] = {}
+    current = None
+    for line in content.splitlines():
+        if line.startswith("[") and line.endswith("]"):
+            current = line[1:-1]
+            sections[current] = []
+        elif current is None:
+            intro.append(line)
+        elif line:
+            sections[current].append(line)
+    return intro, sections
+
+
 class BugreportCommandTest(DulwichCliTestCase):
     """Tests for bugreport command."""
 
     def test_bugreport_default_filename(self):
-        """Test that a timestamped report file is created by default."""
+        """Test that a timestamped report file is created with the expected structure."""
         result, stdout, _stderr = self._run_cli("bugreport")
         self.assertEqual(0, result)
 
@@ -5371,12 +5395,24 @@ class BugreportCommandTest(DulwichCliTestCase):
 
         with open(matches[0]) as f:
             content = f.read()
-        self.assertIn("Thank you for filling out a Git bug report!", content)
-        self.assertIn("[System Info]", content)
-        self.assertIn(
-            f"dulwich version: {'.'.join(str(v) for v in dulwich.__version__)}", content
+
+        intro, sections = _parse_bugreport(content)
+        self.assertEqual("Thank you for filling out a Git bug report!", intro[0])
+        self.assertEqual(["System Info", "Enabled Hooks"], list(sections.keys()))
+
+        version = ".".join(str(v) for v in dulwich.__version__)
+        self.assertEqual(
+            [
+                f"dulwich version: {version}",
+                f"python version: {sys.version}",
+                f"python executable: {sys.executable}",
+                f"platform: {platform.platform()}",
+                f"$SHELL (typically, interactive shell): {os.environ.get('SHELL', '(not set)')}",
+            ],
+            sections["System Info"],
         )
-        self.assertIn("[Enabled Hooks]", content)
+        # No hooks were installed in this repo, so nothing should be listed.
+        self.assertEqual([], sections["Enabled Hooks"])
 
     def test_bugreport_no_suffix(self):
         """Test that --no-suffix produces an unadorned filename."""
@@ -5427,7 +5463,8 @@ class BugreportCommandTest(DulwichCliTestCase):
 
         with open(os.path.join(self.repo_path, "git-bugreport.txt")) as f:
             content = f.read()
-        self.assertIn("pre-commit", content.split("[Enabled Hooks]")[1])
+        _intro, sections = _parse_bugreport(content)
+        self.assertEqual(["pre-commit"], sections["Enabled Hooks"])
 
     def test_bugreport_ignores_non_executable_hook(self):
         """Test that a hook script without the executable bit is not listed.
@@ -5447,7 +5484,8 @@ class BugreportCommandTest(DulwichCliTestCase):
 
         with open(os.path.join(self.repo_path, "git-bugreport.txt")) as f:
             content = f.read()
-        self.assertNotIn("pre-commit", content.split("[Enabled Hooks]")[1])
+        _intro, sections = _parse_bugreport(content)
+        self.assertEqual([], sections["Enabled Hooks"])
 
     def test_bugreport_outside_repository(self):
         """Test the hooks section when run outside of any repository."""
@@ -5464,9 +5502,10 @@ class BugreportCommandTest(DulwichCliTestCase):
 
         with open(os.path.join(self.test_dir, "git-bugreport.txt")) as f:
             content = f.read()
-        self.assertIn(
-            "not run from a git repository - no hooks to show",
-            content,
+        _intro, sections = _parse_bugreport(content)
+        self.assertEqual(
+            ["not run from a git repository - no hooks to show"],
+            sections["Enabled Hooks"],
         )
 
 


### PR DESCRIPTION
Closes #1836.

Adds `dulwich bugreport`, which collects Python/platform info, the
Dulwich version, and the repository's enabled hooks into a text file,
matching C Git's own `git bugreport` layout and its `-o`/`-s`/`--no-suffix`
options: refuses to overwrite an existing report file, and creates the
output directory if it doesn't exist yet.

I checked the exact filename scheme, flag behavior, overwrite handling,
and confirmation message against a local `git bugreport` (git 2.55) run
rather than going from the man page alone, so the output should line up
with real Git closely.

The report assembly lives in `cli.py` rather than going through
`porcelain`, following the existing `cmd_diagnose` precedent — it touches
environment variables and interpreter details that CONTRIBUTING.rst says
the porcelain/plumbing layers should stay agnostic to.

Left `--diagnose` (the zip archive option) out of scope; `cmd_diagnose`
already has a TODO tracking that separately.

## Test plan
- Added 7 unit tests in `tests/cli/test_cli.py`: default filename,
  `--no-suffix`, custom suffix, refuse-to-overwrite, `-o` output
  directory (including auto-creation), hook detection, and running
  outside of a repository.
- `ruff check`, `ruff format --check`, `mypy dulwich`, and `codespell`
  all pass on the changed files.
- Full `tests.cli.test_cli` suite (304 tests) and `tests.nocompat_test_suite`
  (4097 tests) pass with no regressions.
- Updated `docs/c-git-compatibility.txt` (`git bugreport` was listed ✗)
  and `NEWS`.