### PR TITLE
reject traversing reftable names from tables.list

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 1.2.15	UNRELEASED
 
+ * Reject reftable ``tables.list`` entries that contain a path separator or
+   are absolute, so a hostile repository cannot make a ref lookup open a file
+   outside the reftable directory. (netliomax25-code)
+
  * Support ``dulwich commit -C/--reuse-message`` and ``-c/--reedit-message``
    to reuse a commit's message, author and author date, optionally editing
    the message. The committer and new commit ancestry remain independent.

--- a/dulwich/reftable.py
+++ b/dulwich/reftable.py
@@ -961,8 +961,26 @@ class ReftableRefsContainer(RefsContainer):
         with open(tables_list_path, "rb") as f:
             for line in f:
                 table_name = line.decode().strip()
-                if table_name:
-                    files.append(os.path.join(self.reftable_dir, table_name))
+                if not table_name:
+                    continue
+                # tables.list is repository data that dulwich did not
+                # necessarily write. Every name git and dulwich emit is a
+                # bare "<...>.ref" basename, so reject any name with a path
+                # separator, drive/root component or "." / ".." before
+                # joining it under reftable_dir. Without this a corrupt or
+                # hostile tables.list can name a path outside the reftable
+                # directory (an absolute path discards the base entirely in
+                # os.path.join), turning a ref lookup into an open of an
+                # arbitrary file (backslash and colon matter on Windows).
+                if (
+                    "/" in table_name
+                    or "\\" in table_name
+                    or ":" in table_name
+                    or os.path.isabs(table_name)
+                    or table_name in (os.curdir, os.pardir)
+                ):
+                    raise ValueError(f"invalid reftable name {table_name!r}")
+                files.append(os.path.join(self.reftable_dir, table_name))
         return files
 
     def _read_all_tables(self) -> dict[Ref, tuple[int, bytes]]:

--- a/tests/test_reftable.py
+++ b/tests/test_reftable.py
@@ -21,6 +21,7 @@
 
 """Tests for the reftable refs storage format."""
 
+import os
 import shutil
 import tempfile
 import unittest
@@ -285,6 +286,46 @@ class TestReftableRefsContainer(unittest.TestCase):
         # Should have multiple table files
         table_files = self.container._get_table_files()
         self.assertGreaterEqual(len(table_files), 2)
+
+    def _write_tables_list(self, contents):
+        tables_list_path = os.path.join(self.container.reftable_dir, "tables.list")
+        with open(tables_list_path, "wb") as f:
+            f.write(contents)
+
+    def test_get_table_files_rejects_traversal(self):
+        """A hostile tables.list must not name paths outside reftable_dir."""
+        for bad in (
+            b"../../evil.ref\n",
+            b"/etc/hostname\n",
+            b"..\n",
+            b"sub/dir.ref\n",
+            b"a\\b.ref\n",
+            b"C:evil.ref\n",
+        ):
+            self._write_tables_list(bad)
+            with self.assertRaises(ValueError):
+                self.container._get_table_files()
+
+    def test_get_table_files_accepts_basename(self):
+        """A well-formed .ref basename is still resolved under reftable_dir."""
+        self._write_tables_list(b"0x0000000000000001-0x0000000000000001-deadbeef.ref\n")
+        (resolved,) = self.container._get_table_files()
+        self.assertEqual(
+            os.path.join(
+                self.container.reftable_dir,
+                "0x0000000000000001-0x0000000000000001-deadbeef.ref",
+            ),
+            resolved,
+        )
+
+    def test_allkeys_rejects_traversal(self):
+        """A ref read through a traversing tables.list must not open the target."""
+        outside = os.path.join(self.test_dir, "secret_outside.txt")
+        with open(outside, "wb") as f:
+            f.write(b"secret")
+        self._write_tables_list(b"../../secret_outside.txt\n")
+        with self.assertRaises(ValueError):
+            self.container.allkeys()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`ReftableRefsContainer._get_table_files` builds the list of reftable files by joining each line of `reftable/tables.list` onto the reftable directory, and every ref read (`allkeys`, `follow`, `read_loose_ref`, `get_packed_refs`) opens those paths through it. `tables.list` is repository data dulwich did not necessarily write (a repo directory handed to the user, a submodule gitdir, any repo whose config sets `extensions.refStorage=reftable`).

1. `os.path.join(self.reftable_dir, table_name)` runs on an unvalidated line, and `os.path.join` drops the base for an absolute entry and honors `../`, so a line like `/etc/hostname` or `../../secret` escapes the reftable directory.
2. the escaped path is then `open()`ed and parsed as a reftable, giving an attacker-controlled file-open primitive (existence/type oracle, a hang on a FIFO or device node, or a silent merge of an out-of-tree reftable's refs).
3. validate each name at that single chokepoint, rejecting a path separator, colon, absolute path, or `.`/`..` before joining. This mirrors the guard already on MIDX pack names in `DiskObjectStore._get_pack_by_name`, which rejects a name a "corrupt or hostile MIDX" could use to traverse.

Legitimate entries are always the bare `0x...-0x...-<hash>.ref` basenames dulwich writes, so valid behavior is unchanged. Added regression tests and a NEWS entry.