### PR TITLE
Name a symlink by its own path in path_to_tree_path

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,11 @@
    ``ssh://user@host/git/repo.git`` as the remote URL, which points at a
    different repository. (Jelmer Vernooĳ, #2375)
 
+ * Name a symlink by its own path in ``porcelain.path_to_tree_path``, rather
+   than by the path of its target. ``porcelain.status`` listed a tracked
+   symlink as untracked whenever the file it pointed at was itself untracked
+   or missing, so a modified symlink was reported twice. (Jerry Xiao)
+
 1.2.14	2026-08-28
 
  * Collapse consecutive `**` segments in wildmatch translation, matching

--- a/dulwich/porcelain/__init__.py
+++ b/dulwich/porcelain/__init__.py
@@ -1075,7 +1075,12 @@ def path_to_tree_path(
     if isinstance(path, bytes):
         path = os.fsdecode(path)
     path = Path(path)
-    resolved_path = path.resolve()
+    if path.is_symlink():
+        # A symlink is named in the index by its own path, so resolve only its
+        # parent; resolving the link would yield the path of its target.
+        resolved_path = path.parent.resolve() / path.name
+    else:
+        resolved_path = path.resolve()
 
     # Resolve and abspath seems to behave differently regarding symlinks,
     # as we are doing abspath on the file path, we need to do the same on
@@ -1088,16 +1093,7 @@ def path_to_tree_path(
         repopath = os.fsdecode(repopath)
     repopath = Path(repopath).resolve()
 
-    try:
-        relpath = resolved_path.relative_to(repopath)
-    except ValueError:
-        # If path is a symlink that points to a file outside the repo, we
-        # want the relpath for the link itself, not the resolved target
-        if path.is_symlink():
-            parent = path.parent.resolve()
-            relpath = (parent / path.name).relative_to(repopath)
-        else:
-            raise
+    relpath = resolved_path.relative_to(repopath)
     if sys.platform == "win32":
         return str(relpath).replace(os.path.sep, "/").encode(tree_encoding)
     else:

--- a/tests/porcelain/__init__.py
+++ b/tests/porcelain/__init__.py
@@ -7309,6 +7309,46 @@ class StatusTests(PorcelainTestCase):
         self.assertEqual(results.staged["add"][0], os.fsencode(filename_add))
         self.assertEqual(results.unstaged, [os.fsencode("foo")])
 
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_status_tracked_symlink_to_untracked_file(self) -> None:
+        # A tracked symlink is not untracked just because the file it points
+        # at is untracked. Git reports only the target file here.
+        link = os.path.join(self.repo.path, "link")
+        os.symlink("target", link)
+        porcelain.add(repo=self.repo.path, paths=[link])
+        porcelain.commit(
+            repo=self.repo.path,
+            message=b"add symlink",
+            author=b"author <email>",
+            committer=b"committer <email>",
+        )
+        with open(os.path.join(self.repo.path, "target"), "w") as f:
+            f.write("stuff")
+
+        results = porcelain.status(self.repo)
+        self.assertEqual([b"target"], results.untracked)
+        self.assertEqual([], results.unstaged)
+
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_status_modified_symlink_reported_once(self) -> None:
+        # A tracked symlink pointed at a different name is modified, not
+        # untracked. Git reports the path once, as modified.
+        link = os.path.join(self.repo.path, "link")
+        os.symlink("target", link)
+        porcelain.add(repo=self.repo.path, paths=[link])
+        porcelain.commit(
+            repo=self.repo.path,
+            message=b"add symlink",
+            author=b"author <email>",
+            committer=b"committer <email>",
+        )
+        os.remove(link)
+        os.symlink("other", link)
+
+        results = porcelain.status(self.repo)
+        self.assertEqual([b"link"], results.unstaged)
+        self.assertEqual([], results.untracked)
+
     def test_status_with_core_preloadindex(self) -> None:
         """Test status with core.preloadIndex enabled."""
         # Set core.preloadIndex to true
@@ -9836,6 +9876,18 @@ class PathToTreeTests(PorcelainTestCase):
         self.assertEqual(
             b"bar/baz",
             porcelain.path_to_tree_path(os.path.join(os.getcwd(), ".."), "baz"),
+        )
+
+    @skipIf(sys.platform == "win32", "requires symlink support")
+    def test_path_to_tree_path_symlink(self) -> None:
+        # A symlink is named in the index by its own path, not by the path of
+        # the file it points at, even when that file is inside the repository.
+        os.symlink("bar", os.path.join(self.test_dir, "link"))
+        self.assertEqual(
+            b"link",
+            porcelain.path_to_tree_path(
+                self.test_dir, os.path.join(self.test_dir, "link")
+            ),
         )
 
 


### PR DESCRIPTION
Fixes #2402.

`path_to_tree_path()` followed symlinks through `Path.resolve()`, so callers received the target's tree path instead of the link's path.

Resolve only the parent directory for symlinks. This keeps the symlink's own index key and makes `porcelain.status()` match Git when the target is untracked or missing.

Tests cover the helper, a tracked link to an untracked file, and a modified link to a missing target.

Verified with the Dulwich test suites, `ruff`, `mypy`, and Git 2.53.0.

This change was made with AI assistance.
