### PR TITLE
Ignore gitignore lines that carry no pattern

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -31,6 +31,10 @@
    symlink as untracked whenever the file it pointed at was itself untracked
    or missing, so a modified symlink was reported twice. (Jerry Xiao)
 
+ * Ignore gitignore lines that carry no pattern, such as a bare ``!`` or
+   ``/``. A bare ``!`` previously re-included a directory that an earlier
+   pattern in the same file had ignored. (Jelmer Vernooĳ, #2398)
+
 1.2.14	2026-08-28
 
  * Collapse consecutive `**` segments in wildmatch translation, matching

--- a/dulwich/ignore.py
+++ b/dulwich/ignore.py
@@ -283,6 +283,11 @@ class Pattern:
         # Check if this is a directory-only pattern
         self.is_directory_only = pattern.endswith(b"/")
 
+        # Lines like "!" or "/" carry no pattern once the negation prefix and
+        # the directory suffix are stripped. Git keeps them in its pattern list
+        # but they can never match a path, so neither do we.
+        self.is_empty = not pattern.rstrip(b"/")
+
         flags = 0
         if self.ignorecase:
             flags = re.IGNORECASE
@@ -334,6 +339,9 @@ class Pattern:
           path: Path to match (relative to ignore location)
         Returns: boolean
         """
+        if self.is_empty:
+            return False
+
         # For negation directory patterns (e.g., !dir/), only match directories
         if self.is_directory_only and not self.is_exclude and not path.endswith(b"/"):
             return False

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -424,6 +424,16 @@ class IgnoreFilterTests(TestCase):
         self.assertEqual([Pattern(b"!c.c")], list(filter.find_matching(b"c.c")))
         self.assertEqual([], list(filter.find_matching(b"d.c")))
 
+    def test_empty_pattern_never_matches(self) -> None:
+        # Lines that carry no pattern once the negation prefix and the
+        # directory suffix are stripped are inert in git; a bare "!" in
+        # particular does not re-include an earlier ignored directory.
+        for line in [b"!", b"!/", b"/", b"//", b"!//"]:
+            filter = IgnoreFilter([b"build/", line])
+            self.assertIs(True, filter.is_ignored(b"build/"), line)
+            self.assertIs(True, filter.is_ignored(b"build/f"), line)
+            self.assertEqual([], list(filter.find_matching(b"other/")), line)
+
     def test_include_exclude_include(self) -> None:
         filter = IgnoreFilter([b"a.c", b"!a.c", b"a.c"])
         self.assertTrue(filter.is_ignored(b"a.c"))


### PR DESCRIPTION
A line like a bare `!` or `/` has nothing left once the negation prefix and the trailing slash are stripped. Git keeps such a line in its pattern list but it can never match, since the empty pattern is matched against a basename. Dulwich instead compiled it to a regex that matched any path ending in a slash, so a bare `!` after `build/` in the same file re-included the directory.

Fixes #2398